### PR TITLE
chore: fix test patching

### DIFF
--- a/src/zeroconf/_services/browser.pxd
+++ b/src/zeroconf/_services/browser.pxd
@@ -23,7 +23,7 @@ cdef class _DNSPointerOutgoingBucket:
 
 
 @cython.locals(answer=DNSPointer)
-cdef _group_ptr_queries_with_known_answers(object now, object multicast, cython.dict question_with_known_answers)
+cpdef _group_ptr_queries_with_known_answers(object now, object multicast, cython.dict question_with_known_answers)
 
 cdef class QueryScheduler:
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 
 import pytest
 
-from zeroconf import _core, _listener, const
+from zeroconf import _core, const
 
 
 @pytest.fixture(autouse=True)
@@ -34,7 +34,5 @@ def disable_duplicate_packet_suppression():
     Some tests run too slowly because of the duplicate
     packet suppression.
     """
-    with patch.object(_listener, "_DUPLICATE_PACKET_SUPPRESSION_INTERVAL", 0), patch.object(
-        const, "_DUPLICATE_PACKET_SUPPRESSION_INTERVAL", 0
-    ):
+    with patch.object(const, "_DUPLICATE_PACKET_SUPPRESSION_INTERVAL", 0):
         yield

--- a/tests/services/test_browser.py
+++ b/tests/services/test_browser.py
@@ -26,7 +26,6 @@ from zeroconf import (
     current_time_millis,
     millis_to_seconds,
 )
-from zeroconf._handlers import record_manager
 from zeroconf._services import ServiceStateChange
 from zeroconf._services.browser import ServiceBrowser
 from zeroconf._services.info import ServiceInfo
@@ -1159,7 +1158,6 @@ def test_service_browser_matching():
     zc.close()
 
 
-@patch.object(record_manager, '_DNS_PTR_MIN_TTL', 1)
 @patch.object(_engine, "_CACHE_CLEANUP_INTERVAL", 0.01)
 def test_service_browser_expire_callbacks():
     """Test that the ServiceBrowser matching does not match partial names."""

--- a/tests/services/test_browser.py
+++ b/tests/services/test_browser.py
@@ -26,7 +26,6 @@ from zeroconf import (
     current_time_millis,
     millis_to_seconds,
 )
-from zeroconf._handlers import record_manager
 from zeroconf._services import ServiceStateChange
 from zeroconf._services.browser import ServiceBrowser
 from zeroconf._services.info import ServiceInfo
@@ -1159,7 +1158,6 @@ def test_service_browser_matching():
     zc.close()
 
 
-@patch.object(record_manager, '_DNS_PTR_MIN_TTL', 1)
 @patch.object(_engine, "_CACHE_CLEANUP_INTERVAL", 0.01)
 def test_service_browser_expire_callbacks():
     """Test that the ServiceBrowser matching does not match partial names."""
@@ -1216,6 +1214,12 @@ def test_service_browser_expire_callbacks():
         zc,
         mock_incoming_msg([info.dns_pointer(), info.dns_service(), info.dns_text(), *info.dns_addresses()]),
     )
+    # Force the ttl to be 1 second
+    now = current_time_millis()
+    for cache_record in zc.cache.cache.values():
+        for record in cache_record:
+            record.set_created_ttl(now, 1)
+
     time.sleep(0.3)
     info.port = 400
     info._dns_service_cache = None  # we are mutating the record so clear the cache

--- a/tests/services/test_browser.py
+++ b/tests/services/test_browser.py
@@ -26,6 +26,7 @@ from zeroconf import (
     current_time_millis,
     millis_to_seconds,
 )
+from zeroconf._handlers import record_manager
 from zeroconf._services import ServiceStateChange
 from zeroconf._services.browser import ServiceBrowser
 from zeroconf._services.info import ServiceInfo
@@ -1158,6 +1159,7 @@ def test_service_browser_matching():
     zc.close()
 
 
+@patch.object(record_manager, '_DNS_PTR_MIN_TTL', 1)
 @patch.object(_engine, "_CACHE_CLEANUP_INTERVAL", 0.01)
 def test_service_browser_expire_callbacks():
     """Test that the ServiceBrowser matching does not match partial names."""

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1495,6 +1495,7 @@ async def test_response_aggregation_timings_multiple(run_isolated, disable_dupli
     with unittest.mock.patch.object(aiozc.zeroconf, "async_send") as send_mock:
         send_mock.reset_mock()
         protocol.datagram_received(query2.packets()[0], ('127.0.0.1', const._MDNS_PORT))
+        protocol.last_time = 0  # manually reset the last time to avoid duplicate packet suppression
         await asyncio.sleep(0.2)
         calls = send_mock.mock_calls
         assert len(calls) == 1
@@ -1505,6 +1506,7 @@ async def test_response_aggregation_timings_multiple(run_isolated, disable_dupli
 
         send_mock.reset_mock()
         protocol.datagram_received(query2.packets()[0], ('127.0.0.1', const._MDNS_PORT))
+        protocol.last_time = 0  # manually reset the last time to avoid duplicate packet suppression
         await asyncio.sleep(1.2)
         calls = send_mock.mock_calls
         assert len(calls) == 1
@@ -1515,7 +1517,9 @@ async def test_response_aggregation_timings_multiple(run_isolated, disable_dupli
 
         send_mock.reset_mock()
         protocol.datagram_received(query2.packets()[0], ('127.0.0.1', const._MDNS_PORT))
+        protocol.last_time = 0  # manually reset the last time to avoid duplicate packet suppression
         protocol.datagram_received(query2.packets()[0], ('127.0.0.1', const._MDNS_PORT))
+        protocol.last_time = 0  # manually reset the last time to avoid duplicate packet suppression
         # The delay should increase with two packets and
         # 900ms is beyond the maximum aggregation delay
         # when there is no network protection delay


### PR DESCRIPTION
Some of the tests started failing because of fixes to the CI process where we were not properly testing with cython since the patch targets were not patchable.

