### PR TITLE
feat: add a cache to service_type_name

### DIFF
--- a/src/zeroconf/_utils/name.py
+++ b/src/zeroconf/_utils/name.py
@@ -35,6 +35,7 @@ from ..const import (
 )
 
 
+@lru_cache(maxsize=512)
 def service_type_name(type_: str, *, strict: bool = True) -> str:  # pylint: disable=too-many-branches
     """
     Validate a fully qualified service name, instance or subtype. [rfc6763]


### PR DESCRIPTION
This function gets called all over the place and when we construct a lot of ServiceInfos for queries its the most expensive part. Since we tend to query the same records over and over when a ServiceBrowser is running, this can have quite a cost