### PR TITLE
feat: drop async_timeout requirement for python 3.11+

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -227,7 +227,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "e1ee5359a3695e10975e06463e681d6cdc3e2a2a7268bca9b44fa025a8e8980b"
+content-hash = "1b871ae566e35d2aa05a22a4ff564eaec72807a4c37a012e41f8287831435b74"
 
 [metadata.files]
 async-timeout = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ build_command = "pip install poetry && poetry build"
 
 [tool.poetry.dependencies]
 python = "^3.7"
-async-timeout = ">=3.0.1"
+async-timeout = {version = ">=3.0.0", python = "<3.11"}
 ifaddr = ">=0.1.7"
 
 [tool.poetry.group.dev.dependencies]

--- a/src/zeroconf/_utils/asyncio.py
+++ b/src/zeroconf/_utils/asyncio.py
@@ -23,9 +23,13 @@
 import asyncio
 import concurrent.futures
 import contextlib
+import sys
 from typing import Any, Awaitable, Coroutine, Optional, Set
 
-import async_timeout
+if sys.version_info[:2] < (3, 11):
+    from async_timeout import timeout as asyncio_timeout
+else:
+    from asyncio import timeout as asyncio_timeout
 
 from .._exceptions import EventLoopBlocked
 from ..const import _LOADED_SYSTEM_TIMEOUT
@@ -40,7 +44,7 @@ _WAIT_FOR_LOOP_TASKS_TIMEOUT = 3  # Must be larger than _TASK_AWAIT_TIMEOUT
 async def wait_event_or_timeout(event: asyncio.Event, timeout: float) -> None:
     """Wait for an event or timeout."""
     with contextlib.suppress(asyncio.TimeoutError):
-        async with async_timeout.timeout(timeout):
+        async with asyncio_timeout(timeout):
             await event.wait()
 
 


### PR DESCRIPTION
We now use the built-in asyncio.timeout instead
when running on python 3.11+