### PR TITLE
feat: improve performance of constructing ServiceInfo

### DIFF
--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -80,7 +80,7 @@ def instance_name_from_service_info(info: "ServiceInfo") -> str:
     return info.name[: -len(service_name) - 1]
 
 
-_cached_ip_addresses = lru_cache(maxsize=1024)(ipaddress.ip_address)
+_cached_ip_addresses = lru_cache(maxsize=256)(ipaddress.ip_address)
 
 
 class ServiceInfo(RecordUpdateListener):

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -23,6 +23,7 @@
 import ipaddress
 import random
 import socket
+from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Union, cast
 
 from .._dns import (
@@ -77,6 +78,9 @@ def instance_name_from_service_info(info: "ServiceInfo") -> str:
     if not info.type.endswith(service_name):
         raise BadTypeInNameException
     return info.name[: -len(service_name) - 1]
+
+
+_cached_ip_addresses = lru_cache(maxsize=1024)(ipaddress.ip_address)
 
 
 class ServiceInfo(RecordUpdateListener):
@@ -196,7 +200,7 @@ class ServiceInfo(RecordUpdateListener):
 
         for address in value:
             try:
-                addr = ipaddress.ip_address(address)
+                addr = _cached_ip_addresses(address)
             except ValueError:
                 raise TypeError(
                     "Addresses must either be IPv4 or IPv6 strings, bytes, or integers;"
@@ -245,7 +249,7 @@ class ServiceInfo(RecordUpdateListener):
             return self.parsed_addresses(version)
 
         def is_link_local(addr_str: str) -> Any:
-            addr = ipaddress.ip_address(addr_str)
+            addr = _cached_ip_addresses(addr_str)
             return addr.version == 6 and addr.is_link_local
 
         ll_addrs = list(filter(is_link_local, self.parsed_addresses(version)))
@@ -346,7 +350,7 @@ class ServiceInfo(RecordUpdateListener):
             if record.key != self.server_key:
                 return
             try:
-                ip_addr = ipaddress.ip_address(record.address)
+                ip_addr = _cached_ip_addresses(record.address)
             except ValueError as ex:
                 log.warning("Encountered invalid address while processing %s: %s", record, ex)
                 return


### PR DESCRIPTION
Since we see the same IP addresses over and over it pays off to cache the construction of them.

The cache hit rate is nearly 100% after the first time its seen.
```
2023-04-01 02:55:32.822 CRITICAL (SyncWorker_4) [homeassistant.components.profiler] Cache stats for lru_cache <function ip_address at 0x7f4e727dc790> at /usr/local/lib/python3.10/ipaddress.py: CacheInfo(hits=2239, misses=147, maxsize=1024, currsize=147)
2023-04-01 02:55:54.610 CRITICAL (SyncWorker_4) [homeassistant.components.profiler] Cache stats for lru_cache <function ip_address at 0x7f4e727dc790> at /usr/local/lib/python3.10/ipaddress.py: CacheInfo(hits=2434, misses=160, maxsize=1024, currsize=160)
2023-04-01 02:57:39.852 CRITICAL (SyncWorker_3) [homeassistant.components.profiler] Cache stats for lru_cache <function ip_address at 0x7f4e727dc790> at /usr/local/lib/python3.10/ipaddress.py: CacheInfo(hits=3589, misses=160, maxsize=1024, currsize=160)
```

```
2023-04-01 03:02:01.269 CRITICAL (SyncWorker_5) [homeassistant.components.profiler] Cache stats for lru_cache <function ip_address at 0x7f979a434820> at /usr/local/lib/python3.10/ipaddress.py: CacheInfo(hits=1072, misses=133, maxsize=1024, currsize=133)
2023-04-01 03:02:51.449 CRITICAL (SyncWorker_7) [homeassistant.components.profiler] Cache stats for lru_cache <function ip_address at 0x7f979a434820> at /usr/local/lib/python3.10/ipaddress.py: CacheInfo(hits=1571, misses=133, maxsize=1024, currsize=133)
2023-04-01 03:03:30.901 CRITICAL (SyncWorker_15) [homeassistant.components.profiler] Cache stats for lru_cache <function ip_address at 0x7f979a434820> at /usr/local/lib/python3.10/ipaddress.py: CacheInfo(hits=3347, misses=136, maxsize=1024, currsize=136)
```