### PR TITLE
feat: speed up matching types in the ServiceBrowser

### DIFF
--- a/src/zeroconf/_utils/name.py
+++ b/src/zeroconf/_utils/name.py
@@ -20,6 +20,7 @@
     USA
 """
 
+from functools import lru_cache
 from typing import Set
 
 from .._exceptions import BadTypeInNameException
@@ -170,3 +171,6 @@ def possible_types(name: str) -> Set[str]:
             break
         types.add('.'.join(parts))
     return types
+
+
+cached_possible_types = lru_cache(maxsize=256)(possible_types)


### PR DESCRIPTION
Avoids some isinstance checks and uses an lru to generate the possible types.  The LRU has a good hit rate:

```
2023-04-02 05:46:07.886 CRITICAL (SyncWorker_8) [homeassistant.components.profiler] Cache stats for lru_cache <function possible_types at 0x7f0e818d4dc0> at /usr/local/lib/python3.10/site-packages/zeroconf/_utils/name.py: CacheInfo(hits=1989, misses=375, maxsize=256, currsize=256)
2023-04-02 05:47:07.352 CRITICAL (SyncWorker_13) [homeassistant.components.profiler] Cache stats for lru_cache <function possible_types at 0x7f0e818d4dc0> at /usr/local/lib/python3.10/site-packages/zeroconf/_utils/name.py: CacheInfo(hits=2283, misses=387, maxsize=256, currsize=256)
2023-04-02 05:48:04.247 CRITICAL (SyncWorker_15) [homeassistant.components.profiler] Cache stats for lru_cache <function possible_types at 0x7f0e818d4dc0> at /usr/local/lib/python3.10/site-packages/zeroconf/_utils/name.py: CacheInfo(hits=2615, misses=387, maxsize=256, currsize=256)

```