### PR TITLE
feat: improve AsyncServiceBrowser performance

### DIFF
--- a/src/zeroconf/_services/browser.pxd
+++ b/src/zeroconf/_services/browser.pxd
@@ -74,3 +74,5 @@ cdef class _ServiceBrowserBase(RecordUpdateListener):
     cpdef _async_send_ready_queries(self, object now)
 
     cpdef _cancel_send_timer(self)
+
+    cpdef async_update_records_complete(self)

--- a/src/zeroconf/asyncio.py
+++ b/src/zeroconf/asyncio.py
@@ -82,17 +82,6 @@ class AsyncServiceBrowser(_ServiceBrowserBase):
         """Cancel the browser."""
         self._async_cancel()
 
-    def async_update_records_complete(self) -> None:
-        """Called when a record update has completed for all handlers.
-
-        At this point the cache will have the new records.
-
-        This method will be run in the event loop.
-        """
-        for pending in self._pending_handlers.items():
-            self._fire_service_state_changed_event(pending)
-        self._pending_handlers.clear()
-
     async def __aenter__(self) -> 'AsyncServiceBrowser':
         return self
 


### PR DESCRIPTION
provide default handler for `async_update_records_complete` in `_ServiceBrowserBase`

`async_update_records_complete` is no longer an abstract method in `_ServiceBrowserBase` and a default handler is now provided which was originally in `AsyncServiceBrowser`.  This allows us to cythonize the function and use the fast PyDict methods since its called so frequently when a browser is running.

It is still expected that `async_update_records_complete` can be overridden in subclasses, but it is recommended to subclass `ServiceBrowser` or `AsyncServiceBrowser` directly instead of `_ServiceBrowserBase` since the `_` indicates `_ServiceBrowserBase` is protected and its internal api is not public (or stable)