### PR TITLE
fix: do not build musllinux aarch64 wheels to reduce release time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.16.2
         # to supply options, put them in 'env', like:
         env:
-          CIBW_SKIP: cp36-* cp37-* pp36-* pp37-* *p38-*_aarch64 *p39-*_aarch64 *p310-*_aarch64 pp*_aarch64
+          CIBW_SKIP: cp36-* cp37-* pp36-* pp37-* *p38-*_aarch64 *p39-*_aarch64 *p310-*_aarch64 pp*_aarch64 *musllinux*_aarch64
           CIBW_BEFORE_ALL_LINUX: apt-get install -y gcc || yum install -y gcc || apk add gcc
           CIBW_ARCHS_LINUX: auto aarch64
           CIBW_BUILD_VERBOSITY: 3


### PR DESCRIPTION
The last build almost hit the 6 hour limit due to qemu being too slow. We only really need the aarch64 for debian at this point so remove the ones that were just added as there are likely no other consumers of the alpine wheels other than HA which builds their own anyways