### PR TITLE
fix: fix project name in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "python-zeroconf"
+name = "zeroconf"
 version = "0.39.5"
 description = "A pure python implementation of multicast DNS service discovery"
 authors = ["Paul Scott-Murphy", "William McBrine", "Jakub Stasiak", "J. Nick Koston"]


### PR DESCRIPTION
The project name was set incorrectly when the release automation was added