### PR TITLE
feat: speed up decoding dns questions when processing incoming data

### DIFF
--- a/src/zeroconf/_protocol/incoming.pxd
+++ b/src/zeroconf/_protocol/incoming.pxd
@@ -49,7 +49,7 @@ cdef class DNSIncoming:
 
     cdef bint _did_read_others
     cdef public unsigned int flags
-    cdef object offset
+    cdef cython.uint offset
     cdef public bytes data
     cdef unsigned int _data_len
     cdef public cython.dict name_cache

--- a/src/zeroconf/_protocol/incoming.pxd
+++ b/src/zeroconf/_protocol/incoming.pxd
@@ -38,6 +38,7 @@ from .._dns cimport (
     DNSHinfo,
     DNSNsec,
     DNSPointer,
+    DNSQuestion,
     DNSRecord,
     DNSService,
     DNSText,
@@ -52,7 +53,7 @@ cdef class DNSIncoming:
     cdef public bytes data
     cdef unsigned int _data_len
     cdef public cython.dict name_cache
-    cdef public object questions
+    cdef public cython.list questions
     cdef object _answers
     cdef public object id
     cdef public cython.uint num_questions

--- a/src/zeroconf/_protocol/incoming.py
+++ b/src/zeroconf/_protocol/incoming.py
@@ -211,9 +211,12 @@ class DNSIncoming:
 
     def _read_questions(self) -> None:
         """Reads questions section of packet"""
-        self.questions = [
-            DNSQuestion(self._read_name(), *self._unpack(UNPACK_HH, 4)) for _ in range(self.num_questions)
-        ]
+        for _ in range(self.num_questions):
+            name = self._read_name()
+            type_, class_ = UNPACK_HH(self.data, self.offset)
+            self.offset += 4
+            question = DNSQuestion(name, type_, class_)
+            self.questions.append(question)
 
     def _read_character_string(self) -> bytes:
         """Reads a character string from the packet"""


### PR DESCRIPTION
`DNSQuestion` is now imported via cimport to reduce overhead. The unpack dispatch is avoided to reduce the stack overhead