### PR TITLE
feat: avoid python float conversion in listener hot path

### DIFF
--- a/src/zeroconf/_listener.pxd
+++ b/src/zeroconf/_listener.pxd
@@ -10,6 +10,7 @@ cdef object logging_DEBUG
 
 
 cdef cython.uint _MAX_MSG_ABSOLUTE
+cdef cython.uint _DUPLICATE_PACKET_SUPPRESSION_INTERVAL
 
 cdef class AsyncListener:
 

--- a/src/zeroconf/_listener.pxd
+++ b/src/zeroconf/_listener.pxd
@@ -25,3 +25,5 @@ cdef class AsyncListener:
 
     @cython.locals(now=cython.float, msg=DNSIncoming)
     cpdef datagram_received(self, cython.bytes bytes, cython.tuple addrs)
+
+    cdef _cancel_any_timers_for_addr(self, object addr)

--- a/src/zeroconf/_listener.pxd
+++ b/src/zeroconf/_listener.pxd
@@ -9,6 +9,8 @@ cdef object logging_DEBUG
 from ._protocol.incoming cimport DNSIncoming
 
 
+cdef cython.uint _MAX_MSG_ABSOLUTE
+
 cdef class AsyncListener:
 
     cdef public object zc

--- a/src/zeroconf/_listener.pxd
+++ b/src/zeroconf/_listener.pxd
@@ -7,7 +7,7 @@ from ._utils.time cimport current_time_millis, millis_to_seconds
 
 cdef object log
 cdef object logging_DEBUG
-
+cdef object TYPE_CHECKING
 
 cdef cython.uint _MAX_MSG_ABSOLUTE
 cdef cython.uint _DUPLICATE_PACKET_SUPPRESSION_INTERVAL

--- a/src/zeroconf/_listener.py
+++ b/src/zeroconf/_listener.py
@@ -182,10 +182,11 @@ class AsyncListener:
                 return
         deferred.append(msg)
         delay = millis_to_seconds(random.randint(*_TC_DELAY_RANDOM_INTERVAL))
-        assert self.zc.loop is not None
+        loop = self.zc.loop
+        assert loop is not None
         self._cancel_any_timers_for_addr(addr)
-        self._timers[addr] = self.zc.loop.call_later(
-            delay, self._respond_query, None, addr, port, transport, v6_flow_scope
+        self._timers[addr] = loop.call_at(
+            loop.time() + delay, self._respond_query, None, addr, port, transport, v6_flow_scope
         )
 
     def _cancel_any_timers_for_addr(self, addr: _str) -> None:

--- a/src/zeroconf/_listener.py
+++ b/src/zeroconf/_listener.py
@@ -38,6 +38,8 @@ _TC_DELAY_RANDOM_INTERVAL = (400, 500)
 
 
 _bytes = bytes
+_str = str
+_int = int
 
 logging_DEBUG = logging.DEBUG
 
@@ -186,7 +188,7 @@ class AsyncListener:
             delay, self._respond_query, None, addr, port, transport, v6_flow_scope
         )
 
-    def _cancel_any_timers_for_addr(self, addr: str) -> None:
+    def _cancel_any_timers_for_addr(self, addr: _str) -> None:
         """Cancel any future truncated packet timers for the address."""
         if addr in self._timers:
             self._timers.pop(addr).cancel()
@@ -194,8 +196,8 @@ class AsyncListener:
     def _respond_query(
         self,
         msg: Optional[DNSIncoming],
-        addr: str,
-        port: int,
+        addr: _str,
+        port: _int,
         transport: _WrappedTransport,
         v6_flow_scope: Union[Tuple[()], Tuple[int, int]] = (),
     ) -> None:

--- a/src/zeroconf/_listener.py
+++ b/src/zeroconf/_listener.py
@@ -110,10 +110,13 @@ class AsyncListener:
                 )
             return
 
-        v6_flow_scope: Union[Tuple[()], Tuple[int, int]] = ()
         if len(addrs) == 2:
+            v6_flow_scope: Union[Tuple[()], Tuple[int, int]] = ()
             # https://github.com/python/mypy/issues/1178
             addr, port = addrs  # type: ignore
+            addr_port = addrs
+            if TYPE_CHECKING:
+                addr_port = cast(Tuple[str, int], addr_port)
             scope = None
         else:
             # https://github.com/python/mypy/issues/1178
@@ -121,8 +124,9 @@ class AsyncListener:
             if debug:  # pragma: no branch
                 log.debug('IPv6 scope_id %d associated to the receiving interface', scope)
             v6_flow_scope = (flow, scope)
+            addr_port = (addr, port)
 
-        msg = DNSIncoming(data, (addr, port), scope, now)
+        msg = DNSIncoming(data, addr_port, scope, now)
         self.data = data
         self.last_time = now
         self.last_message = msg


### PR DESCRIPTION
There were quite a few float to pyfloat conversion that can be avoided by adding cdefs