### PR TITLE
feat: optimize incoming parser by adding additonal cython typing

### DIFF
--- a/src/zeroconf/_protocol/incoming.pxd
+++ b/src/zeroconf/_protocol/incoming.pxd
@@ -57,7 +57,7 @@ cdef class DNSIncoming:
         length=cython.uint,
         link=cython.uint
     )
-    cdef _decode_labels_at_offset(self, unsigned int off, cython.list labels, object seen_pointers)
+    cdef unsigned int _decode_labels_at_offset(self, unsigned int off, cython.list labels, object seen_pointers)
 
     cdef _read_header(self)
 


### PR DESCRIPTION
This is ~1% speed up because it avoids a lot of uint to python int conversions