### PR TITLE
feat: avoid calling get_running_loop when resolving ServiceInfo

### DIFF
--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -722,6 +722,9 @@ class ServiceInfo(RecordUpdateListener):
         if self.load_from_cache(zc, now):
             return True
 
+        if TYPE_CHECKING:
+            assert zc.loop is not None
+
         first_request = True
         delay = _LISTENER_TIME
         next_ = now
@@ -743,8 +746,6 @@ class ServiceInfo(RecordUpdateListener):
                     delay *= 2
                     next_ += random.randint(*_AVOID_SYNC_DELAY_RANDOM_INTERVAL)
 
-                if TYPE_CHECKING:
-                    assert zc.loop is not None
                 await self.async_wait(min(next_, last) - now, zc.loop)
                 now = current_time_millis()
         finally:

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -263,11 +263,11 @@ class ServiceInfo(RecordUpdateListener):
             assert self._properties is not None
         return self._properties
 
-    async def async_wait(self, timeout: float) -> None:
+    async def async_wait(self, timeout: float, loop: Optional[asyncio.AbstractEventLoop] = None) -> None:
         """Calling task waits for a given number of milliseconds or until notified."""
-        loop = get_running_loop()
-        assert loop is not None
-        await wait_for_future_set_or_timeout(loop, self._new_records_futures, timeout)
+        await wait_for_future_set_or_timeout(
+            loop or asyncio.get_running_loop(), self._new_records_futures, timeout
+        )
 
     def addresses_by_version(self, version: IPVersion) -> List[bytes]:
         """List addresses matching IP version.
@@ -743,7 +743,9 @@ class ServiceInfo(RecordUpdateListener):
                     delay *= 2
                     next_ += random.randint(*_AVOID_SYNC_DELAY_RANDOM_INTERVAL)
 
-                await self.async_wait(min(next_, last) - now)
+                if TYPE_CHECKING:
+                    assert zc.loop is not None
+                await self.async_wait(min(next_, last) - now, zc.loop)
                 now = current_time_millis()
         finally:
             zc.async_remove_listener(self)


### PR DESCRIPTION
We already have the loop available as `zc.loop`

At Home Assistant startup we have a thundering heard of ServiceInfos being resolved. Avoid the get_running_loop() calls since it generates `os.getpid()` syscalls
