### PR TITLE
feat: context managers in ServiceBrowser and AsyncServiceBrowser

### DIFF
--- a/src/zeroconf/_services/browser.py
+++ b/src/zeroconf/_services/browser.py
@@ -26,6 +26,7 @@ import random
 import threading
 import warnings
 from abc import abstractmethod
+from types import TracebackType  # noqa # used in type hints
 from typing import (
     TYPE_CHECKING,
     Callable,
@@ -35,6 +36,7 @@ from typing import (
     Optional,
     Set,
     Tuple,
+    Type,
     Union,
     cast,
 )
@@ -576,3 +578,15 @@ class ServiceBrowser(_ServiceBrowserBase, threading.Thread):
         for pending in self._pending_handlers.items():
             self.queue.put(pending)
         self._pending_handlers.clear()
+
+    def __enter__(self) -> 'ServiceBrowser':
+        return self
+
+    def __exit__(  # pylint: disable=useless-return
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> Optional[bool]:
+        self.cancel()
+        return None

--- a/src/zeroconf/asyncio.py
+++ b/src/zeroconf/asyncio.py
@@ -93,6 +93,18 @@ class AsyncServiceBrowser(_ServiceBrowserBase):
             self._fire_service_state_changed_event(pending)
         self._pending_handlers.clear()
 
+    async def __aenter__(self) -> 'AsyncServiceBrowser':
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> Optional[bool]:
+        await self.async_cancel()
+        return None
+
 
 class AsyncZeroconfServiceTypes(ZeroconfServiceTypes):
     """An async version of ZeroconfServiceTypes."""

--- a/tests/services/test_browser.py
+++ b/tests/services/test_browser.py
@@ -3,13 +3,14 @@
 
 """ Unit tests for zeroconf._services.browser. """
 
+import asyncio
 import logging
 import os
 import socket
 import time
 import unittest
 from threading import Event
-from typing import Iterable, Set
+from typing import Iterable, Set, cast
 from unittest.mock import patch
 
 import pytest
@@ -66,6 +67,35 @@ def test_service_browser_cancel_multiple_times():
     browser.cancel()
     browser.cancel()
     browser.cancel()
+
+    zc.close()
+
+
+def test_service_browser_cancel_context_manager():
+    """Test we can cancel a ServiceBrowser with it being used as a context manager."""
+
+    # instantiate a zeroconf instance
+    zc = Zeroconf(interfaces=['127.0.0.1'])
+    # start a browser
+    type_ = "_hap._tcp.local."
+
+    class MyServiceListener(r.ServiceListener):
+        pass
+
+    listener = MyServiceListener()
+
+    browser = r.ServiceBrowser(zc, type_, None, listener)
+
+    assert cast(bool, browser.done) is False
+
+    with browser:
+        pass
+
+    # ensure call_soon_threadsafe in ServiceBrowser.cancel is run
+    assert zc.loop is not None
+    asyncio.run_coroutine_threadsafe(asyncio.sleep(0), zc.loop).result()
+
+    assert cast(bool, browser.done) is True
 
     zc.close()
 

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -9,6 +9,7 @@ import os
 import socket
 import threading
 import time
+from typing import cast
 from unittest.mock import ANY, call, patch
 
 import pytest
@@ -777,6 +778,32 @@ async def test_async_context_manager() -> None:
         await task
         aiosinfo = await aiozc.async_get_service_info(type_, registration_name)
         assert aiosinfo is not None
+
+
+@pytest.mark.asyncio
+async def test_service_browser_cancel_async_context_manager():
+    """Test we can cancel an AsyncServiceBrowser with it being used as an async context manager."""
+
+    # instantiate a zeroconf instance
+    aiozc = AsyncZeroconf(interfaces=['127.0.0.1'])
+    zc = aiozc.zeroconf
+    type_ = "_hap._tcp.local."
+
+    class MyServiceListener(ServiceListener):
+        pass
+
+    listener = MyServiceListener()
+
+    browser = AsyncServiceBrowser(zc, type_, None, listener)
+
+    assert cast(bool, browser.done) is False
+
+    async with browser:
+        pass
+
+    assert cast(bool, browser.done) is True
+
+    await aiozc.async_close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
I started using this package for the first time recently, and when trying to use the [async browser example](https://github.com/python-zeroconf/python-zeroconf/blob/master/examples/async_browser.py), I found the requirement to use `AsyncServiceBrowser.async_cancel()` at the end of everything. After discovering that AsyncZeroconf has an async context manager, I found that AsyncServiceBrowser did not have its own.

I tried my best to replicate #284 (#177), however I am not sure how to go about adding test coverage. Apologies for not adding any.

Here's an example of how my code is simplified using the context manager (in Python 3.11):
```
async def main():
    services = ["_example._tcp.local."]
    async with (
        AsyncZeroconf() as aiozeroconf,
        AsyncServiceBrowser(aiozeroconf.zeroconf, services, handlers=[
            lambda **kwargs: tg.create_task(async_display_service_info(**kwargs)) and None
        ]),
        asyncio.TaskGroup() as tg,
    ):
        await asyncio.sleep(5)


if __name__ == '__main__':
    asyncio.run(main())
```