### PR TITLE
fix: reduce cast calls in service browser

### DIFF
--- a/src/zeroconf/_services/browser.py
+++ b/src/zeroconf/_services/browser.py
@@ -157,18 +157,16 @@ def generate_service_query(
         question = DNSQuestion(type_, _TYPE_PTR, _CLASS_IN)
         question.unicast = qu_question
         known_answers = {
-            cast(DNSPointer, record)
+            record
             for record in zc.cache.get_all_by_details(type_, _TYPE_PTR, _CLASS_IN)
             if not record.is_stale(now)
         }
-        if not qu_question and zc.question_history.suppresses(
-            question, now, cast(Set[DNSRecord], known_answers)
-        ):
+        if not qu_question and zc.question_history.suppresses(question, now, known_answers):
             log.debug("Asking %s was suppressed by the question history", question)
             continue
-        questions_with_known_answers[question] = known_answers
+        questions_with_known_answers[question] = cast(Set[DNSPointer], known_answers)
         if not qu_question:
-            zc.question_history.add_question_at_time(question, now, cast(Set[DNSRecord], known_answers))
+            zc.question_history.add_question_at_time(question, now, known_answers)
 
     return _group_ptr_queries_with_known_answers(now, multicast, questions_with_known_answers)
 


### PR DESCRIPTION
There were so many casts being called here they showed up on the profiler since they were inside the set comp