### PR TITLE
fix: revert DNSIncoming cimport in _dns.pxd

### DIFF
--- a/src/zeroconf/_dns.pxd
+++ b/src/zeroconf/_dns.pxd
@@ -1,8 +1,6 @@
 
 import cython
 
-from ._protocol.incoming cimport DNSIncoming
-
 
 cdef object _LEN_BYTE
 cdef object _LEN_SHORT

--- a/src/zeroconf/_dns.pxd
+++ b/src/zeroconf/_dns.pxd
@@ -42,7 +42,7 @@ cdef class DNSRecord(DNSEntry):
     @cython.locals(
         answers=cython.list,
     )
-    cpdef suppressed_by(self, DNSIncoming msg)
+    cpdef suppressed_by(self, object msg)
 
     cpdef get_expiration_time(self, cython.uint percent)
 


### PR DESCRIPTION
fixes #1207

This seems to cause a problem for some systems. Its not clear why but this is likely the only change that could have triggered the issue so lets revert it