### PR TITLE
Automatically determine what address to advertise, per-interface

### DIFF
--- a/examples/registration.py
+++ b/examples/registration.py
@@ -32,8 +32,11 @@ if __name__ == '__main__':
 
     info = ServiceInfo(
         "_http._tcp.local.",
-        "Paul's Test Web Site._http._tcp.local.",
-        addresses=[socket.inet_aton("127.0.0.1")],
+        "Paul's Test Web Site._http._tcp.local.", 
+        #None indicates automatic addressing, every interface's IP
+        #Is advertised on that interface. You can also specify a
+        #Specific address by passing it through inet_aton.
+        addresses=[None],
         port=80,
         properties=desc,
         server="ash-2.local.",

--- a/zeroconf.py
+++ b/zeroconf.py
@@ -1876,7 +1876,7 @@ def normalize_interface_choice(
         result += ip6_addresses_to_indexes(choice)
     else:
         raise TypeError("choice must be a list or InterfaceChoice, got %r" % choice)
-    return result
+    return sorted(result)
 
 
 def new_socket(port: int = _MDNS_PORT, ip_version: IpVersion = IpVersion.V4Only, bindto:str='') -> socket.socket:


### PR DESCRIPTION
This is a rather large change, but it solves a fairly big usability issue.

If you have multiple interfaces, manually supplying a list of IPs isn't enough, as we do not want to advertise the WiFi IP to the Ethernet interface, etc.

Even allowing per-interface lists of IPs causes trouble, as IP addresses can change, and one would have to track that manually. 

Besides that, it's nontrivial to get your own addresses if you don't already have it, and having to add a dozen lines or so for something so common seems wasteful.

My proposed solution is to allow None as an address, which is automatically replaced with the IP of whatever device the packet is being sent from. To do this I have bound all the sockets to the individual devices(Other than the listen socket), so that we can send multicasts to specific interfaces.

This causes another problem, in that relying on per-device sockets gets messy when things are dynamic. I resolve this problem by recreating the sockets if the list of interfaces changes. To do this I poll every 3 minutes, but I also refresh the list and retry if a send fails.


This patch has a slight performance hit I'd imagine, because every response now requires "recompiling" the response packet bytes, but MDNS isn't exactly a high datarate application as it is.

Thanks for your time!!