### PR TITLE
fix: race with InvalidStateError when async_request times out

### DIFF
--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -89,6 +89,12 @@ def instance_name_from_service_info(info: "ServiceInfo") -> str:
 _cached_ip_addresses = lru_cache(maxsize=256)(ip_address)
 
 
+def _set_future_none_if_not_done(fut: asyncio.Future) -> None:
+    """Set a future to None if it is not done."""
+    if not fut.done():
+        fut.set_result(None)
+
+
 class ServiceInfo(RecordUpdateListener):
     """Service information.
 
@@ -235,7 +241,7 @@ class ServiceInfo(RecordUpdateListener):
         loop = asyncio.get_running_loop()
         future = loop.create_future()
         self._new_records_futures.append(future)
-        handle = loop.call_later(millis_to_seconds(timeout), future.set_result, None)
+        handle = loop.call_later(millis_to_seconds(timeout), _set_future_none_if_not_done, future)
         try:
             await future
         finally:

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -91,7 +91,7 @@ _cached_ip_addresses = lru_cache(maxsize=256)(ip_address)
 
 def _set_future_none_if_not_done(fut: asyncio.Future) -> None:
     """Set a future to None if it is not done."""
-    if not fut.done():
+    if not fut.done():  # pragma: no branch
         fut.set_result(None)
 
 


### PR DESCRIPTION
If async_request timed out at just the wrong time it could result in an InvalidStateError

```
2023-08-02 19:29:06.131 ERROR (MainThread) [homeassistant] Error doing job: Exception in callback Future.set_result(None)
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.11/3.11.4_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/asyncio/events.py", line 80, in _run
    self._context.run(self._callback, *self._args)
asyncio.exceptions.InvalidStateError: invalid state
```

This was harmless but created noise