### PR TITLE
feat: speed up the service registry

### DIFF
--- a/src/zeroconf/_core.py
+++ b/src/zeroconf/_core.py
@@ -745,7 +745,7 @@ class Zeroconf(QuietLogger):
         # goodbye packets for the address records
 
         assert info.server is not None
-        entries = self.registry.async_get_infos_server(info.server)
+        entries = self.registry.async_get_infos_server(info.server.lower())
         broadcast_addresses = not bool(entries)
         return asyncio.ensure_future(
             self._async_broadcast_service(info, _UNREGISTER_TIME, 0, broadcast_addresses)

--- a/src/zeroconf/_services/registry.py
+++ b/src/zeroconf/_services/registry.py
@@ -60,7 +60,7 @@ class ServiceRegistry:
 
     def async_get_info_name(self, name: str) -> Optional[ServiceInfo]:
         """Return all ServiceInfo for the name."""
-        return self._services.get(name.lower())
+        return self._services.get(name)
 
     def async_get_types(self) -> List[str]:
         """Return all types."""
@@ -76,7 +76,7 @@ class ServiceRegistry:
 
     def _async_get_by_index(self, records: Dict[str, List], key: str) -> List[ServiceInfo]:
         """Return all ServiceInfo matching the index."""
-        return [self._services[name] for name in records.get(key.lower(), [])]
+        return [self._services[name] for name in records.get(key, [])]
 
     def _add(self, info: ServiceInfo) -> None:
         """Add a new service under the lock."""

--- a/tests/services/test_registry.py
+++ b/tests/services/test_registry.py
@@ -110,22 +110,3 @@ class TestServiceRegistry(unittest.TestCase):
         assert registry.async_get_infos_type(type_.lower()) == [info]
         assert registry.async_get_infos_server("ash-2.local.") == [info]
         assert registry.async_get_types() == [type_.lower()]
-
-    def test_lookups_lower_case_by_upper_case(self):
-        type_ = "_test-srvc-type._tcp.local."
-        name = "xxxyyy"
-        registration_name = f"{name}.{type_}"
-
-        desc = {'path': '/~paulsm/'}
-        info = ServiceInfo(
-            type_, registration_name, 80, 0, 0, desc, "ash-2.local.", addresses=[socket.inet_aton("10.0.1.2")]
-        )
-
-        registry = r.ServiceRegistry()
-        registry.async_add(info)
-
-        assert registry.async_get_service_infos() == [info]
-        assert registry.async_get_info_name(registration_name.upper()) == info
-        assert registry.async_get_infos_type(type_.upper()) == [info]
-        assert registry.async_get_infos_server("ASH-2.local.") == [info]
-        assert registry.async_get_types() == [type_]

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -342,6 +342,32 @@ def test_aaaa_query():
 
 @unittest.skipIf(not has_working_ipv6(), 'Requires IPv6')
 @unittest.skipIf(os.environ.get('SKIP_IPV6'), 'IPv6 tests disabled')
+def test_aaaa_query_upper_case():
+    """Test that queries for AAAA records work and should respond right away with an upper case name."""
+    zc = Zeroconf(interfaces=['127.0.0.1'])
+    type_ = "_knownaaaservice._tcp.local."
+    name = "knownname"
+    registration_name = f"{name}.{type_}"
+    desc = {'path': '/~paulsm/'}
+    server_name = "ash-2.local."
+    ipv6_address = socket.inet_pton(socket.AF_INET6, "2001:db8::1")
+    info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, server_name, addresses=[ipv6_address])
+    zc.registry.async_add(info)
+
+    generated = r.DNSOutgoing(const._FLAGS_QR_QUERY)
+    question = r.DNSQuestion(server_name.upper(), const._TYPE_AAAA, const._CLASS_IN)
+    generated.add_question(question)
+    packets = generated.packets()
+    question_answers = zc.query_handler.async_response([r.DNSIncoming(packet) for packet in packets], False)
+    mcast_answers = list(question_answers.mcast_now)
+    assert mcast_answers[0].address == ipv6_address  # type: ignore[attr-defined]
+    # unregister
+    zc.registry.async_remove(info)
+    zc.close()
+
+
+@unittest.skipIf(not has_working_ipv6(), 'Requires IPv6')
+@unittest.skipIf(os.environ.get('SKIP_IPV6'), 'IPv6 tests disabled')
 def test_a_and_aaaa_record_fate_sharing():
     """Test that queries for AAAA always return A records in the additionals and should respond right away."""
     zc = Zeroconf(interfaces=['127.0.0.1'])
@@ -456,6 +482,48 @@ async def test_probe_answered_immediately():
     zc.registry.async_add(info)
     query = r.DNSOutgoing(const._FLAGS_QR_QUERY)
     question = r.DNSQuestion(info.type, const._TYPE_PTR, const._CLASS_IN)
+    query.add_question(question)
+    query.add_authorative_answer(info.dns_pointer())
+    question_answers = zc.query_handler.async_response(
+        [r.DNSIncoming(packet) for packet in query.packets()], False
+    )
+    assert not question_answers.ucast
+    assert not question_answers.mcast_aggregate
+    assert not question_answers.mcast_aggregate_last_second
+    assert question_answers.mcast_now
+
+    query = r.DNSOutgoing(const._FLAGS_QR_QUERY)
+    question = r.DNSQuestion(info.type, const._TYPE_PTR, const._CLASS_IN)
+    question.unicast = True
+    query.add_question(question)
+    query.add_authorative_answer(info.dns_pointer())
+    question_answers = zc.query_handler.async_response(
+        [r.DNSIncoming(packet) for packet in query.packets()], False
+    )
+    assert question_answers.ucast
+    assert question_answers.mcast_now
+    assert not question_answers.mcast_aggregate
+    assert not question_answers.mcast_aggregate_last_second
+    zc.close()
+
+
+@pytest.mark.asyncio
+async def test_probe_answered_immediately_with_uppercase_name():
+    """Verify probes are responded to immediately with an uppercase name."""
+    # instantiate a zeroconf instance
+    zc = Zeroconf(interfaces=['127.0.0.1'])
+
+    # service definition
+    type_ = "_test-srvc-type._tcp.local."
+    name = "xxxyyy"
+    registration_name = f"{name}.{type_}"
+    desc = {'path': '/~paulsm/'}
+    info = ServiceInfo(
+        type_, registration_name, 80, 0, 0, desc, "ash-2.local.", addresses=[socket.inet_aton("10.0.1.2")]
+    )
+    zc.registry.async_add(info)
+    query = r.DNSOutgoing(const._FLAGS_QR_QUERY)
+    question = r.DNSQuestion(info.type.upper(), const._TYPE_PTR, const._CLASS_IN)
     query.add_question(question)
     query.add_authorative_answer(info.dns_pointer())
     question_answers = zc.query_handler.async_response(


### PR DESCRIPTION
Every lookup was doing .lower() on the input after #597. Since we only feed this data in via handlers and core, we should lower the name before feeding it into the registry to avoid doing it 1000s of times