### PR TITLE
fix: ensure ServiceInfo cache is cleared when adding to the registry

### DIFF
--- a/src/zeroconf/_services/info.pxd
+++ b/src/zeroconf/_services/info.pxd
@@ -107,3 +107,5 @@ cdef class ServiceInfo(RecordUpdateListener):
 
     @cython.locals(cacheable=cython.bint)
     cdef cython.set _get_address_and_nsec_records(self, object override_ttl)
+
+    cpdef async_clear_cache(self)

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -273,6 +273,14 @@ class ServiceInfo(RecordUpdateListener):
             assert self._properties is not None
         return self._properties
 
+    def async_clear_cache(self) -> None:
+        """Clear the cache for this service info."""
+        self._dns_address_cache = None
+        self._dns_pointer_cache = None
+        self._dns_service_cache = None
+        self._dns_text_cache = None
+        self._get_address_and_nsec_records_cache = None
+
     async def async_wait(self, timeout: float, loop: Optional[asyncio.AbstractEventLoop] = None) -> None:
         """Calling task waits for a given number of milliseconds or until notified."""
         if not self._new_records_futures:

--- a/src/zeroconf/_services/registry.py
+++ b/src/zeroconf/_services/registry.py
@@ -91,6 +91,7 @@ class ServiceRegistry:
         if info.key in self._services:
             raise ServiceNameAlreadyRegistered
 
+        info.async_clear_cache()
         self._services[info.key] = info
         self.types.setdefault(info.type.lower(), []).append(info.key)
         self.servers.setdefault(info.server_key, []).append(info.key)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,13 @@ from zeroconf import _core, _listener, const
 
 
 @pytest.fixture(autouse=True)
+def fast_register():
+    """Make the register call faster."""
+    with patch.object(_core, "_REGISTER_TIME", 0.0), patch.object(const, "_REGISTER_TIME", 0.0):
+        yield
+
+
+@pytest.fixture(autouse=True)
 def verify_threads_ended():
     """Verify that the threads are not running after the test."""
     threads_before = frozenset(threading.enumerate())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,13 +12,6 @@ from zeroconf import _core, _listener, const
 
 
 @pytest.fixture(autouse=True)
-def fast_register():
-    """Make the register call faster."""
-    with patch.object(_core, "_REGISTER_TIME", 0.0), patch.object(const, "_REGISTER_TIME", 0.0):
-        yield
-
-
-@pytest.fixture(autouse=True)
 def verify_threads_ended():
     """Verify that the threads are not running after the test."""
     threads_before = frozenset(threading.enumerate())

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -171,6 +171,12 @@ async def test_async_service_registration() -> None:
     )
     task = await aiozc.async_update_service(new_info)
     await task
+    assert new_info.dns_service().server_key == "ash-2.local."
+    new_info.server = "ash-3.local."
+    task = await aiozc.async_update_service(new_info)
+    await task
+    assert new_info.dns_service().server_key == "ash-3.local."
+
     task = await aiozc.async_unregister_service(new_info)
     await task
     await aiozc.async_close()

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -184,6 +184,7 @@ async def test_async_service_registration() -> None:
     assert calls == [
         ('add', type_, registration_name),
         ('update', type_, registration_name),
+        ('update', type_, registration_name),
         ('remove', type_, registration_name),
     ]
 


### PR DESCRIPTION
If the service info was modified in place the update would not be reflected when calling async_update_service.

This wasn't an expected use case, but it happens in the wild.