### PR TITLE
fix: reduce debug logging overhead by adding missing checks to datagram_received

### DIFF
--- a/src/zeroconf/_core.py
+++ b/src/zeroconf/_core.py
@@ -282,18 +282,20 @@ class AsyncListener(asyncio.Protocol, QuietLogger):
         else:
             # https://github.com/python/mypy/issues/1178
             addr, port, flow, scope = addrs  # type: ignore
-            log.debug('IPv6 scope_id %d associated to the receiving interface', scope)
+            if debug:
+                log.debug('IPv6 scope_id %d associated to the receiving interface', scope)
             v6_flow_scope = (flow, scope)
 
         if data_len > _MAX_MSG_ABSOLUTE:
             # Guard against oversized packets to ensure bad implementations cannot overwhelm
             # the system.
-            log.debug(
-                "Discarding incoming packet with length %s, which is larger "
-                "than the absolute maximum size of %s",
-                data_len,
-                _MAX_MSG_ABSOLUTE,
-            )
+            if debug:
+                log.debug(
+                    "Discarding incoming packet with length %s, which is larger "
+                    "than the absolute maximum size of %s",
+                    data_len,
+                    _MAX_MSG_ABSOLUTE,
+                )
             return
 
         now = current_time_millis()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -761,6 +761,22 @@ def test_guard_against_oversized_packets():
         is None
     )
 
+    logging.getLogger('zeroconf').setLevel(logging.INFO)
+
+    listener.datagram_received(over_sized_packet, ('::1', const._MDNS_PORT, 1, 1))
+    assert (
+        zc.cache.async_get_unique(
+            r.DNSText(
+                "packet0.local.",
+                const._TYPE_TXT,
+                const._CLASS_IN | const._CLASS_UNIQUE,
+                500,
+                b'path=/~paulsm/',
+            )
+        )
+        is None
+    )
+
     zc.close()
 
 


### PR DESCRIPTION
I only noticed these were missing when I ran the profiler on a system with IPv6