### PR TITLE
fix: improve performance of ServiceInfo.async_request

### DIFF
--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -174,7 +174,7 @@ class ServiceInfo(RecordUpdateListener):
         self.host_ttl = host_ttl
         self.other_ttl = other_ttl
         self.interface_index = interface_index
-        self._new_records_futures: List[asyncio.Future[None]] = []
+        self._new_records_futures: List[asyncio.Future] = []
 
     @property
     def name(self) -> str:
@@ -230,7 +230,7 @@ class ServiceInfo(RecordUpdateListener):
         """
         return self._properties
 
-    def _timeout_waiting_new_records(self, future: asyncio.Future[None]) -> None:
+    def _timeout_waiting_new_records(self, future: asyncio.Future) -> None:
         """Timeout waiting for new records to arrive."""
         if not future.done():
             future.set_result(None)

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -230,17 +230,12 @@ class ServiceInfo(RecordUpdateListener):
         """
         return self._properties
 
-    def _timeout_waiting_new_records(self, future: asyncio.Future) -> None:
-        """Timeout waiting for new records to arrive."""
-        if not future.done():
-            future.set_result(None)
-
     async def async_wait(self, timeout: float) -> None:
         """Calling task waits for a given number of milliseconds or until notified."""
         loop = asyncio.get_running_loop()
         future = loop.create_future()
         self._new_records_futures.append(future)
-        handle = loop.call_later(millis_to_seconds(timeout), self._timeout_waiting_new_records, future)
+        handle = loop.call_later(millis_to_seconds(timeout), future.set_result, None)
         try:
             await future
         finally:

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -595,7 +595,7 @@ class ServiceInfo(RecordUpdateListener):
             self.server = self.name
             self.server_key = self.server.lower()
 
-    def load_from_cache(self, zc: 'Zeroconf', now: Optional[float]) -> bool:
+    def load_from_cache(self, zc: 'Zeroconf', now: Optional[float] = None) -> bool:
         """Populate the service info from the cache.
 
         This method is designed to be threadsafe.

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -411,12 +411,11 @@ class ServiceInfo(RecordUpdateListener):
 
         This method will be run in the event loop.
         """
-        if self._process_records_threadsafe(zc, now, records):
-            notify_futures = self._new_records_futures
-            for future in notify_futures:
+        if self._process_records_threadsafe(zc, now, records) and self._new_records_futures:
+            for future in self._new_records_futures:
                 if not future.done():
                     future.set_result(None)
-            notify_futures.clear()
+            self._new_records_futures.clear()
 
     def _process_records_threadsafe(self, zc: 'Zeroconf', now: float, records: List[RecordUpdate]) -> bool:
         """Thread safe record updating.


### PR DESCRIPTION
When there are many lookups at once, this can overload the system. Refactor to use faster primitives

<img width="1448" alt="Screenshot 2023-08-01 at 1 18 10 PM" src="https://github.com/python-zeroconf/python-zeroconf/assets/663432/5c72681f-5185-4698-b89c-83fc7b3ac19c">

This block disappears from the profile after this change