### PR TITLE
chore: remove default calls to .keys()

### DIFF
--- a/src/zeroconf/_handlers.py
+++ b/src/zeroconf/_handlers.py
@@ -166,7 +166,7 @@ class _QueryResponse:
     def add_ucast_question_response(self, answers: _AnswerWithAdditionalsType) -> None:
         """Generate a response to a unicast query."""
         self._additionals.update(answers)
-        self._ucast.update(answers.keys())
+        self._ucast.update(answers)
 
     def add_mcast_question_response(self, answers: _AnswerWithAdditionalsType) -> None:
         """Generate a response to a multicast query."""

--- a/src/zeroconf/_services/registry.py
+++ b/src/zeroconf/_services/registry.py
@@ -66,7 +66,7 @@ class ServiceRegistry:
 
     def async_get_types(self) -> List[str]:
         """Return all types."""
-        return list(self.types.keys())
+        return list(self.types)
 
     def async_get_infos_type(self, type_: str) -> List[ServiceInfo]:
         """Return all ServiceInfo matching type."""

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -577,7 +577,7 @@ def test_qu_response():
 
     def _validate_complete_response(answers):
         has_srv = has_txt = has_a = has_aaaa = has_nsec = False
-        nbr_answers = len(answers.keys())
+        nbr_answers = len(answers)
         additionals = set().union(*answers.values())
         nbr_additionals = len(additionals)
 


### PR DESCRIPTION
There were still a few places where we called `.keys()` when its the default.