### PR TITLE
feat: reduce overhead to process incoming questions

### DIFF
--- a/build_ext.py
+++ b/build_ext.py
@@ -31,6 +31,7 @@ def build(setup_kwargs: Any) -> None:
                         "src/zeroconf/_protocol/outgoing.py",
                         "src/zeroconf/_handlers/record_manager.py",
                         "src/zeroconf/_services/registry.py",
+                        "src/zeroconf/_utils/time.py",
                     ],
                     compiler_directives={"language_level": "3"},  # Python 3
                 ),

--- a/src/zeroconf/_listener.pxd
+++ b/src/zeroconf/_listener.pxd
@@ -1,12 +1,12 @@
 
 import cython
 
+from ._protocol.incoming cimport DNSIncoming
+from ._utils.time cimport current_time_millis, millis_to_seconds
 
-cdef object millis_to_seconds
+
 cdef object log
 cdef object logging_DEBUG
-
-from ._protocol.incoming cimport DNSIncoming
 
 
 cdef class AsyncListener:

--- a/src/zeroconf/_utils/time.pxd
+++ b/src/zeroconf/_utils/time.pxd
@@ -1,0 +1,4 @@
+
+cpdef current_time_millis()
+
+cpdef millis_to_seconds(object millis)

--- a/src/zeroconf/_utils/time.py
+++ b/src/zeroconf/_utils/time.py
@@ -23,6 +23,8 @@
 
 import time
 
+_float = float
+
 
 def current_time_millis() -> float:
     """Current time in milliseconds.
@@ -33,6 +35,6 @@ def current_time_millis() -> float:
     return time.monotonic() * 1000
 
 
-def millis_to_seconds(millis: float) -> float:
+def millis_to_seconds(millis: _float) -> float:
     """Convert milliseconds to seconds."""
     return millis / 1000.0


### PR DESCRIPTION
When the mac discovery app is open, the number of questions goes up almost 10x. We can reduce a bit of the overhead by cythonizing the time functions and cimporting it into the hot path