### PR TITLE
chore: fix race in dns tests

### DIFF
--- a/tests/test_dns.py
+++ b/tests/test_dns.py
@@ -149,13 +149,13 @@ class TestDunder(unittest.TestCase):
         now = current_time_millis()
         assert record.is_stale(now) is False
         assert record.is_stale(now + (8 / 4.1 * 1000)) is False
-        assert record.is_stale(now + (8 / 2 * 1000)) is True
+        assert record.is_stale(now + (8 / 1.9 * 1000)) is True
         assert record.is_stale(now + (8 * 1000)) is True
 
     def test_dns_record_is_recent(self):
         now = current_time_millis()
         record = r.DNSRecord('irrelevant', const._TYPE_SRV, const._CLASS_IN, 8)
-        assert record.is_recent(now + (8 / 4.1 * 1000)) is True
+        assert record.is_recent(now + (8 / 4.2 * 1000)) is True
         assert record.is_recent(now + (8 / 3 * 1000)) is False
         assert record.is_recent(now + (8 / 2 * 1000)) is False
         assert record.is_recent(now + (8 * 1000)) is False


### PR DESCRIPTION
time can move forward too slowly or quickly for these tests on the github runners