### PR TITLE
feat: speed up ServiceInfo with a cython pxd

### DIFF
--- a/build_ext.py
+++ b/build_ext.py
@@ -32,6 +32,7 @@ def build(setup_kwargs: Any) -> None:
                         "src/zeroconf/_handlers/answers.py",
                         "src/zeroconf/_handlers/record_manager.py",
                         "src/zeroconf/_handlers/query_handler.py",
+                        "src/zeroconf/_services/info.py",
                         "src/zeroconf/_services/registry.py",
                         "src/zeroconf/_updates.py",
                         "src/zeroconf/_utils/time.py",

--- a/src/zeroconf/_services/info.pxd
+++ b/src/zeroconf/_services/info.pxd
@@ -1,0 +1,73 @@
+
+import cython
+
+from .._cache cimport DNSCache
+from .._dns cimport DNSPointer, DNSRecord, DNSService, DNSText
+from .._protocol.outgoing cimport DNSOutgoing
+from .._updates cimport RecordUpdateListener
+from .._utils.time cimport current_time_millis
+
+
+cdef object _TYPE_SRV
+cdef object _TYPE_TXT
+cdef object _TYPE_A
+cdef object _TYPE_AAAA
+cdef object _TYPE_PTR
+cdef object _TYPE_NSEC
+cdef object _CLASS_IN
+cdef object _FLAGS_QR_QUERY
+
+cdef object service_type_name
+
+cdef object DNSQuestionType
+
+cdef object TYPE_CHECKING
+
+cdef class ServiceInfo(RecordUpdateListener):
+
+    cdef public cython.bytes text
+    cdef public str type
+    cdef str _name
+    cdef public str key
+    cdef public cython.list _ipv4_addresses
+    cdef public cython.list _ipv6_addresses
+    cdef public object port
+    cdef public object weight
+    cdef public object priority
+    cdef public str server
+    cdef public str server_key
+    cdef public cython.dict _properties
+    cdef public object host_ttl
+    cdef public object other_ttl
+    cdef public object interface_index
+    cdef public cython.set _new_records_futures
+    cdef public DNSPointer _dns_pointer_cache
+    cdef public DNSService _dns_service_cache
+    cdef public DNSText _dns_text_cache
+    cdef public cython.list _dns_address_cache
+    cdef public cython.set _get_address_and_nsec_records_cache
+
+    @cython.locals(
+        cache=DNSCache
+    )
+    cpdef async_update_records(self, object zc, object now, cython.list records)
+
+    @cython.locals(
+        cache=DNSCache
+    )
+    cpdef _load_from_cache(self, object zc, object now)
+
+    cdef _unpack_text_into_properties(self)
+
+    cdef _set_properties(self, cython.dict properties)
+
+    cdef _set_text(self, cython.bytes text)
+
+    cdef _get_ip_addresses_from_cache_lifo(self, object zc, object now, object type)
+
+    cdef _process_record_threadsafe(self, object zc, DNSRecord record, object now)
+
+    @cython.locals(
+        cache=DNSCache
+    )
+    cdef cython.list _get_address_records_from_cache_by_type(self, object zc, object _type)

--- a/src/zeroconf/_services/info.pxd
+++ b/src/zeroconf/_services/info.pxd
@@ -24,6 +24,9 @@ cdef object service_type_name
 cdef object DNS_QUESTION_TYPE_QU
 cdef object DNS_QUESTION_TYPE_QM
 
+cdef object _IPVersion_All_value
+cdef object _IPVersion_V4Only_value
+
 cdef object TYPE_CHECKING
 
 cdef class ServiceInfo(RecordUpdateListener):

--- a/src/zeroconf/_services/info.pxd
+++ b/src/zeroconf/_services/info.pxd
@@ -78,3 +78,5 @@ cdef class ServiceInfo(RecordUpdateListener):
     cdef _set_ipv4_addresses_from_cache(self, object zc, object now)
 
     cdef _set_ipv6_addresses_from_cache(self, object zc, object now)
+
+    cdef cython.list _ip_addresses_by_version_value(self, object version_value)

--- a/src/zeroconf/_services/info.pxd
+++ b/src/zeroconf/_services/info.pxd
@@ -8,6 +8,8 @@ from .._updates cimport RecordUpdateListener
 from .._utils.time cimport current_time_millis
 
 
+cdef object _resolve_all_futures_to_none
+
 cdef object _TYPE_SRV
 cdef object _TYPE_TXT
 cdef object _TYPE_A
@@ -71,3 +73,7 @@ cdef class ServiceInfo(RecordUpdateListener):
         cache=DNSCache
     )
     cdef cython.list _get_address_records_from_cache_by_type(self, object zc, object _type)
+
+    cdef _set_ipv4_addresses_from_cache(self, object zc, object now)
+
+    cdef _set_ipv6_addresses_from_cache(self, object zc, object now)

--- a/src/zeroconf/_services/info.pxd
+++ b/src/zeroconf/_services/info.pxd
@@ -83,3 +83,5 @@ cdef class ServiceInfo(RecordUpdateListener):
     cdef _set_ipv6_addresses_from_cache(self, object zc, object now)
 
     cdef cython.list _ip_addresses_by_version_value(self, object version_value)
+
+    cdef addresses_by_version(self, object version)

--- a/src/zeroconf/_services/info.pxd
+++ b/src/zeroconf/_services/info.pxd
@@ -21,7 +21,8 @@ cdef object _FLAGS_QR_QUERY
 
 cdef object service_type_name
 
-cdef object DNSQuestionType
+cdef object DNS_QUESTION_TYPE_QU
+cdef object DNS_QUESTION_TYPE_QM
 
 cdef object TYPE_CHECKING
 

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -287,10 +287,9 @@ class ServiceInfo(RecordUpdateListener):
         """
         version_value = version.value
         if version_value == _IPVersion_All_value:
-            return [
-                *(addr.packed for addr in self._ipv4_addresses),
-                *(addr.packed for addr in self._ipv6_addresses),
-            ]
+            ip_v4_packed = [addr.packed for addr in self._ipv4_addresses]
+            ip_v6_packed = [addr.packed for addr in self._ipv6_addresses]
+            return [*ip_v4_packed, *ip_v6_packed]
         if version_value == _IPVersion_V4Only_value:
             return [addr.packed for addr in self._ipv4_addresses]
         return [addr.packed for addr in self._ipv6_addresses]

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -81,6 +81,8 @@ _AVOID_SYNC_DELAY_RANDOM_INTERVAL = (20, 120)
 float_ = float
 int_ = int
 
+DNS_QUESTION_TYPE_QU = DNSQuestionType.QU
+DNS_QUESTION_TYPE_QM = DNSQuestionType.QM
 
 if TYPE_CHECKING:
     from .._core import Zeroconf
@@ -747,7 +749,9 @@ class ServiceInfo(RecordUpdateListener):
                     return False
                 if next_ <= now:
                     out = self.generate_request_query(
-                        zc, now, question_type or DNSQuestionType.QU if first_request else DNSQuestionType.QM
+                        zc,
+                        now,
+                        question_type or DNS_QUESTION_TYPE_QU if first_request else DNS_QUESTION_TYPE_QM,
                     )
                     first_request = False
                     if not out.questions:
@@ -776,7 +780,7 @@ class ServiceInfo(RecordUpdateListener):
         out.add_question_or_one_cache(cache, now, name, _TYPE_TXT, _CLASS_IN)
         out.add_question_or_all_cache(cache, now, server_or_name, _TYPE_A, _CLASS_IN)
         out.add_question_or_all_cache(cache, now, server_or_name, _TYPE_AAAA, _CLASS_IN)
-        if question_type == DNSQuestionType.QU:
+        if question_type == DNS_QUESTION_TYPE_QU:
             for question in out.questions:
                 question.unicast = True
         return out

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -414,7 +414,7 @@ class ServiceInfo(RecordUpdateListener):
         address_list.reverse()  # Reverse to get LIFO order
         return address_list
 
-    def _set_ipv6_addresses_from_cache(self, zc: 'Zeroconf', now: float) -> None:
+    def _set_ipv6_addresses_from_cache(self, zc: 'Zeroconf', now: float_) -> None:
         """Set IPv6 addresses from the cache."""
         if TYPE_CHECKING:
             self._ipv6_addresses = cast(
@@ -423,7 +423,7 @@ class ServiceInfo(RecordUpdateListener):
         else:
             self._ipv6_addresses = self._get_ip_addresses_from_cache_lifo(zc, now, _TYPE_AAAA)
 
-    def _set_ipv4_addresses_from_cache(self, zc: 'Zeroconf', now: float) -> None:
+    def _set_ipv4_addresses_from_cache(self, zc: 'Zeroconf', now: float_) -> None:
         """Set IPv4 addresses from the cache."""
         if TYPE_CHECKING:
             self._ipv4_addresses = cast(

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -309,7 +309,7 @@ class ServiceInfo(RecordUpdateListener):
         return self._ip_addresses_by_version_value(version.value)
 
     def _ip_addresses_by_version_value(
-        self, version_value: int
+        self, version_value: int_
     ) -> Union[List[IPv4Address], List[IPv6Address], List[_BaseAddress]]:
         """Backend for addresses_by_version that uses the raw value."""
         if version_value == _IPVersion_All_value:


### PR DESCRIPTION
Its a shame that `dns_text`, `dns_pointer` etc take kwargs as we could make them cdefs as they are really what gets called the most here when using Homekit.  We could change the function signatures but I've already found code in the while calling it so it would be a breaking change for them.

