### PR TITLE
feat: cache construction of records used to answer queries from the service registry

### DIFF
--- a/src/zeroconf/_core.py
+++ b/src/zeroconf/_core.py
@@ -400,7 +400,7 @@ class Zeroconf(QuietLogger):
         #
         # _CLASS_UNIQUE is the "QU" bit
         out.add_question(DNSQuestion(info.type, _TYPE_PTR, _CLASS_IN | _CLASS_UNIQUE))
-        out.add_authorative_answer(info.dns_pointer(created=current_time_millis()))
+        out.add_authorative_answer(info.dns_pointer())
         return out
 
     def _add_broadcast_answer(  # pylint: disable=no-self-use
@@ -411,14 +411,14 @@ class Zeroconf(QuietLogger):
         broadcast_addresses: bool = True,
     ) -> None:
         """Add answers to broadcast a service."""
-        now = current_time_millis()
+        current_time_millis()
         other_ttl = info.other_ttl if override_ttl is None else override_ttl
         host_ttl = info.host_ttl if override_ttl is None else override_ttl
-        out.add_answer_at_time(info.dns_pointer(override_ttl=other_ttl, created=now), 0)
-        out.add_answer_at_time(info.dns_service(override_ttl=host_ttl, created=now), 0)
-        out.add_answer_at_time(info.dns_text(override_ttl=other_ttl, created=now), 0)
+        out.add_answer_at_time(info.dns_pointer(override_ttl=other_ttl), 0)
+        out.add_answer_at_time(info.dns_service(override_ttl=host_ttl), 0)
+        out.add_answer_at_time(info.dns_text(override_ttl=other_ttl), 0)
         if broadcast_addresses:
-            for record in info.get_address_and_nsec_records(override_ttl=host_ttl, created=now):
+            for record in info.get_address_and_nsec_records(override_ttl=host_ttl):
                 out.add_answer_at_time(record, 0)
 
     def unregister_service(self, info: ServiceInfo) -> None:

--- a/src/zeroconf/_core.py
+++ b/src/zeroconf/_core.py
@@ -412,8 +412,8 @@ class Zeroconf(QuietLogger):
     ) -> None:
         """Add answers to broadcast a service."""
         current_time_millis()
-        other_ttl = info.other_ttl if override_ttl is None else override_ttl
-        host_ttl = info.host_ttl if override_ttl is None else override_ttl
+        other_ttl = None if override_ttl is None else override_ttl
+        host_ttl = None if override_ttl is None else override_ttl
         out.add_answer_at_time(info.dns_pointer(override_ttl=other_ttl), 0)
         out.add_answer_at_time(info.dns_service(override_ttl=host_ttl), 0)
         out.add_answer_at_time(info.dns_text(override_ttl=other_ttl), 0)

--- a/src/zeroconf/_handlers/query_handler.py
+++ b/src/zeroconf/_handlers/query_handler.py
@@ -163,7 +163,7 @@ class QueryHandler:
         self.question_history = question_history
 
     def _add_service_type_enumeration_query_answers(
-        self, answer_set: _AnswerWithAdditionalsType, known_answers: DNSRRSet, now: float
+        self, answer_set: _AnswerWithAdditionalsType, known_answers: DNSRRSet
     ) -> None:
         """Provide an answer to a service type enumeration query.
 
@@ -171,13 +171,13 @@ class QueryHandler:
         """
         for stype in self.registry.async_get_types():
             dns_pointer = DNSPointer(
-                _SERVICE_TYPE_ENUMERATION_NAME, _TYPE_PTR, _CLASS_IN, _DNS_OTHER_TTL, stype, now
+                _SERVICE_TYPE_ENUMERATION_NAME, _TYPE_PTR, _CLASS_IN, _DNS_OTHER_TTL, stype, 0
             )
             if not known_answers.suppresses(dns_pointer):
                 answer_set[dns_pointer] = set()
 
     def _add_pointer_answers(
-        self, lower_name: str, answer_set: _AnswerWithAdditionalsType, known_answers: DNSRRSet, now: float
+        self, lower_name: str, answer_set: _AnswerWithAdditionalsType, known_answers: DNSRRSet
     ) -> None:
         """Answer PTR/ANY question."""
         for service in self.registry.async_get_infos_type(lower_name):
@@ -196,7 +196,6 @@ class QueryHandler:
         lower_name: str,
         answer_set: _AnswerWithAdditionalsType,
         known_answers: DNSRRSet,
-        now: float,
         type_: int,
     ) -> None:
         """Answer A/AAAA/ANY question."""
@@ -231,16 +230,16 @@ class QueryHandler:
         question_lower_name = question.name.lower()
 
         if question.type == _TYPE_PTR and question_lower_name == _SERVICE_TYPE_ENUMERATION_NAME:
-            self._add_service_type_enumeration_query_answers(answer_set, known_answers, now)
+            self._add_service_type_enumeration_query_answers(answer_set, known_answers)
             return answer_set
 
         type_ = question.type
 
         if type_ in (_TYPE_PTR, _TYPE_ANY):
-            self._add_pointer_answers(question_lower_name, answer_set, known_answers, now)
+            self._add_pointer_answers(question_lower_name, answer_set, known_answers)
 
         if type_ in (_TYPE_A, _TYPE_AAAA, _TYPE_ANY):
-            self._add_address_answers(question_lower_name, answer_set, known_answers, now, type_)
+            self._add_address_answers(question_lower_name, answer_set, known_answers, type_)
 
         if type_ in (_TYPE_SRV, _TYPE_TXT, _TYPE_ANY):
             service = self.registry.async_get_info_name(question_lower_name)

--- a/src/zeroconf/_handlers/query_handler.py
+++ b/src/zeroconf/_handlers/query_handler.py
@@ -183,13 +183,13 @@ class QueryHandler:
         for service in self.registry.async_get_infos_type(lower_name):
             # Add recommended additional answers according to
             # https://tools.ietf.org/html/rfc6763#section-12.1.
-            dns_pointer = service.dns_pointer(created=now)
+            dns_pointer = service.dns_pointer()
             if known_answers.suppresses(dns_pointer):
                 continue
             answer_set[dns_pointer] = {
-                service.dns_service(created=now),
-                service.dns_text(created=now),
-            } | service.get_address_and_nsec_records(created=now)
+                service.dns_service(),
+                service.dns_text(),
+            } | service.get_address_and_nsec_records()
 
     def _add_address_answers(
         self,
@@ -204,7 +204,7 @@ class QueryHandler:
             answers: List[DNSAddress] = []
             additionals: Set[DNSRecord] = set()
             seen_types: Set[int] = set()
-            for dns_address in service.dns_addresses(created=now):
+            for dns_address in service.dns_addresses():
                 seen_types.add(dns_address.type)
                 if dns_address.type != type_:
                     additionals.add(dns_address)
@@ -214,12 +214,12 @@ class QueryHandler:
             if answers:
                 if missing_types:
                     assert service.server is not None, "Service server must be set for NSEC record."
-                    additionals.add(service.dns_nsec(list(missing_types), created=now))
+                    additionals.add(service.dns_nsec(list(missing_types)))
                 for answer in answers:
                     answer_set[answer] = additionals
             elif type_ in missing_types:
                 assert service.server is not None, "Service server must be set for NSEC record."
-                answer_set[service.dns_nsec(list(missing_types), created=now)] = set()
+                answer_set[service.dns_nsec(list(missing_types))] = set()
 
     def _answer_question(
         self,
@@ -248,11 +248,11 @@ class QueryHandler:
                 if type_ in (_TYPE_SRV, _TYPE_ANY):
                     # Add recommended additional answers according to
                     # https://tools.ietf.org/html/rfc6763#section-12.2.
-                    dns_service = service.dns_service(created=now)
+                    dns_service = service.dns_service()
                     if not known_answers.suppresses(dns_service):
-                        answer_set[dns_service] = service.get_address_and_nsec_records(created=now)
+                        answer_set[dns_service] = service.get_address_and_nsec_records()
                 if type_ in (_TYPE_TXT, _TYPE_ANY):
-                    dns_text = service.dns_text(created=now)
+                    dns_text = service.dns_text()
                     if not known_answers.suppresses(dns_text):
                         answer_set[dns_text] = set()
 

--- a/src/zeroconf/_handlers/query_handler.py
+++ b/src/zeroconf/_handlers/query_handler.py
@@ -171,7 +171,7 @@ class QueryHandler:
         """
         for stype in self.registry.async_get_types():
             dns_pointer = DNSPointer(
-                _SERVICE_TYPE_ENUMERATION_NAME, _TYPE_PTR, _CLASS_IN, _DNS_OTHER_TTL, stype, 0
+                _SERVICE_TYPE_ENUMERATION_NAME, _TYPE_PTR, _CLASS_IN, _DNS_OTHER_TTL, stype, 0.0
             )
             if not known_answers.suppresses(dns_pointer):
                 answer_set[dns_pointer] = set()

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -517,7 +517,7 @@ class ServiceInfo(RecordUpdateListener):
                 class_,
                 ttl,
                 ip_addr.packed,
-                created=0,
+                created=0.0,
             )
             for ip_addr in self._ip_addresses_by_version_value(version_value)
         ]
@@ -536,7 +536,7 @@ class ServiceInfo(RecordUpdateListener):
             _CLASS_IN,
             override_ttl if override_ttl is not None else self.other_ttl,
             self._name,
-            0,
+            0.0,
         )
         if cacheable:
             self._dns_pointer_cache = record
@@ -559,7 +559,7 @@ class ServiceInfo(RecordUpdateListener):
             self.weight,
             port,
             self.server or self._name,
-            0,
+            0.0,
         )
         if cacheable:
             self._dns_service_cache = record
@@ -576,7 +576,7 @@ class ServiceInfo(RecordUpdateListener):
             _CLASS_IN_UNIQUE,
             override_ttl if override_ttl is not None else self.other_ttl,
             self.text,
-            0,
+            0.0,
         )
         if cacheable:
             self._dns_text_cache = record
@@ -591,7 +591,7 @@ class ServiceInfo(RecordUpdateListener):
             override_ttl if override_ttl is not None else self.host_ttl,
             self._name,
             missing_types,
-            0,
+            0.0,
         )
 
     def get_address_and_nsec_records(self, override_ttl: Optional[int] = None) -> Set[DNSRecord]:

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -218,6 +218,7 @@ class ServiceInfo(RecordUpdateListener):
         """
         self._ipv4_addresses.clear()
         self._ipv6_addresses.clear()
+        self._dns_address_cache = None
 
         for address in value:
             try:

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -523,7 +523,8 @@ class ServiceInfo(RecordUpdateListener):
 
     def dns_pointer(self, override_ttl: Optional[int] = None) -> DNSPointer:
         """Return DNSPointer from ServiceInfo."""
-        if self._dns_pointer_cache is not None and override_ttl is None:
+        cacheable = override_ttl is None
+        if self._dns_pointer_cache is not None and cacheable:
             return self._dns_pointer_cache
         record = DNSPointer(
             self.type,
@@ -533,12 +534,14 @@ class ServiceInfo(RecordUpdateListener):
             self._name,
             0,
         )
-        self._dns_pointer_cache = record
+        if cacheable:
+            self._dns_pointer_cache = record
         return record
 
     def dns_service(self, override_ttl: Optional[int] = None) -> DNSService:
         """Return DNSService from ServiceInfo."""
-        if self._dns_service_cache is not None and override_ttl is None:
+        cacheable = override_ttl is None
+        if self._dns_service_cache is not None and cacheable:
             return self._dns_service_cache
         port = self.port
         if TYPE_CHECKING:
@@ -554,12 +557,14 @@ class ServiceInfo(RecordUpdateListener):
             self.server or self._name,
             0,
         )
-        self._dns_service_cache = record
+        if cacheable:
+            self._dns_service_cache = record
         return record
 
     def dns_text(self, override_ttl: Optional[int] = None) -> DNSText:
         """Return DNSText from ServiceInfo."""
-        if self._dns_text_cache is not None and override_ttl is None:
+        cacheable = override_ttl is None
+        if self._dns_text_cache is not None and cacheable:
             return self._dns_text_cache
         record = DNSText(
             self._name,
@@ -569,7 +574,8 @@ class ServiceInfo(RecordUpdateListener):
             self.text,
             0,
         )
-        self._dns_text_cache = record
+        if cacheable:
+            self._dns_text_cache = record
         return record
 
     def dns_nsec(self, missing_types: List[int], override_ttl: Optional[int] = None) -> DNSNsec:

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -199,6 +199,9 @@ class ServiceInfo(RecordUpdateListener):
         """Replace the the name and reset the key."""
         self._name = name
         self.key = name.lower()
+        self._dns_service_cache = None
+        self._dns_pointer_cache = None
+        self._dns_text_cache = None
 
     @property
     def addresses(self) -> List[bytes]:

--- a/tests/services/test_browser.py
+++ b/tests/services/test_browser.py
@@ -792,6 +792,8 @@ def test_service_browser_is_aware_of_port_changes():
     assert service_info.port == 80
 
     info.port = 400
+    info._dns_service_cache = None  # we are mutating the record so clear the cache
+
     _inject_response(
         zc,
         mock_incoming_msg([info.dns_service()]),
@@ -856,6 +858,8 @@ def test_service_browser_listeners_update_service():
         mock_incoming_msg([info.dns_pointer(), info.dns_service(), info.dns_text(), *info.dns_addresses()]),
     )
     time.sleep(0.2)
+    info._dns_service_cache = None  # we are mutating the record so clear the cache
+
     info.port = 400
     _inject_response(
         zc,
@@ -914,6 +918,8 @@ def test_service_browser_listeners_no_update_service():
     )
     time.sleep(0.2)
     info.port = 400
+    info._dns_service_cache = None  # we are mutating the record so clear the cache
+
     _inject_response(
         zc,
         mock_incoming_msg([info.dns_service()]),
@@ -1131,6 +1137,8 @@ def test_service_browser_matching():
     )
     time.sleep(0.2)
     info.port = 400
+    info._dns_service_cache = None  # we are mutating the record so clear the cache
+
     _inject_response(
         zc,
         mock_incoming_msg([info.dns_service()]),
@@ -1210,6 +1218,8 @@ def test_service_browser_expire_callbacks():
     )
     time.sleep(0.3)
     info.port = 400
+    info._dns_service_cache = None  # we are mutating the record so clear the cache
+
     _inject_response(
         zc,
         mock_incoming_msg([info.dns_service()]),

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -986,6 +986,7 @@ async def test_qu_response_only_sends_additionals_if_sends_answer():
     a_record = info.dns_addresses()[0]
     a_record.set_created_ttl(current_time_millis() - (a_record.ttl * 1000 / 2), a_record.ttl)
     assert not a_record.is_recent(current_time_millis())
+    info._dns_address_cache = None  # we are mutating the record so clear the cache
     zc.cache.async_add_records([a_record])
 
     # With QU should respond to only unicast when the answer has been recently multicast


### PR DESCRIPTION
- Anything we save for a query response does not need a created time since we only use this for records we are not authoritative for.  These records are good until they unregistered.
- The query_handler was constructing records for every question, when they never change once registered in the registry

Someone could be mutating the data after they register the `ServiceInfo` but that would be wrong anyways since they should be calling `async_update_service` with new `ServiceInfo` since any changes wouldn't be broadcast anyways.

This is not as clean as I would have liked it to be as we have to maintain backwards compat for `override_ttl`