### PR TITLE
feat: reduce overhead to enumerate ip addresses in ServiceInfo

### DIFF
--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -63,6 +63,8 @@ from ..const import (
     _TYPE_TXT,
 )
 
+_IPVersion_All_value = IPVersion.All.value
+_IPVersion_V4Only_value = IPVersion.V4Only.value
 # https://datatracker.ietf.org/doc/html/rfc6762#section-5.2
 # The most common case for calling ServiceInfo is from a
 # ServiceBrowser. After the first request we add a few random
@@ -245,24 +247,15 @@ class ServiceInfo(RecordUpdateListener):
         This means the first address will always be the most recently added
         address of the given IP version.
         """
-        if version == IPVersion.All:
+        version_value = version.value
+        if version_value == _IPVersion_All_value:
             return [
                 *(addr.packed for addr in self._ipv4_addresses),
                 *(addr.packed for addr in self._ipv6_addresses),
             ]
-        if version == IPVersion.V4Only:
+        if version_value == _IPVersion_V4Only_value:
             return [addr.packed for addr in self._ipv4_addresses]
         return [addr.packed for addr in self._ipv6_addresses]
-
-    def _ip_addresses_by_version_value(
-        self, version_value: int
-    ) -> Union[List[ipaddress.IPv4Address], List[ipaddress.IPv6Address], List[ipaddress._BaseAddress]]:
-        """Backend for addresses_by_version that uses the raw value."""
-        if version_value == IPVersion.All.value:
-            return [*self._ipv4_addresses, *self._ipv6_addresses]
-        if version_value == IPVersion.V4Only.value:
-            return self._ipv4_addresses
-        return self._ipv6_addresses
 
     def ip_addresses_by_version(
         self, version: IPVersion
@@ -276,6 +269,16 @@ class ServiceInfo(RecordUpdateListener):
         address of the given IP version.
         """
         return self._ip_addresses_by_version_value(version.value)
+
+    def _ip_addresses_by_version_value(
+        self, version_value: int
+    ) -> Union[List[ipaddress.IPv4Address], List[ipaddress.IPv6Address], List[ipaddress._BaseAddress]]:
+        """Backend for addresses_by_version that uses the raw value."""
+        if version_value == _IPVersion_All_value:
+            return [*self._ipv4_addresses, *self._ipv6_addresses]
+        if version_value == _IPVersion_V4Only_value:
+            return self._ipv4_addresses
+        return self._ipv6_addresses
 
     def parsed_addresses(self, version: IPVersion = IPVersion.All) -> List[str]:
         """List addresses in their parsed string form.


### PR DESCRIPTION
Most of the reply overhead was because of the enums which happens A LOT if there are homekit devices on the network

<img width="1413" alt="Screenshot 2023-06-12 at 11 43 26 AM" src="https://github.com/python-zeroconf/python-zeroconf/assets/663432/90b7cbaa-7b19-4d96-981a-c08e8dbe335e">
