### PR TITLE
feat: include tests and docs in sdist archives

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,12 @@ classifiers=[
 packages = [
     { include = "zeroconf", from = "src" },
 ]
+include = [
+    { path = "CHANGELOG.md", format = "sdist" },
+    { path = "COPYING", format = "sdist" },
+    { path = "docs", format = "sdist" },
+    { path = "tests", format = "sdist" },
+]
 
 [tool.poetry.urls]
 "Bug Tracker" = "https://github.com/python-zeroconf/python-zeroconf/issues"


### PR DESCRIPTION
Include documentation and test files in source distributions, in order to make them more useful for packagers (Linux distributions, Conda). Testing is an important part of packaging process, and at least Gentoo users have requested offline documentation for Python packages. Furthermore, the COPYING file was missing from sdist, even though it was referenced in README.