### PR TITLE
feat: use server_key when processing DNSService records

### DIFF
--- a/src/zeroconf/_core.py
+++ b/src/zeroconf/_core.py
@@ -440,8 +440,8 @@ class Zeroconf(QuietLogger):
         # If another server uses the same addresses, we do not want to send
         # goodbye packets for the address records
 
-        assert info.server is not None
-        entries = self.registry.async_get_infos_server(info.server.lower())
+        assert info.server_key is not None
+        entries = self.registry.async_get_infos_server(info.server_key)
         broadcast_addresses = not bool(entries)
         return asyncio.ensure_future(
             self._async_broadcast_service(info, _UNREGISTER_TIME, 0, broadcast_addresses)

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -472,7 +472,7 @@ class ServiceInfo(RecordUpdateListener):
             old_server_key = self.server_key
             self.name = record.name
             self.server = record.server
-            self.server_key = record.server.lower()
+            self.server_key = record.server_key
             self.port = record.port
             self.weight = record.weight
             self.priority = record.priority

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -586,7 +586,7 @@ class ServiceInfo(RecordUpdateListener):
         """
         if self.server is None:
             self.server = self._name
-            self.server_key = self.server.lower()
+            self.server_key = self.key
 
     def load_from_cache(self, zc: 'Zeroconf', now: Optional[float] = None) -> bool:
         """Populate the service info from the cache.


### PR DESCRIPTION
This is a small cleanup to avoid calling .lower() when we already have the server_key. performance benefit is negligible