### PR TITLE
feat: speed up processing incoming records

### DIFF
--- a/src/zeroconf/_cache.pxd
+++ b/src/zeroconf/_cache.pxd
@@ -13,6 +13,7 @@ from ._dns cimport (
 
 cdef object _UNIQUE_RECORD_TYPES
 cdef object _TYPE_PTR
+cdef object _ONE_SECOND
 
 cdef _remove_key(cython.dict cache, object key, DNSRecord record)
 
@@ -22,9 +23,19 @@ cdef class DNSCache:
     cdef public cython.dict cache
     cdef public cython.dict service_cache
 
+    @cython.locals(
+        records=cython.list,
+        record=DNSRecord,
+    )
+    cdef _async_all_by_details(self, object name, object type_, object class_)
+
     cdef _async_add(self, DNSRecord record)
 
     cdef _async_remove(self, DNSRecord record)
 
+    @cython.locals(
+        record=DNSRecord,
+    )
+    cdef _async_mark_unique_records_older_than_1s_to_expire(self, object unique_types, object answers, object now)
 
 cdef _dns_record_matches(DNSRecord record, object key, object type_, object class_)

--- a/src/zeroconf/_cache.pxd
+++ b/src/zeroconf/_cache.pxd
@@ -24,7 +24,7 @@ cdef class DNSCache:
     cdef public cython.dict service_cache
 
     @cython.locals(
-        records=cython.list,
+        records=cython.dict,
         record=DNSRecord,
     )
     cdef _async_all_by_details(self, object name, object type_, object class_)

--- a/src/zeroconf/_cache.py
+++ b/src/zeroconf/_cache.py
@@ -226,7 +226,7 @@ class DNSCache:
         """Return a copy of the list of current cache names."""
         return list(self.cache)
 
-    def async_mark_unique_cached_records_older_than_1s_to_expire(
+    def async_mark_unique_records_older_than_1s_to_expire(
         self, unique_types: Set[Tuple[str, int, int]], answers: Iterable[DNSRecord], now: float
     ) -> None:
         # rfc6762#section-10.2 para 2

--- a/src/zeroconf/_cache.py
+++ b/src/zeroconf/_cache.py
@@ -21,7 +21,7 @@
 """
 
 import itertools
-from typing import Dict, Iterable, Iterator, List, Optional, Set, Tuple, Union, cast
+from typing import Dict, Iterable, List, Optional, Set, Tuple, Union, cast
 
 from ._dns import (
     DNSAddress,
@@ -41,6 +41,8 @@ _UniqueRecordsType = Union[DNSAddress, DNSHinfo, DNSPointer, DNSText, DNSService
 _DNSRecordCacheType = Dict[str, Dict[DNSRecord, DNSRecord]]
 _DNSRecord = DNSRecord
 _str = str
+_float = float
+_int = int
 
 
 def _remove_key(cache: _DNSRecordCacheType, key: _str, record: _DNSRecord) -> None:
@@ -134,19 +136,29 @@ class DNSCache:
             return None
         return store.get(entry)
 
-    def async_all_by_details(self, name: _str, type_: int, class_: int) -> Iterator[DNSRecord]:
+    def async_all_by_details(self, name: _str, type_: int, class_: int) -> Iterable[DNSRecord]:
         """Gets all matching entries by details.
 
-        This function is not threadsafe and must be called from
+        This function is not thread-safe and must be called from
+        the event loop.
+        """
+        return self._async_all_by_details(name, type_, class_)
+
+    def _async_all_by_details(self, name: _str, type_: int, class_: int) -> list[DNSRecord]:
+        """Gets all matching entries by details.
+
+        This function is not thread-safe and must be called from
         the event loop.
         """
         key = name.lower()
         records = self.cache.get(key)
+        matches: List[DNSRecord] = []
         if records is None:
-            return
-        for entry in records:
-            if _dns_record_matches(entry, key, type_, class_):
-                yield entry
+            return matches
+        for record in records:
+            if _dns_record_matches(record, key, type_, class_):
+                matches.append(record)
+        return matches
 
     def async_entries_with_name(self, name: str) -> Dict[DNSRecord, DNSRecord]:
         """Returns a dict of entries whose key matches the name.
@@ -227,7 +239,12 @@ class DNSCache:
         return list(self.cache)
 
     def async_mark_unique_records_older_than_1s_to_expire(
-        self, unique_types: Set[Tuple[str, int, int]], answers: Iterable[DNSRecord], now: float
+        self, unique_types: Set[Tuple[_str, _int, _int]], answers: Iterable[DNSRecord], now: _float
+    ) -> None:
+        self._async_mark_unique_records_older_than_1s_to_expire(unique_types, answers, now)
+
+    def _async_mark_unique_records_older_than_1s_to_expire(
+        self, unique_types: Set[Tuple[_str, _int, _int]], answers: Iterable[DNSRecord], now: _float
     ) -> None:
         # rfc6762#section-10.2 para 2
         # Since unique is set, all old records with that name, rrtype,
@@ -235,10 +252,10 @@ class DNSCache:
         # invalid, and marked to expire from the cache in one second.
         answers_rrset = set(answers)
         for name, type_, class_ in unique_types:
-            for entry in self.async_all_by_details(name, type_, class_):
-                if (now - entry.created > _ONE_SECOND) and entry not in answers_rrset:
+            for record in self._async_all_by_details(name, type_, class_):
+                if (now - record.created > _ONE_SECOND) and record not in answers_rrset:
                     # Expire in 1s
-                    entry.set_created_ttl(now, 1)
+                    record.set_created_ttl(now, 1)
 
 
 def _dns_record_matches(record: _DNSRecord, key: _str, type_: int, class_: int) -> bool:

--- a/src/zeroconf/_cache.py
+++ b/src/zeroconf/_cache.py
@@ -144,7 +144,7 @@ class DNSCache:
         """
         return self._async_all_by_details(name, type_, class_)
 
-    def _async_all_by_details(self, name: _str, type_: int, class_: int) -> list[DNSRecord]:
+    def _async_all_by_details(self, name: _str, type_: int, class_: int) -> List[DNSRecord]:
         """Gets all matching entries by details.
 
         This function is not thread-safe and must be called from

--- a/src/zeroconf/_handlers.py
+++ b/src/zeroconf/_handlers.py
@@ -420,9 +420,7 @@ class RecordManager:
                 removes.add(record)
 
         if unique_types:
-            self.cache.async_mark_unique_cached_records_older_than_1s_to_expire(
-                unique_types, msg.answers, now
-            )
+            self.cache.async_mark_unique_records_older_than_1s_to_expire(unique_types, msg.answers, now)
 
         if updates:
             self.async_updates(now, updates)


### PR DESCRIPTION
moves `async_mark_unique_records_older_than_1s_to_expire` into the cache since this function alters the cache and we should not be altering the cache outside of the cache.