### PR TITLE
feat: refactor notify implementation to reduce overhead of adding and removing listeners

### DIFF
--- a/src/zeroconf/_core.py
+++ b/src/zeroconf/_core.py
@@ -49,6 +49,7 @@ from ._services.registry import ServiceRegistry
 from ._transport import _WrappedTransport
 from ._updates import RecordUpdateListener
 from ._utils.asyncio import (
+    _resolve_all_futures_to_none,
     _set_future_none_if_not_done,
     await_awaitable,
     get_running_loop,
@@ -264,12 +265,8 @@ class Zeroconf(QuietLogger):
     def async_notify_all(self) -> None:
         """Schedule an async_notify_all."""
         notify_futures = self._notify_futures
-        if not notify_futures:
-            return
-        for future in notify_futures:
-            if not future.done():
-                future.set_result(None)
-        notify_futures.clear()
+        if notify_futures:
+            _resolve_all_futures_to_none(notify_futures)
 
     def get_service_info(
         self, type_: str, name: str, timeout: int = 3000, question_type: Optional[DNSQuestionType] = None

--- a/src/zeroconf/_core.py
+++ b/src/zeroconf/_core.py
@@ -264,6 +264,8 @@ class Zeroconf(QuietLogger):
     def async_notify_all(self) -> None:
         """Schedule an async_notify_all."""
         notify_futures = self._notify_futures
+        if not notify_futures:
+            return
         for future in notify_futures:
             if not future.done():
                 future.set_result(None)

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -40,6 +40,7 @@ from .._logger import log
 from .._protocol.outgoing import DNSOutgoing
 from .._updates import RecordUpdate, RecordUpdateListener
 from .._utils.asyncio import (
+    _resolve_all_futures_to_none,
     _set_future_none_if_not_done,
     get_running_loop,
     run_coro_with_timeout,
@@ -443,10 +444,7 @@ class ServiceInfo(RecordUpdateListener):
         """
         new_records_futures = self._new_records_futures
         if self._process_records_threadsafe(zc, now, records) and new_records_futures:
-            for future in new_records_futures:
-                if not future.done():
-                    future.set_result(None)
-            new_records_futures.clear()
+            _resolve_all_futures_to_none(new_records_futures)
 
     def _process_records_threadsafe(self, zc: 'Zeroconf', now: float, records: List[RecordUpdate]) -> bool:
         """Thread safe record updating.

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -39,7 +39,11 @@ from .._exceptions import BadTypeInNameException
 from .._logger import log
 from .._protocol.outgoing import DNSOutgoing
 from .._updates import RecordUpdate, RecordUpdateListener
-from .._utils.asyncio import get_running_loop, run_coro_with_timeout
+from .._utils.asyncio import (
+    _set_future_none_if_not_done,
+    get_running_loop,
+    run_coro_with_timeout,
+)
 from .._utils.name import service_type_name
 from .._utils.net import IPVersion, _encode_address
 from .._utils.time import current_time_millis, millis_to_seconds
@@ -87,12 +91,6 @@ def instance_name_from_service_info(info: "ServiceInfo", strict: bool = True) ->
 
 
 _cached_ip_addresses = lru_cache(maxsize=256)(ip_address)
-
-
-def _set_future_none_if_not_done(fut: asyncio.Future) -> None:
-    """Set a future to None if it is not done."""
-    if not fut.done():  # pragma: no branch
-        fut.set_result(None)
 
 
 class ServiceInfo(RecordUpdateListener):
@@ -180,7 +178,7 @@ class ServiceInfo(RecordUpdateListener):
         self.host_ttl = host_ttl
         self.other_ttl = other_ttl
         self.interface_index = interface_index
-        self._new_records_futures: List[asyncio.Future] = []
+        self._new_records_futures: Set[asyncio.Future] = set()
 
     @property
     def name(self) -> str:
@@ -244,12 +242,14 @@ class ServiceInfo(RecordUpdateListener):
         """Calling task waits for a given number of milliseconds or until notified."""
         loop = asyncio.get_running_loop()
         future = loop.create_future()
-        self._new_records_futures.append(future)
+        new_records_futures = self._new_records_futures
+        new_records_futures.add(future)
         handle = loop.call_later(millis_to_seconds(timeout), _set_future_none_if_not_done, future)
         try:
             await future
         finally:
             handle.cancel()
+            new_records_futures.discard(future)
 
     def addresses_by_version(self, version: IPVersion) -> List[bytes]:
         """List addresses matching IP version.
@@ -441,11 +441,12 @@ class ServiceInfo(RecordUpdateListener):
 
         This method will be run in the event loop.
         """
-        if self._process_records_threadsafe(zc, now, records) and self._new_records_futures:
-            for future in self._new_records_futures:
+        new_records_futures = self._new_records_futures
+        if self._process_records_threadsafe(zc, now, records) and new_records_futures:
+            for future in new_records_futures:
                 if not future.done():
                     future.set_result(None)
-            self._new_records_futures.clear()
+            new_records_futures.clear()
 
     def _process_records_threadsafe(self, zc: 'Zeroconf', now: float, records: List[RecordUpdate]) -> bool:
         """Thread safe record updating.

--- a/src/zeroconf/_utils/asyncio.py
+++ b/src/zeroconf/_utils/asyncio.py
@@ -41,6 +41,12 @@ _GET_ALL_TASKS_TIMEOUT = 3
 _WAIT_FOR_LOOP_TASKS_TIMEOUT = 3  # Must be larger than _TASK_AWAIT_TIMEOUT
 
 
+def _set_future_none_if_not_done(fut: asyncio.Future) -> None:
+    """Set a future to None if it is not done."""
+    if not fut.done():  # pragma: no branch
+        fut.set_result(None)
+
+
 async def wait_event_or_timeout(event: asyncio.Event, timeout: float) -> None:
     """Wait for an event or timeout."""
     with contextlib.suppress(asyncio.TimeoutError):

--- a/src/zeroconf/_utils/asyncio.py
+++ b/src/zeroconf/_utils/asyncio.py
@@ -54,6 +54,20 @@ def _resolve_all_futures_to_none(futures: Set[asyncio.Future]) -> None:
     futures.clear()
 
 
+async def wait_for_future_set_or_timeout(
+    loop: asyncio.AbstractEventLoop, future_set: Set[asyncio.Future], timeout: float
+) -> None:
+    """Wait for a future or timeout (in milliseconds)."""
+    future = loop.create_future()
+    future_set.add(future)
+    handle = loop.call_later(millis_to_seconds(timeout), _set_future_none_if_not_done, future)
+    try:
+        await future
+    finally:
+        handle.cancel()
+        future_set.discard(future)
+
+
 async def wait_event_or_timeout(event: asyncio.Event, timeout: float) -> None:
     """Wait for an event or timeout."""
     with contextlib.suppress(asyncio.TimeoutError):

--- a/src/zeroconf/_utils/asyncio.py
+++ b/src/zeroconf/_utils/asyncio.py
@@ -47,6 +47,13 @@ def _set_future_none_if_not_done(fut: asyncio.Future) -> None:
         fut.set_result(None)
 
 
+def _resolve_all_futures_to_none(futures: Set[asyncio.Future]) -> None:
+    """Resolve all futures to None."""
+    for fut in futures:
+        _set_future_none_if_not_done(fut)
+    futures.clear()
+
+
 async def wait_event_or_timeout(event: asyncio.Event, timeout: float) -> None:
     """Wait for an event or timeout."""
     with contextlib.suppress(asyncio.TimeoutError):


### PR DESCRIPTION
Noticed this while profiling the esphome code as it adds/remove listeners every time its trying to connect to an offline device