### PR TITLE
feat: optimize equality checks for DNS records

### DIFF
--- a/src/zeroconf/_dns.pxd
+++ b/src/zeroconf/_dns.pxd
@@ -24,6 +24,8 @@ cdef class DNSEntry:
     cdef public object class_
     cdef public object unique
 
+    cdef _dns_entry_matches(self, DNSEntry other)
+
 cdef class DNSQuestion(DNSEntry):
 
     cdef public cython.int _hash
@@ -98,6 +100,3 @@ cdef class DNSRRSet:
 
     @cython.locals(other=DNSRecord)
     cpdef suppresses(self, DNSRecord record)
-
-
-cdef _dns_entry_matches(DNSEntry entry, object key, object type_, object class_)

--- a/src/zeroconf/_dns.pxd
+++ b/src/zeroconf/_dns.pxd
@@ -100,4 +100,4 @@ cdef class DNSRRSet:
     cpdef suppresses(self, DNSRecord record)
 
 
-cdef _dns_entry_matches(DNSEntry entry, str key, cython.int type_, cython.int class_)
+cdef _dns_entry_matches(DNSEntry entry, object key, object type_, object class_)

--- a/src/zeroconf/_dns.pxd
+++ b/src/zeroconf/_dns.pxd
@@ -1,4 +1,5 @@
 
+import cython
 
 
 cdef object _LEN_BYTE
@@ -12,67 +13,91 @@ cdef object _EXPIRE_FULL_TIME_MS
 cdef object _EXPIRE_STALE_TIME_MS
 cdef object _RECENT_TIME_MS
 
+cdef object _CLASS_UNIQUE
+cdef object _CLASS_MASK
 
 cdef class DNSEntry:
 
-    cdef public key
-    cdef public name
-    cdef public type
-    cdef public class_
-    cdef public unique
+    cdef public object key
+    cdef public object name
+    cdef public object type
+    cdef public object class_
+    cdef public object unique
 
 cdef class DNSQuestion(DNSEntry):
 
-    cdef public _hash
+    cdef public cython.int _hash
 
 cdef class DNSRecord(DNSEntry):
 
-    cdef public ttl
-    cdef public created
+    cdef public object ttl
+    cdef public object created
+
+    cdef _suppressed_by_answer(self, DNSRecord answer)
+
 
 cdef class DNSAddress(DNSRecord):
 
-    cdef public _hash
-    cdef public address
-    cdef public scope_id
+    cdef public cython.int _hash
+    cdef public object address
+    cdef public object scope_id
+
+    cdef _eq(self, DNSAddress other)
 
 
 cdef class DNSHinfo(DNSRecord):
 
-    cdef public _hash
-    cdef public cpu
-    cdef public os
+    cdef public cython.int _hash
+    cdef public object cpu
+    cdef public object os
+
+    cdef _eq(self, DNSHinfo other)
 
 
 cdef class DNSPointer(DNSRecord):
 
-    cdef public _hash
-    cdef public alias
+    cdef public cython.int _hash
+    cdef public object alias
+
+    cdef _eq(self, DNSPointer other)
+
 
 cdef class DNSText(DNSRecord):
 
-    cdef public _hash
-    cdef public text
+    cdef public cython.int _hash
+    cdef public object text
+
+    cdef _eq(self, DNSText other)
+
 
 cdef class DNSService(DNSRecord):
 
-    cdef public _hash
-    cdef public priority
-    cdef public weight
-    cdef public port
-    cdef public server
-    cdef public server_key
+    cdef public cython.int _hash
+    cdef public object priority
+    cdef public object weight
+    cdef public object port
+    cdef public object server
+    cdef public object server_key
+
+    cdef _eq(self, DNSService other)
+
 
 cdef class DNSNsec(DNSRecord):
 
-    cdef public _hash
-    cdef public next_name
-    cdef public rdtypes
+    cdef public cython.int _hash
+    cdef public object next_name
+    cdef public cython.list rdtypes
+
+    cdef _eq(self, DNSNsec other)
 
 
 cdef class DNSRRSet:
 
     cdef _records
-    cdef _lookup
+    cdef cython.dict _lookup
 
-cdef _dns_entry_matches(DNSEntry entry, object key, object type_, object class_)
+    @cython.locals(other=DNSRecord)
+    cpdef suppresses(self, DNSRecord record)
+
+
+cdef _dns_entry_matches(DNSEntry entry, str key, cython.int type_, cython.int class_)

--- a/src/zeroconf/_dns.py
+++ b/src/zeroconf/_dns.py
@@ -169,9 +169,9 @@ class DNSRecord(DNSEntry):
     def suppressed_by(self, msg: 'DNSIncoming') -> bool:
         """Returns true if any answer in a message can suffice for the
         information held in this record."""
-        return any(self.suppressed_by_answer(record) for record in msg.answers)
+        return any(self._suppressed_by_answer(record) for record in msg.answers)
 
-    def suppressed_by_answer(self, other: 'DNSRecord') -> bool:
+    def _suppressed_by_answer(self, other) -> bool:  # type: ignore[no-untyped-def]
         """Returns true if another record has same name, type and class,
         and if its TTL is at least half of this record's."""
         return self == other and other.ttl > (self.ttl / 2)
@@ -246,9 +246,11 @@ class DNSAddress(DNSRecord):
 
     def __eq__(self, other: Any) -> bool:
         """Tests equality on address"""
+        return isinstance(other, DNSAddress) and self._eq(other)
+
+    def _eq(self, other) -> bool:  # type: ignore[no-untyped-def]
         return (
-            isinstance(other, DNSAddress)
-            and self.address == other.address
+            self.address == other.address
             and self.scope_id == other.scope_id
             and _dns_entry_matches(other, self.key, self.type, self.class_)
         )
@@ -289,10 +291,13 @@ class DNSHinfo(DNSRecord):
         out.write_character_string(self.os.encode('utf-8'))
 
     def __eq__(self, other: Any) -> bool:
-        """Tests equality on cpu and os"""
+        """Tests equality on cpu and os."""
+        return isinstance(other, DNSHinfo) and self._eq(other)
+
+    def _eq(self, other) -> bool:  # type: ignore[no-untyped-def]
+        """Tests equality on cpu and os."""
         return (
-            isinstance(other, DNSHinfo)
-            and self.cpu == other.cpu
+            self.cpu == other.cpu
             and self.os == other.os
             and _dns_entry_matches(other, self.key, self.type, self.class_)
         )
@@ -334,12 +339,12 @@ class DNSPointer(DNSRecord):
         out.write_name(self.alias)
 
     def __eq__(self, other: Any) -> bool:
-        """Tests equality on alias"""
-        return (
-            isinstance(other, DNSPointer)
-            and self.alias == other.alias
-            and _dns_entry_matches(other, self.key, self.type, self.class_)
-        )
+        """Tests equality on alias."""
+        return isinstance(other, DNSPointer) and self._eq(other)
+
+    def _eq(self, other) -> bool:  # type: ignore[no-untyped-def]
+        """Tests equality on alias."""
+        return self.alias == other.alias and _dns_entry_matches(other, self.key, self.type, self.class_)
 
     def __hash__(self) -> int:
         """Hash to compare like DNSPointer."""
@@ -373,12 +378,12 @@ class DNSText(DNSRecord):
         return self._hash
 
     def __eq__(self, other: Any) -> bool:
-        """Tests equality on text"""
-        return (
-            isinstance(other, DNSText)
-            and self.text == other.text
-            and _dns_entry_matches(other, self.key, self.type, self.class_)
-        )
+        """Tests equality on text."""
+        return isinstance(other, DNSText) and self._eq(other)
+
+    def _eq(self, other) -> bool:  # type: ignore[no-untyped-def]
+        """Tests equality on text."""
+        return self.text == other.text and _dns_entry_matches(other, self.key, self.type, self.class_)
 
     def __repr__(self) -> str:
         """String representation"""
@@ -411,7 +416,7 @@ class DNSService(DNSRecord):
         self.port = port
         self.server = server
         self.server_key = server.lower()
-        self._hash = hash((self.key, type_, self.class_, priority, weight, port, server))
+        self._hash = hash((self.key, type_, self.class_, priority, weight, port, self.server_key))
 
     def write(self, out: 'DNSOutgoing') -> None:
         """Used in constructing an outgoing packet"""
@@ -422,12 +427,15 @@ class DNSService(DNSRecord):
 
     def __eq__(self, other: Any) -> bool:
         """Tests equality on priority, weight, port and server"""
+        return isinstance(other, DNSService) and self._eq(other)
+
+    def _eq(self, other) -> bool:  # type: ignore[no-untyped-def]
+        """Tests equality on priority, weight, port and server."""
         return (
-            isinstance(other, DNSService)
-            and self.priority == other.priority
+            self.priority == other.priority
             and self.weight == other.weight
             and self.port == other.port
-            and self.server == other.server
+            and self.server_key == other.server_key
             and _dns_entry_matches(other, self.key, self.type, self.class_)
         )
 
@@ -478,10 +486,13 @@ class DNSNsec(DNSRecord):
         out.write_string(out_bytes)
 
     def __eq__(self, other: Any) -> bool:
-        """Tests equality on cpu and os"""
+        """Tests equality on next_name and rdtypes."""
+        return isinstance(other, DNSNsec) and self._eq(other)
+
+    def _eq(self, other) -> bool:  # type: ignore[no-untyped-def]
+        """Tests equality on next_name and rdtypes."""
         return (
-            isinstance(other, DNSNsec)
-            and self.next_name == other.next_name
+            self.next_name == other.next_name
             and self.rdtypes == other.rdtypes
             and _dns_entry_matches(other, self.key, self.type, self.class_)
         )
@@ -495,6 +506,9 @@ class DNSNsec(DNSRecord):
         return self.to_string(
             self.next_name + "," + "|".join([self.get_type(type_) for type_ in self.rdtypes])
         )
+
+
+_DNSRecord = DNSRecord
 
 
 class DNSRRSet:
@@ -514,10 +528,13 @@ class DNSRRSet:
             self._lookup = {record: record for record in self._records}
         return self._lookup
 
-    def suppresses(self, record: DNSRecord) -> bool:
+    def suppresses(self, record: _DNSRecord) -> bool:
         """Returns true if any answer in the rrset can suffice for the
         information held in this record."""
-        other = self.lookup.get(record)
+        if self._lookup is None:
+            other = self.lookup.get(record)
+        else:
+            other = self._lookup.get(record)
         return bool(other and other.ttl > (record.ttl / 2))
 
     def __contains__(self, record: DNSRecord) -> bool:

--- a/src/zeroconf/_dns.py
+++ b/src/zeroconf/_dns.py
@@ -72,9 +72,12 @@ class DNSEntry:
         self.class_ = class_ & _CLASS_MASK
         self.unique = (class_ & _CLASS_UNIQUE) != 0
 
+    def _dns_entry_matches(self, other) -> bool:  # type: ignore[no-untyped-def]
+        return self.key == other.key and self.type == other.type and self.class_ == other.class_
+
     def __eq__(self, other: Any) -> bool:
         """Equality test on key (lowercase name), type, and class"""
-        return _dns_entry_matches(other, self.key, self.type, self.class_) and isinstance(other, DNSEntry)
+        return isinstance(other, DNSEntry) and self._dns_entry_matches(other)
 
     @staticmethod
     def get_class_(class_: int) -> str:
@@ -117,7 +120,7 @@ class DNSQuestion(DNSEntry):
 
     def __eq__(self, other: Any) -> bool:
         """Tests equality on dns question."""
-        return isinstance(other, DNSQuestion) and _dns_entry_matches(other, self.key, self.type, self.class_)
+        return isinstance(other, DNSQuestion) and self._dns_entry_matches(other)
 
     @property
     def max_size(self) -> int:
@@ -252,7 +255,7 @@ class DNSAddress(DNSRecord):
         return (
             self.address == other.address
             and self.scope_id == other.scope_id
-            and _dns_entry_matches(other, self.key, self.type, self.class_)
+            and self._dns_entry_matches(other)
         )
 
     def __hash__(self) -> int:
@@ -296,11 +299,7 @@ class DNSHinfo(DNSRecord):
 
     def _eq(self, other) -> bool:  # type: ignore[no-untyped-def]
         """Tests equality on cpu and os."""
-        return (
-            self.cpu == other.cpu
-            and self.os == other.os
-            and _dns_entry_matches(other, self.key, self.type, self.class_)
-        )
+        return self.cpu == other.cpu and self.os == other.os and self._dns_entry_matches(other)
 
     def __hash__(self) -> int:
         """Hash to compare like DNSHinfo."""
@@ -344,7 +343,7 @@ class DNSPointer(DNSRecord):
 
     def _eq(self, other) -> bool:  # type: ignore[no-untyped-def]
         """Tests equality on alias."""
-        return self.alias == other.alias and _dns_entry_matches(other, self.key, self.type, self.class_)
+        return self.alias == other.alias and self._dns_entry_matches(other)
 
     def __hash__(self) -> int:
         """Hash to compare like DNSPointer."""
@@ -383,7 +382,7 @@ class DNSText(DNSRecord):
 
     def _eq(self, other) -> bool:  # type: ignore[no-untyped-def]
         """Tests equality on text."""
-        return self.text == other.text and _dns_entry_matches(other, self.key, self.type, self.class_)
+        return self.text == other.text and self._dns_entry_matches(other)
 
     def __repr__(self) -> str:
         """String representation"""
@@ -436,7 +435,7 @@ class DNSService(DNSRecord):
             and self.weight == other.weight
             and self.port == other.port
             and self.server == other.server
-            and _dns_entry_matches(other, self.key, self.type, self.class_)
+            and self._dns_entry_matches(other)
         )
 
     def __hash__(self) -> int:
@@ -494,7 +493,7 @@ class DNSNsec(DNSRecord):
         return (
             self.next_name == other.next_name
             and self.rdtypes == other.rdtypes
-            and _dns_entry_matches(other, self.key, self.type, self.class_)
+            and self._dns_entry_matches(other)
         )
 
     def __hash__(self) -> int:
@@ -540,11 +539,3 @@ class DNSRRSet:
     def __contains__(self, record: DNSRecord) -> bool:
         """Returns true if the rrset contains the record."""
         return record in self.lookup
-
-
-_DNSEntry = DNSEntry
-_str = str
-
-
-def _dns_entry_matches(entry: _DNSEntry, key: _str, type_: int, class_: int) -> bool:
-    return key == entry.key and type_ == entry.type and class_ == entry.class_

--- a/src/zeroconf/_dns.py
+++ b/src/zeroconf/_dns.py
@@ -416,7 +416,7 @@ class DNSService(DNSRecord):
         self.port = port
         self.server = server
         self.server_key = server.lower()
-        self._hash = hash((self.key, type_, self.class_, priority, weight, port, self.server_key))
+        self._hash = hash((self.key, type_, self.class_, priority, weight, port, server))
 
     def write(self, out: 'DNSOutgoing') -> None:
         """Used in constructing an outgoing packet"""
@@ -435,7 +435,7 @@ class DNSService(DNSRecord):
             self.priority == other.priority
             and self.weight == other.weight
             and self.port == other.port
-            and self.server_key == other.server_key
+            and self.server == other.server
             and _dns_entry_matches(other, self.key, self.type, self.class_)
         )
 


### PR DESCRIPTION
By moving some of the equality checking to `cdef`s we can avoid the generic python accessors and access the properties directly on the object. This can only be done once it passes the `isinstance` check for the same type.