### PR TITLE
feat: reduce type checking overhead at run time

### DIFF
--- a/src/zeroconf/_handlers/multicast_outgoing_queue.pxd
+++ b/src/zeroconf/_handlers/multicast_outgoing_queue.pxd
@@ -5,7 +5,7 @@ from .._utils.time cimport current_time_millis, millis_to_seconds
 from .answers cimport AnswerGroup, construct_outgoing_multicast_answers
 
 
-cdef object TYPE_CHECKING
+cdef bint TYPE_CHECKING
 cdef tuple MULTICAST_DELAY_RANDOM_INTERVAL
 cdef object RAND_INT
 

--- a/src/zeroconf/_handlers/query_handler.pxd
+++ b/src/zeroconf/_handlers/query_handler.pxd
@@ -10,7 +10,7 @@ from .._services.registry cimport ServiceRegistry
 from .answers cimport QuestionAnswers
 
 
-cdef object TYPE_CHECKING
+cdef bint TYPE_CHECKING
 cdef cython.uint _ONE_SECOND, _TYPE_PTR, _TYPE_ANY, _TYPE_A, _TYPE_AAAA, _TYPE_SRV, _TYPE_TXT
 cdef str _SERVICE_TYPE_ENUMERATION_NAME
 cdef cython.set _RESPOND_IMMEDIATE_TYPES

--- a/src/zeroconf/_handlers/record_manager.pxd
+++ b/src/zeroconf/_handlers/record_manager.pxd
@@ -9,7 +9,7 @@ from .._protocol.incoming cimport DNSIncoming
 cdef cython.float _DNS_PTR_MIN_TTL
 cdef object _ADDRESS_RECORD_TYPES
 cdef object RecordUpdate
-cdef object TYPE_CHECKING
+cdef bint TYPE_CHECKING
 cdef object _TYPE_PTR
 
 

--- a/src/zeroconf/_listener.pxd
+++ b/src/zeroconf/_listener.pxd
@@ -8,7 +8,7 @@ from ._utils.time cimport current_time_millis, millis_to_seconds
 
 cdef object log
 cdef object logging_DEBUG
-cdef object TYPE_CHECKING
+cdef bint TYPE_CHECKING
 
 cdef cython.uint _MAX_MSG_ABSOLUTE
 cdef cython.uint _DUPLICATE_PACKET_SUPPRESSION_INTERVAL

--- a/src/zeroconf/_protocol/outgoing.pxd
+++ b/src/zeroconf/_protocol/outgoing.pxd
@@ -15,7 +15,7 @@ cdef cython.uint _FLAGS_TC
 cdef cython.uint _MAX_MSG_ABSOLUTE
 cdef cython.uint _MAX_MSG_TYPICAL
 
-cdef object TYPE_CHECKING
+cdef bint TYPE_CHECKING
 
 cdef object PACK_BYTE
 cdef object PACK_SHORT

--- a/src/zeroconf/_services/browser.pxd
+++ b/src/zeroconf/_services/browser.pxd
@@ -7,7 +7,7 @@ from .._updates cimport RecordUpdateListener
 from .._utils.time cimport current_time_millis, millis_to_seconds
 
 
-cdef object TYPE_CHECKING
+cdef bint TYPE_CHECKING
 cdef object cached_possible_types
 cdef cython.uint _EXPIRE_REFRESH_TIME_PERCENT
 cdef object SERVICE_STATE_CHANGE_ADDED, SERVICE_STATE_CHANGE_REMOVED, SERVICE_STATE_CHANGE_UPDATED

--- a/src/zeroconf/_services/info.pxd
+++ b/src/zeroconf/_services/info.pxd
@@ -30,7 +30,7 @@ cdef object _IPVersion_V4Only_value
 
 cdef cython.set _ADDRESS_RECORD_TYPES
 
-cdef object TYPE_CHECKING
+cdef bint TYPE_CHECKING
 
 cdef class ServiceInfo(RecordUpdateListener):
 


### PR DESCRIPTION
There was no need for TYPE_CHECKING to be an object which requires a jump back into python code