### PR TITLE
feat: small speed up to handler dispatch

### DIFF
--- a/src/zeroconf/_services/__init__.py
+++ b/src/zeroconf/_services/__init__.py
@@ -50,7 +50,7 @@ class Signal:
         self._handlers: List[Callable[..., None]] = []
 
     def fire(self, **kwargs: Any) -> None:
-        for h in list(self._handlers):
+        for h in self._handlers[:]:
             h(**kwargs)
 
     @property


### PR DESCRIPTION
We were making a copy of the handler list every time a change was fired. We can use a view instead to avoid the list changed during iteration problem until we can refactor to only change the handler list in the event loop.