### PR TITLE
fix: addresses incorrect after server name change

### DIFF
--- a/src/zeroconf/_core.py
+++ b/src/zeroconf/_core.py
@@ -641,6 +641,7 @@ class Zeroconf(QuietLogger):
             info.host_ttl = ttl
             info.other_ttl = ttl
 
+        info.set_server_if_missing()
         await self.async_wait_for_start()
         await self.async_check_service(info, allow_name_change, cooperating_responders)
         self.registry.async_add(info)
@@ -738,10 +739,12 @@ class Zeroconf(QuietLogger):
 
     async def async_unregister_service(self, info: ServiceInfo) -> Awaitable:
         """Unregister a service."""
+        info.set_server_if_missing()
         self.registry.async_remove(info)
         # If another server uses the same addresses, we do not want to send
         # goodbye packets for the address records
 
+        assert info.server is not None
         entries = self.registry.async_get_infos_server(info.server)
         broadcast_addresses = not bool(entries)
         return asyncio.ensure_future(

--- a/src/zeroconf/_handlers.py
+++ b/src/zeroconf/_handlers.py
@@ -247,7 +247,7 @@ def _get_address_and_nsec_records(service: ServiceInfo, now: float) -> Set[DNSRe
         records.add(dns_address)
     missing_types: Set[int] = _ADDRESS_RECORD_TYPES - seen_types
     if missing_types:
-        records.add(construct_nsec_record(service.server, list(missing_types), now))
+        records.add(construct_nsec_record(service.server or service.name, list(missing_types), now))
     return records
 
 
@@ -310,11 +310,15 @@ class QueryHandler:
             missing_types: Set[int] = _ADDRESS_RECORD_TYPES - seen_types
             if answers:
                 if missing_types:
-                    additionals.add(construct_nsec_record(service.server, list(missing_types), now))
+                    additionals.add(
+                        construct_nsec_record(service.server or service.name, list(missing_types), now)
+                    )
                 for answer in answers:
                     answer_set[answer] = additionals
             elif type_ in missing_types:
-                answer_set[construct_nsec_record(service.server, list(missing_types), now)] = set()
+                answer_set[
+                    construct_nsec_record(service.server or service.name, list(missing_types), now)
+                ] = set()
 
     def _answer_question(
         self,

--- a/src/zeroconf/_handlers.py
+++ b/src/zeroconf/_handlers.py
@@ -247,7 +247,8 @@ def _get_address_and_nsec_records(service: ServiceInfo, now: float) -> Set[DNSRe
         records.add(dns_address)
     missing_types: Set[int] = _ADDRESS_RECORD_TYPES - seen_types
     if missing_types:
-        records.add(construct_nsec_record(service.server or service.name, list(missing_types), now))
+        assert service.server is not None, "Service server must be set for NSEC record."
+        records.add(construct_nsec_record(service.server, list(missing_types), now))
     return records
 
 
@@ -310,15 +311,13 @@ class QueryHandler:
             missing_types: Set[int] = _ADDRESS_RECORD_TYPES - seen_types
             if answers:
                 if missing_types:
-                    additionals.add(
-                        construct_nsec_record(service.server or service.name, list(missing_types), now)
-                    )
+                    assert service.server is not None, "Service server must be set for NSEC record."
+                    additionals.add(construct_nsec_record(service.server, list(missing_types), now))
                 for answer in answers:
                     answer_set[answer] = additionals
             elif type_ in missing_types:
-                answer_set[
-                    construct_nsec_record(service.server or service.name, list(missing_types), now)
-                ] = set()
+                assert service.server is not None, "Service server must be set for NSEC record."
+                answer_set[construct_nsec_record(service.server, list(missing_types), now)] = set()
 
     def _answer_question(
         self,

--- a/src/zeroconf/_services/registry.py
+++ b/src/zeroconf/_services/registry.py
@@ -80,6 +80,7 @@ class ServiceRegistry:
 
     def _add(self, info: ServiceInfo) -> None:
         """Add a new service under the lock."""
+        assert info.server_key is not None, "ServiceInfo must have a server"
         if info.key in self._services:
             raise ServiceNameAlreadyRegistered
 
@@ -93,6 +94,7 @@ class ServiceRegistry:
             if info.key not in self._services:
                 continue
             old_service_info = self._services[info.key]
+            assert old_service_info.server_key is not None
             self.types[old_service_info.type.lower()].remove(info.key)
             self.servers[old_service_info.server_key].remove(info.key)
             del self._services[info.key]

--- a/tests/services/test_info.py
+++ b/tests/services/test_info.py
@@ -961,10 +961,10 @@ async def test_port_changes_are_seen():
 
 
 @pytest.mark.asyncio
-async def test_ip_changes_are_seen():
-    """Test that ip changes are seen by async_request."""
+async def test_ipv4_changes_are_seen():
+    """Test that ipv4 changes are seen by async_request."""
     type_ = "_http._tcp.local."
-    registration_name = "multiarec.%s" % type_
+    registration_name = "multiaipv4rec.%s" % type_
     aiozc = AsyncZeroconf(interfaces=['127.0.0.1'])
     host = "multahost.local."
 
@@ -1039,4 +1039,312 @@ async def test_ip_changes_are_seen():
     assert info.addresses_by_version(IPVersion.V4Only) == [b'\x7f\x00\x00\x02', b'\x7f\x00\x00\x01']
     await info.async_request(aiozc.zeroconf, timeout=200)
     assert info.addresses_by_version(IPVersion.V4Only) == [b'\x7f\x00\x00\x02', b'\x7f\x00\x00\x01']
+    await aiozc.async_close()
+
+
+@pytest.mark.asyncio
+async def test_ipv6_changes_are_seen():
+    """Test that ipv6 changes are seen by async_request."""
+    type_ = "_http._tcp.local."
+    registration_name = "multiaipv6rec.%s" % type_
+    aiozc = AsyncZeroconf(interfaces=['127.0.0.1'])
+    host = "multahost.local."
+
+    # New kwarg way
+    generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
+    generated.add_answer_at_time(
+        r.DNSNsec(
+            registration_name,
+            const._TYPE_NSEC,
+            const._CLASS_IN | const._CLASS_UNIQUE,
+            const._DNS_OTHER_TTL,
+            registration_name,
+            [const._TYPE_A],
+        ),
+        0,
+    )
+    generated.add_answer_at_time(
+        r.DNSService(
+            registration_name,
+            const._TYPE_SRV,
+            const._CLASS_IN | const._CLASS_UNIQUE,
+            10000,
+            0,
+            0,
+            80,
+            host,
+        ),
+        0,
+    )
+    generated.add_answer_at_time(
+        r.DNSAddress(
+            host,
+            const._TYPE_AAAA,
+            const._CLASS_IN,
+            10000,
+            b'\xde\xad\xbe\xef\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
+        ),
+        0,
+    )
+    generated.add_answer_at_time(
+        r.DNSText(
+            registration_name,
+            const._TYPE_TXT,
+            const._CLASS_IN | const._CLASS_UNIQUE,
+            10000,
+            b'\x04ff=0\x04ci=2\x04sf=0\x0bsh=6fLM5A==',
+        ),
+        0,
+    )
+    await aiozc.zeroconf.async_wait_for_start()
+    await asyncio.sleep(0)
+    aiozc.zeroconf.handle_response(r.DNSIncoming(generated.packets()[0]))
+    info = ServiceInfo(type_, registration_name)
+    info.load_from_cache(aiozc.zeroconf)
+    assert info.addresses_by_version(IPVersion.V6Only) == [
+        b'\xde\xad\xbe\xef\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+    ]
+
+    generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
+    generated.add_answer_at_time(
+        r.DNSAddress(
+            host,
+            const._TYPE_AAAA,
+            const._CLASS_IN,
+            10000,
+            b'\x00\xad\xbe\xef\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
+        ),
+        0,
+    )
+    aiozc.zeroconf.handle_response(r.DNSIncoming(generated.packets()[0]))
+
+    info = ServiceInfo(type_, registration_name)
+    info.load_from_cache(aiozc.zeroconf)
+    assert info.addresses_by_version(IPVersion.V6Only) == [
+        b'\x00\xad\xbe\xef\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
+        b'\xde\xad\xbe\xef\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
+    ]
+    await info.async_request(aiozc.zeroconf, timeout=200)
+    assert info.addresses_by_version(IPVersion.V6Only) == [
+        b'\x00\xad\xbe\xef\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
+        b'\xde\xad\xbe\xef\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
+    ]
+    await aiozc.async_close()
+
+
+@pytest.mark.asyncio
+async def test_bad_ip_addresses_ignored_in_cache():
+    """Test that bad ip address in the cache are ignored async_request."""
+    type_ = "_http._tcp.local."
+    registration_name = "multiarec.%s" % type_
+    aiozc = AsyncZeroconf(interfaces=['127.0.0.1'])
+    host = "multahost.local."
+
+    # New kwarg way
+    generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
+    generated.add_answer_at_time(
+        r.DNSService(
+            registration_name,
+            const._TYPE_SRV,
+            const._CLASS_IN | const._CLASS_UNIQUE,
+            10000,
+            0,
+            0,
+            80,
+            host,
+        ),
+        0,
+    )
+    generated.add_answer_at_time(
+        r.DNSAddress(
+            host,
+            const._TYPE_A,
+            const._CLASS_IN,
+            10000,
+            b'\x7f\x00\x00\x01',
+        ),
+        0,
+    )
+    generated.add_answer_at_time(
+        r.DNSText(
+            registration_name,
+            const._TYPE_TXT,
+            const._CLASS_IN | const._CLASS_UNIQUE,
+            10000,
+            b'\x04ff=0\x04ci=2\x04sf=0\x0bsh=6fLM5A==',
+        ),
+        0,
+    )
+    # Manually add a bad record to the cache
+    aiozc.zeroconf.cache.async_add_records([DNSAddress(host, const._TYPE_A, const._CLASS_IN, 10000, b'\x00')])
+
+    await aiozc.zeroconf.async_wait_for_start()
+    await asyncio.sleep(0)
+    aiozc.zeroconf.handle_response(r.DNSIncoming(generated.packets()[0]))
+    info = ServiceInfo(type_, registration_name)
+    info.load_from_cache(aiozc.zeroconf)
+    assert info.addresses_by_version(IPVersion.V4Only) == [b'\x7f\x00\x00\x01']
+
+
+@pytest.mark.asyncio
+async def test_service_name_change_as_seen_has_ip_in_cache():
+    """Test that service name changes are seen by async_request when the ip is in the cache."""
+    type_ = "_http._tcp.local."
+    registration_name = "multiarec.%s" % type_
+    aiozc = AsyncZeroconf(interfaces=['127.0.0.1'])
+    host = "multahost.local."
+
+    # New kwarg way
+    generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
+    generated.add_answer_at_time(
+        r.DNSNsec(
+            registration_name,
+            const._TYPE_NSEC,
+            const._CLASS_IN | const._CLASS_UNIQUE,
+            const._DNS_OTHER_TTL,
+            registration_name,
+            [const._TYPE_AAAA],
+        ),
+        0,
+    )
+    generated.add_answer_at_time(
+        r.DNSAddress(
+            registration_name,
+            const._TYPE_A,
+            const._CLASS_IN,
+            10000,
+            b'\x7f\x00\x00\x01',
+        ),
+        0,
+    )
+    generated.add_answer_at_time(
+        r.DNSAddress(
+            host,
+            const._TYPE_A,
+            const._CLASS_IN,
+            10000,
+            b'\x7f\x00\x00\x02',
+        ),
+        0,
+    )
+    generated.add_answer_at_time(
+        r.DNSText(
+            registration_name,
+            const._TYPE_TXT,
+            const._CLASS_IN | const._CLASS_UNIQUE,
+            10000,
+            b'\x04ff=0\x04ci=2\x04sf=0\x0bsh=6fLM5A==',
+        ),
+        0,
+    )
+    await aiozc.zeroconf.async_wait_for_start()
+    await asyncio.sleep(0)
+    aiozc.zeroconf.handle_response(r.DNSIncoming(generated.packets()[0]))
+
+    info = ServiceInfo(type_, registration_name)
+    await info.async_request(aiozc.zeroconf, timeout=200)
+    assert info.addresses_by_version(IPVersion.V4Only) == []
+
+    generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
+    generated.add_answer_at_time(
+        r.DNSService(
+            registration_name,
+            const._TYPE_SRV,
+            const._CLASS_IN | const._CLASS_UNIQUE,
+            10000,
+            0,
+            0,
+            80,
+            host,
+        ),
+        0,
+    )
+    aiozc.zeroconf.handle_response(r.DNSIncoming(generated.packets()[0]))
+
+    info = ServiceInfo(type_, registration_name)
+    await info.async_request(aiozc.zeroconf, timeout=200)
+    assert info.addresses_by_version(IPVersion.V4Only) == [b'\x7f\x00\x00\x02']
+
+    await aiozc.async_close()
+
+
+@pytest.mark.asyncio
+async def test_service_name_change_as_seen_ip_not_in_cache():
+    """Test that service name changes are seen by async_request when the ip is not in the cache."""
+    type_ = "_http._tcp.local."
+    registration_name = "multiarec.%s" % type_
+    aiozc = AsyncZeroconf(interfaces=['127.0.0.1'])
+    host = "multahost.local."
+
+    # New kwarg way
+    generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
+    generated.add_answer_at_time(
+        r.DNSNsec(
+            registration_name,
+            const._TYPE_NSEC,
+            const._CLASS_IN | const._CLASS_UNIQUE,
+            const._DNS_OTHER_TTL,
+            registration_name,
+            [const._TYPE_AAAA],
+        ),
+        0,
+    )
+    generated.add_answer_at_time(
+        r.DNSAddress(
+            registration_name,
+            const._TYPE_A,
+            const._CLASS_IN,
+            10000,
+            b'\x7f\x00\x00\x01',
+        ),
+        0,
+    )
+    generated.add_answer_at_time(
+        r.DNSText(
+            registration_name,
+            const._TYPE_TXT,
+            const._CLASS_IN | const._CLASS_UNIQUE,
+            10000,
+            b'\x04ff=0\x04ci=2\x04sf=0\x0bsh=6fLM5A==',
+        ),
+        0,
+    )
+    await aiozc.zeroconf.async_wait_for_start()
+    await asyncio.sleep(0)
+    aiozc.zeroconf.handle_response(r.DNSIncoming(generated.packets()[0]))
+
+    info = ServiceInfo(type_, registration_name)
+    await info.async_request(aiozc.zeroconf, timeout=200)
+    assert info.addresses_by_version(IPVersion.V4Only) == []
+
+    generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
+    generated.add_answer_at_time(
+        r.DNSService(
+            registration_name,
+            const._TYPE_SRV,
+            const._CLASS_IN | const._CLASS_UNIQUE,
+            10000,
+            0,
+            0,
+            80,
+            host,
+        ),
+        0,
+    )
+    generated.add_answer_at_time(
+        r.DNSAddress(
+            host,
+            const._TYPE_A,
+            const._CLASS_IN,
+            10000,
+            b'\x7f\x00\x00\x02',
+        ),
+        0,
+    )
+    aiozc.zeroconf.handle_response(r.DNSIncoming(generated.packets()[0]))
+
+    info = ServiceInfo(type_, registration_name)
+    await info.async_request(aiozc.zeroconf, timeout=200)
+    assert info.addresses_by_version(IPVersion.V4Only) == [b'\x7f\x00\x00\x02']
+
     await aiozc.async_close()

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -103,7 +103,7 @@ class TestRegistrar(unittest.TestCase):
         query.add_question(r.DNSQuestion(info.type, const._TYPE_PTR, const._CLASS_IN))
         query.add_question(r.DNSQuestion(info.name, const._TYPE_SRV, const._CLASS_IN))
         query.add_question(r.DNSQuestion(info.name, const._TYPE_TXT, const._CLASS_IN))
-        query.add_question(r.DNSQuestion(info.server, const._TYPE_A, const._CLASS_IN))
+        query.add_question(r.DNSQuestion(info.server or info.name, const._TYPE_A, const._CLASS_IN))
         question_answers = zc.query_handler.async_response(
             [r.DNSIncoming(packet) for packet in query.packets()], False
         )
@@ -141,7 +141,7 @@ class TestRegistrar(unittest.TestCase):
         query.add_question(r.DNSQuestion(info.type, const._TYPE_PTR, const._CLASS_IN))
         query.add_question(r.DNSQuestion(info.name, const._TYPE_SRV, const._CLASS_IN))
         query.add_question(r.DNSQuestion(info.name, const._TYPE_TXT, const._CLASS_IN))
-        query.add_question(r.DNSQuestion(info.server, const._TYPE_A, const._CLASS_IN))
+        query.add_question(r.DNSQuestion(info.server or info.name, const._TYPE_A, const._CLASS_IN))
         question_answers = zc.query_handler.async_response(
             [r.DNSIncoming(packet) for packet in query.packets()], False
         )


### PR DESCRIPTION
If the server name changed we would return the addresses for the old server name.

If the server name differed from the record name we would include the wrong addresses if the SRV record was not already in the cache because we would never ask for it and use the record name to lookup the A/AAAA records.

The downside is that this will likely increase the number of network requests but https://github.com/python-zeroconf/python-zeroconf/pull/1153 should mitigate the impact of that a bit