### PR TITLE
feat: speed up incoming packet processing with a memory view

### DIFF
--- a/src/zeroconf/_protocol/incoming.pxd
+++ b/src/zeroconf/_protocol/incoming.pxd
@@ -50,6 +50,7 @@ cdef class DNSIncoming:
     cdef public unsigned int flags
     cdef cython.uint offset
     cdef public bytes data
+    cdef const unsigned char [:] view
     cdef unsigned int _data_len
     cdef public cython.dict name_cache
     cdef public cython.list questions


### PR DESCRIPTION
All the single char conversions can avoid the bytes copy, and since there are a lot of them this is ~ an 8% speed up