### PR TITLE
feat: cythonize handlers

### DIFF
--- a/build_ext.py
+++ b/build_ext.py
@@ -24,7 +24,9 @@ def build(setup_kwargs: Any) -> None:
                 ext_modules=cythonize(
                     [
                         "src/zeroconf/_cache.py",
+                        "src/zeroconf/_core.py",
                         "src/zeroconf/_dns.py",
+                        "src/zeroconf/_handlers.py",
                         "src/zeroconf/_protocol/incoming.py",
                         "src/zeroconf/_protocol/outgoing.py",
                     ],

--- a/src/zeroconf/_core.pxd
+++ b/src/zeroconf/_core.pxd
@@ -1,0 +1,2 @@
+
+from ._handlers import QueryHandler, RecordManager

--- a/src/zeroconf/_handlers.pxd
+++ b/src/zeroconf/_handlers.pxd
@@ -8,7 +8,6 @@ from ._protocol.outgoing cimport DNSOutgoing
 
 
 cdef object RecordUpdate
-cdef object _DNS_PTR_MIN_TTL
 
 cdef class QueryHandler:
 

--- a/src/zeroconf/_handlers.pxd
+++ b/src/zeroconf/_handlers.pxd
@@ -1,0 +1,35 @@
+
+import cython
+
+from ._cache cimport DNSCache
+from ._dns cimport DNSAddress, DNSNsec, DNSPointer, DNSQuestion, DNSRecord, DNSRRSet
+from ._protocol.incoming cimport DNSIncoming
+from ._protocol.outgoing cimport DNSOutgoing
+
+
+cdef object RecordUpdate
+cdef object _DNS_PTR_MIN_TTL
+
+cdef class QueryHandler:
+
+    cdef object registry
+    cdef DNSCache cache
+    cdef object question_history
+
+cdef class RecordManager:
+
+    cdef object zc
+    cdef DNSCache cache
+    cdef public cython.list listeners
+
+cdef class _QueryResponse:
+
+    cdef bint _is_probe
+    cdef DNSIncoming _msg
+    cdef object _now
+    cdef DNSCache _cache
+    cdef object _additionals
+    cdef cython.set _ucast
+    cdef cython.set _mcast_now
+    cdef cython.set _mcast_aggregate
+    cdef cython.set _mcast_aggregate_last_second

--- a/src/zeroconf/_handlers.py
+++ b/src/zeroconf/_handlers.py
@@ -23,12 +23,12 @@
 import itertools
 import random
 from collections import deque
+from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Dict,
     Iterable,
     List,
-    NamedTuple,
     Optional,
     Set,
     Tuple,
@@ -75,14 +75,16 @@ _ADDRESS_RECORD_TYPES = {_TYPE_A, _TYPE_AAAA}
 _RESPOND_IMMEDIATE_TYPES = {_TYPE_NSEC, _TYPE_SRV, *_ADDRESS_RECORD_TYPES}
 
 
-class QuestionAnswers(NamedTuple):
+@dataclass
+class QuestionAnswers:
     ucast: _AnswerWithAdditionalsType
     mcast_now: _AnswerWithAdditionalsType
     mcast_aggregate: _AnswerWithAdditionalsType
     mcast_aggregate_last_second: _AnswerWithAdditionalsType
 
 
-class AnswerGroup(NamedTuple):
+@dataclass
+class AnswerGroup:
     """A group of answers scheduled to be sent at the same time."""
 
     send_after: float  # Must be sent after this time

--- a/src/zeroconf/_handlers.py
+++ b/src/zeroconf/_handlers.py
@@ -23,7 +23,6 @@
 import itertools
 import random
 from collections import deque
-from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Dict,
@@ -75,21 +74,35 @@ _ADDRESS_RECORD_TYPES = {_TYPE_A, _TYPE_AAAA}
 _RESPOND_IMMEDIATE_TYPES = {_TYPE_NSEC, _TYPE_SRV, *_ADDRESS_RECORD_TYPES}
 
 
-@dataclass
 class QuestionAnswers:
-    ucast: _AnswerWithAdditionalsType
-    mcast_now: _AnswerWithAdditionalsType
-    mcast_aggregate: _AnswerWithAdditionalsType
-    mcast_aggregate_last_second: _AnswerWithAdditionalsType
+    """A group of answers for a question."""
+
+    __slots__ = ("ucast", "mcast_now", "mcast_aggregate", "mcast_aggregate_last_second")
+
+    def __init__(
+        self,
+        ucast: _AnswerWithAdditionalsType,
+        mcast_now: _AnswerWithAdditionalsType,
+        mcast_aggregate: _AnswerWithAdditionalsType,
+        mcast_aggregate_last_second: _AnswerWithAdditionalsType,
+    ) -> None:
+        """Initialize the question answers."""
+        self.ucast = ucast
+        self.mcast_now = mcast_now
+        self.mcast_aggregate = mcast_aggregate
+        self.mcast_aggregate_last_second = mcast_aggregate_last_second
 
 
-@dataclass
 class AnswerGroup:
     """A group of answers scheduled to be sent at the same time."""
 
-    send_after: float  # Must be sent after this time
-    send_before: float  # Must be sent before this time
-    answers: _AnswerWithAdditionalsType
+    __slots__ = ("send_after", "send_before", "answers")
+
+    def __init__(self, send_after: float, send_before: float, answers: _AnswerWithAdditionalsType) -> None:
+        """Initialize the answer group."""
+        self.send_after = send_after  # Must be sent after this time
+        self.send_before = send_before  # Must be sent before this time
+        self.answers = answers
 
 
 def _message_is_probe(msg: DNSIncoming) -> bool:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -16,6 +16,11 @@ import unittest.mock
 from typing import Set, cast
 from unittest.mock import patch
 
+try:
+    from unittest.mock import AsyncMock
+except ImportError:
+    from unittest.mock import Mock as AsyncMock  # type: ignore[misc]
+
 import pytest
 
 import zeroconf as r
@@ -818,8 +823,8 @@ def test_shutdown_while_register_in_process():
 @pytest.mark.asyncio
 @unittest.skipIf(sys.version_info[:3][1] < 8, 'Requires Python 3.8 or later to patch _async_setup')
 @patch("zeroconf._core._STARTUP_TIMEOUT", 0)
-@patch("zeroconf._core.AsyncEngine._async_setup")
-async def test_event_loop_blocked(mock_start):
+@patch("zeroconf._core.AsyncEngine._async_setup", AsyncMock())
+async def test_event_loop_blocked():
     """Test we raise NotRunningException when waiting for startup that times out."""
     aiozc = AsyncZeroconf(interfaces=['127.0.0.1'])
     with pytest.raises(NotRunningException):


### PR DESCRIPTION
There are still cases were we cannot answer questions fast enough to keep up with systems (mainly HomeKit) that require a response within a time period to prevent a device from going offline.

We need to optimize the sending responses a bit as well via https://github.com/python-zeroconf/python-zeroconf/pull/1135

<img width="1692" alt="Screenshot 2023-03-31 at 1 44 04 PM" src="https://user-images.githubusercontent.com/663432/229251323-e51e155c-a5e6-4921-b62d-78c3595c6879.png">
