### PR TITLE
chore: prepare ServiceInfo base class RecordUpdateListener for cython

### DIFF
--- a/build_ext.py
+++ b/build_ext.py
@@ -33,6 +33,7 @@ def build(setup_kwargs: Any) -> None:
                         "src/zeroconf/_handlers/record_manager.py",
                         "src/zeroconf/_handlers/query_handler.py",
                         "src/zeroconf/_services/registry.py",
+                        "src/zeroconf/_updates.py",
                         "src/zeroconf/_utils/time.py",
                     ],
                     compiler_directives={"language_level": "3"},  # Python 3

--- a/src/zeroconf/__init__.py
+++ b/src/zeroconf/__init__.py
@@ -50,6 +50,7 @@ from ._exceptions import (
 from ._logger import QuietLogger, log  # noqa # import needed for backwards compat
 from ._protocol.incoming import DNSIncoming  # noqa # import needed for backwards compat
 from ._protocol.outgoing import DNSOutgoing  # noqa # import needed for backwards compat
+from ._record_update import RecordUpdate
 from ._services import (  # noqa # import needed for backwards compat
     ServiceListener,
     ServiceStateChange,
@@ -65,7 +66,7 @@ from ._services.registry import (  # noqa # import needed for backwards compat
     ServiceRegistry,
 )
 from ._services.types import ZeroconfServiceTypes
-from ._updates import RecordUpdate, RecordUpdateListener
+from ._updates import RecordUpdateListener
 from ._utils.name import service_type_name  # noqa # import needed for backwards compat
 from ._utils.net import (  # noqa # import needed for backwards compat
     InterfaceChoice,

--- a/src/zeroconf/_engine.py
+++ b/src/zeroconf/_engine.py
@@ -26,7 +26,7 @@ import socket
 import threading
 from typing import TYPE_CHECKING, List, Optional, cast
 
-from ._updates import RecordUpdate
+from ._record_update import RecordUpdate
 from ._utils.asyncio import get_running_loop, run_coro_with_timeout
 from ._utils.time import current_time_millis
 from .const import _CACHE_CLEANUP_INTERVAL

--- a/src/zeroconf/_handlers/record_manager.py
+++ b/src/zeroconf/_handlers/record_manager.py
@@ -26,7 +26,8 @@ from .._cache import _UniqueRecordsType
 from .._dns import DNSQuestion, DNSRecord
 from .._logger import log
 from .._protocol.incoming import DNSIncoming
-from .._updates import RecordUpdate, RecordUpdateListener
+from .._record_update import RecordUpdate
+from .._updates import RecordUpdateListener
 from .._utils.time import current_time_millis
 from ..const import _ADDRESS_RECORD_TYPES, _DNS_PTR_MIN_TTL, _TYPE_PTR
 

--- a/src/zeroconf/_record_update.py
+++ b/src/zeroconf/_record_update.py
@@ -1,0 +1,30 @@
+""" Multicast DNS Service Discovery for Python, v0.14-wmcbrine
+    Copyright 2003 Paul Scott-Murphy, 2014 William McBrine
+
+    This module provides a framework for the use of DNS Service Discovery
+    using IP multicast.
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+    USA
+"""
+
+from typing import NamedTuple, Optional
+
+from ._dns import DNSRecord
+
+
+class RecordUpdate(NamedTuple):
+    new: DNSRecord
+    old: Optional[DNSRecord]

--- a/src/zeroconf/_services/browser.py
+++ b/src/zeroconf/_services/browser.py
@@ -44,13 +44,14 @@ from typing import (
 from .._dns import DNSPointer, DNSQuestion, DNSQuestionType
 from .._logger import log
 from .._protocol.outgoing import DNSOutgoing
+from .._record_update import RecordUpdate
 from .._services import (
     ServiceListener,
     ServiceStateChange,
     Signal,
     SignalRegistrationInterface,
 )
-from .._updates import RecordUpdate, RecordUpdateListener
+from .._updates import RecordUpdateListener
 from .._utils.name import cached_possible_types, service_type_name
 from .._utils.time import current_time_millis, millis_to_seconds
 from ..const import (

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -38,7 +38,8 @@ from .._dns import (
 from .._exceptions import BadTypeInNameException
 from .._logger import log
 from .._protocol.outgoing import DNSOutgoing
-from .._updates import RecordUpdate, RecordUpdateListener
+from .._record_update import RecordUpdate
+from .._updates import RecordUpdateListener
 from .._utils.asyncio import (
     _resolve_all_futures_to_none,
     get_running_loop,

--- a/src/zeroconf/_updates.pxd
+++ b/src/zeroconf/_updates.pxd
@@ -1,0 +1,9 @@
+
+import cython
+
+
+cdef class RecordUpdateListener:
+
+    cpdef async_update_records(self, object zc, object now, cython.list records)
+
+    cpdef async_update_records_complete(self)

--- a/src/zeroconf/_updates.py
+++ b/src/zeroconf/_updates.py
@@ -20,17 +20,16 @@
     USA
 """
 
-from typing import TYPE_CHECKING, List, NamedTuple, Optional
+from typing import TYPE_CHECKING, List
 
 from ._dns import DNSRecord
+from ._record_update import RecordUpdate
 
 if TYPE_CHECKING:
     from ._core import Zeroconf
 
 
-class RecordUpdate(NamedTuple):
-    new: DNSRecord
-    old: Optional[DNSRecord]
+float_ = float
 
 
 class RecordUpdateListener:
@@ -50,7 +49,7 @@ class RecordUpdateListener:
         """
         raise RuntimeError("update_record is deprecated and will be removed in a future version.")
 
-    def async_update_records(self, zc: 'Zeroconf', now: float, records: List[RecordUpdate]) -> None:
+    def async_update_records(self, zc: 'Zeroconf', now: float_, records: List[RecordUpdate]) -> None:
         """Update multiple records in one shot.
 
         All records that are received in a single packet are passed


### PR DESCRIPTION
This should effectively do nothing except make ServiceInfo cythonable since cython requires the base class to be a cdef