### PR TITLE
fix: remove typing on reset_ttl for cython compat

### DIFF
--- a/src/zeroconf/_dns.py
+++ b/src/zeroconf/_dns.py
@@ -207,7 +207,7 @@ class DNSRecord(DNSEntry):
         """Returns true if the record more than one quarter of its TTL remaining."""
         return self.created + (_RECENT_TIME_MS * self.ttl) > now
 
-    def reset_ttl(self, other: 'DNSRecord') -> None:
+    def reset_ttl(self, other) -> None:  # type: ignore[no-untyped-def]
         """Sets this record's TTL and created time to that of
         another record."""
         self.set_created_ttl(other.created, other.ttl)


### PR DESCRIPTION
fixes #1207

```
Cythonizing src/zeroconf/_dns.py

Error compiling Cython file:
------------------------------------------------------------
...

    def is_recent(self, now: _float) -> bool:
        """Returns true if the record more than one quarter of its TTL remaining."""
        return self.created + (_RECENT_TIME_MS * self.ttl) > now

    def reset_ttl(self, other: 'DNSRecord') -> None:
                       ^
------------------------------------------------------------

src/zeroconf/_dns.py:210:24: Compiler crash in AnalyseDeclarationsTransform

File 'ModuleNode.py', line 124, in analyse_declarations: ModuleNode(_dns.py:1:0,
    doc = ' Multicast DNS Service Discovery for Python, v0.14-wmcbrine\n    Copyright 2003 Paul Scott-Murphy, 2014 William McBrine\n\n    This module provides a framework for the use of DNS Service Discovery\n    using IP multicast.\n\n    This library is free software; you can redistribute it and/or\n    modify it under the terms of the GNU Lesser General Public\n    License as published by the Free Software Foundation; either\n    version 2.1 of the License, or (at your option) any later version.\n\n    This library is distributed in the hope that it will be useful,\n    but WITHOUT ANY WARRANTY; without even the implied warranty of\n    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU\n    Lesser General Public License for more details.\n\n    You should have received a copy of the GNU Lesser General Public\n    License along with this library; if not, write to the Free Software\n    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301\n    USA\n',
    full_module_name = 'zeroconf._dns')
File 'Nodes.py', line 431, in analyse_declarations: StatListNode(_dns.py:23:0)
File 'Nodes.py', line 431, in analyse_declarations: StatListNode(_dns.py:156:0)
File 'Nodes.py', line 4817, in analyse_declarations: CClassDefNode(_dns.py:156:0,
    class_name = 'DNSRecord',
    doc = 'A DNS record - like a DNS entry, but has a TTL',
    visibility = 'private')
File 'Nodes.py', line 431, in analyse_declarations: StatListNode(_dns.py:158:4)
File 'Nodes.py', line 2359, in analyse_declarations: CFuncDefNode(_dns.py:210:4,
    doc = "Sets this record's TTL and created time to that of\n        another record.",
    is_c_class_method = 1,
    modifiers = [...]/0,
    overridable = 1,
    visibility = 'private')
File 'Nodes.py', line 681, in analyse: CFuncDeclaratorNode(_dns.py:210:4,
    calling_convention = '')
File 'Nodes.py', line 909, in analyse: CArgDeclNode(_dns.py:210:24,
    is_generic = 1,
    outer_attrs = [...]/2)

Compiler crash traceback from this point on:
  File "/usr/lib64/python3.8/site-packages/Cython/Compiler/Nodes.py", line 909, in analyse
    if self.annotation and env and env.directives['annotation_typing'] and self.base_type.name is None:
AttributeError: 'CAnalysedBaseTypeNode' object has no attribute 'name'
```