### PR TITLE
feat: optimize processing of records in RecordUpdateListener subclasses

### DIFF
--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -410,35 +410,17 @@ class ServiceInfo(RecordUpdateListener):
         else:
             self._ipv4_addresses = self._get_ip_addresses_from_cache_lifo(zc, now, _TYPE_A)
 
-    def update_record(self, zc: 'Zeroconf', now: float, record: Optional[DNSRecord]) -> None:
-        """Updates service information from a DNS record.
-
-        This method is deprecated and will be removed in a future version.
-        update_records should be implemented instead.
-
-        This method will be run in the event loop.
-        """
-        if record is not None:
-            self._process_record_threadsafe(zc, record, now)
-
     def async_update_records(self, zc: 'Zeroconf', now: float, records: List[RecordUpdate]) -> None:
         """Updates service information from a DNS record.
 
         This method will be run in the event loop.
         """
         new_records_futures = self._new_records_futures
-        if self._process_records_threadsafe(zc, now, records) and new_records_futures:
-            _resolve_all_futures_to_none(new_records_futures)
-
-    def _process_records_threadsafe(self, zc: 'Zeroconf', now: float, records: List[RecordUpdate]) -> bool:
-        """Thread safe record updating.
-
-        Returns True if new records were added.
-        """
         updated: bool = False
         for record_update in records:
             updated |= self._process_record_threadsafe(zc, record_update.new, now)
-        return updated
+        if updated and new_records_futures:
+            _resolve_all_futures_to_none(new_records_futures)
 
     def _process_record_threadsafe(self, zc: 'Zeroconf', record: DNSRecord, now: float) -> bool:
         """Thread safe record updating.

--- a/src/zeroconf/_updates.py
+++ b/src/zeroconf/_updates.py
@@ -56,7 +56,7 @@ class RecordUpdateListener:
         All records that are received in a single packet are passed
         to update_records.
 
-        This implementation is a compatiblity shim to ensure older code
+        This implementation is a compatibility shim to ensure older code
         that uses RecordUpdateListener as a base class will continue to
         get calls to update_record. This method will raise
         NotImplementedError in a future version.


### PR DESCRIPTION
These classes used to process a single record at a time, but since we now process them all in batches, we can remove all the breakout functions.  This will also fix futures not resolving since the legacy backcompat was partially broken in info.py

This removes the legacy `update_record` as its been a few years now from `info.py`, but leaves the one in `_updates.py` for back-compat as it appears some libs are not updated yet

https://github.com/python-zeroconf/python-zeroconf/blob/b492eb4204e433dec7b9f9a1c79525649ef33b5c/src/zeroconf/_updates.py#L43
https://github.com/python-zeroconf/python-zeroconf/blob/b492eb4204e433dec7b9f9a1c79525649ef33b5c/src/zeroconf/_services/info.py#L413