### PR TITLE
feat: speed up adding and removing RecordUpdateListeners

### DIFF
--- a/src/zeroconf/_core.py
+++ b/src/zeroconf/_core.py
@@ -240,7 +240,7 @@ class Zeroconf(QuietLogger):
             raise NotRunningException
 
     @property
-    def listeners(self) -> List[RecordUpdateListener]:
+    def listeners(self) -> Set[RecordUpdateListener]:
         return self.record_manager.listeners
 
     async def async_wait(self, timeout: float) -> None:

--- a/src/zeroconf/_handlers/record_manager.pxd
+++ b/src/zeroconf/_handlers/record_manager.pxd
@@ -11,12 +11,13 @@ cdef object _ADDRESS_RECORD_TYPES
 cdef object RecordUpdate
 cdef object TYPE_CHECKING
 cdef object _TYPE_PTR
+cdef object RecordUpdateListener
 
 cdef class RecordManager:
 
     cdef public object zc
     cdef public DNSCache cache
-    cdef public cython.list listeners
+    cdef public cython.set listeners
 
     cpdef async_updates(self, object now, object records)
 
@@ -29,3 +30,7 @@ cdef class RecordManager:
         now_float=cython.float
     )
     cpdef async_updates_from_response(self, DNSIncoming msg)
+
+    cpdef async_add_listener(self, object listener, object question)
+
+    cpdef async_remove_listener(self, object listener)

--- a/src/zeroconf/_handlers/record_manager.pxd
+++ b/src/zeroconf/_handlers/record_manager.pxd
@@ -11,7 +11,7 @@ cdef object _ADDRESS_RECORD_TYPES
 cdef object RecordUpdate
 cdef object TYPE_CHECKING
 cdef object _TYPE_PTR
-cdef object RecordUpdateListener
+
 
 cdef class RecordManager:
 

--- a/src/zeroconf/_handlers/record_manager.py
+++ b/src/zeroconf/_handlers/record_manager.py
@@ -45,7 +45,7 @@ class RecordManager:
         """Init the record manager."""
         self.zc = zeroconf
         self.cache = zeroconf.cache
-        self.listeners: List[RecordUpdateListener] = []
+        self.listeners: Set[RecordUpdateListener] = set()
 
     def async_updates(self, now: _float, records: List[RecordUpdate]) -> None:
         """Used to notify listeners of new information that has updated
@@ -174,7 +174,7 @@ class RecordManager:
                 " In the future this will fail"
             )
 
-        self.listeners.append(listener)
+        self.listeners.add(listener)
 
         if question is None:
             return

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -758,10 +758,6 @@ class ServiceInfo(RecordUpdateListener):
                 question.unicast = True
         return out
 
-    def __eq__(self, other: object) -> bool:
-        """Tests equality of service name"""
-        return isinstance(other, ServiceInfo) and other._name == self._name
-
     def __repr__(self) -> str:
         """String representation"""
         return '{}({})'.format(


### PR DESCRIPTION
Listeners were stored in a list which meant a linear search had to happen to remove them. We add/remove these quite a bit when resolving a service, also ESPHome churns these quite a bit when a device is offline.

Technically breaking change: `Zeroconf.listeners` now returns a `set` instead of a `list`
Technically breaking change: `ServiceInfo.__eq__` is now the default python implementation as it wasn't hashable otherwise and comparing on `name` was wrong since it wasn't case aware

