### PR TITLE
feat: avoid decoding known answers if we have no answers to give

### DIFF
--- a/src/zeroconf/_core.py
+++ b/src/zeroconf/_core.py
@@ -577,7 +577,7 @@ class Zeroconf(QuietLogger):
     ) -> None:
         """Respond to a (re)assembled query.
 
-        If the protocol recieved packets with the TC bit set, it will
+        If the protocol received packets with the TC bit set, it will
         wait a bit for the rest of the packets and only call
         handle_assembled_query once it has a complete set of packets
         or the timer expires. If the TC bit is not set, a single

--- a/src/zeroconf/_core.py
+++ b/src/zeroconf/_core.py
@@ -583,11 +583,11 @@ class Zeroconf(QuietLogger):
         or the timer expires. If the TC bit is not set, a single
         packet will be in packets.
         """
-        now = packets[0].now
         ucast_source = port != _MDNS_PORT
         question_answers = self.query_handler.async_response(packets, ucast_source)
         if not question_answers:
             return
+        now = packets[0].now
         if question_answers.ucast:
             questions = packets[0].questions
             id_ = packets[0].id

--- a/src/zeroconf/_core.py
+++ b/src/zeroconf/_core.py
@@ -586,6 +586,8 @@ class Zeroconf(QuietLogger):
         now = packets[0].now
         ucast_source = port != _MDNS_PORT
         question_answers = self.query_handler.async_response(packets, ucast_source)
+        if not question_answers:
+            return
         if question_answers.ucast:
             questions = packets[0].questions
             id_ = packets[0].id

--- a/src/zeroconf/_handlers/answers.py
+++ b/src/zeroconf/_handlers/answers.py
@@ -59,6 +59,14 @@ class QuestionAnswers:
         self.mcast_aggregate = mcast_aggregate
         self.mcast_aggregate_last_second = mcast_aggregate_last_second
 
+    def __repr__(self) -> str:
+        """Return a string representation of this QuestionAnswers."""
+        return (
+            f'QuestionAnswers(ucast={self.ucast}, mcast_now={self.mcast_now}, '
+            f'mcast_aggregate={self.mcast_aggregate}, '
+            f'mcast_aggregate_last_second={self.mcast_aggregate_last_second})'
+        )
+
 
 class AnswerGroup:
     """A group of answers scheduled to be sent at the same time."""

--- a/src/zeroconf/_handlers/multicast_outgoing_queue.py
+++ b/src/zeroconf/_handlers/multicast_outgoing_queue.py
@@ -77,7 +77,7 @@ class MulticastOutgoingQueue:
             # If we calculate a random delay for the send after time
             # that is less than the last group scheduled to go out,
             # we instead add the answers to the last group as this
-            # allows aggregating additonal responses
+            # allows aggregating additional responses
             last_group = self.queue[-1]
             if send_after <= last_group.send_after:
                 last_group.answers.update(answers)

--- a/src/zeroconf/_handlers/multicast_outgoing_queue.py
+++ b/src/zeroconf/_handlers/multicast_outgoing_queue.py
@@ -116,7 +116,7 @@ class MulticastOutgoingQueue:
             # be sure we schedule them to go out later
             loop.call_at(loop.time() + millis_to_seconds(self.queue[0].send_after - now), self.async_ready)
 
-        if answers:
+        if answers:  # pragma: no branch
             # If we have the same answer scheduled to go out, remove them
             self._remove_answers_from_queue(answers)
             zc.async_send(construct_outgoing_multicast_answers(answers))

--- a/src/zeroconf/_handlers/query_handler.pxd
+++ b/src/zeroconf/_handlers/query_handler.pxd
@@ -27,6 +27,14 @@ cdef unsigned int _ANSWER_STRATEGY_TEXT
 cdef list _EMPTY_SERVICES_LIST
 cdef list _EMPTY_TYPES_LIST
 
+cdef class _AnswerStrategy:
+
+    cdef public DNSQuestion question
+    cdef public unsigned int strategy_type
+    cdef public list types
+    cdef public list services
+
+
 cdef class _QueryResponse:
 
     cdef bint _is_probe
@@ -76,7 +84,7 @@ cdef class QueryHandler:
     @cython.locals(
         msg=DNSIncoming,
         msgs=list,
-        strategy=tuple,
+        strategy=_AnswerStrategy,
         question=DNSQuestion,
         answer_set=cython.dict,
         known_answers=DNSRRSet,

--- a/src/zeroconf/_handlers/query_handler.pxd
+++ b/src/zeroconf/_handlers/query_handler.pxd
@@ -18,12 +18,14 @@ cdef cython.set _ADDRESS_RECORD_TYPES
 cdef object IPVersion, _IPVersion_ALL
 cdef object _TYPE_PTR, _CLASS_IN, _DNS_OTHER_TTL
 
-cdef object _ANSWER_STRATEGY_SERVICE_TYPE_ENUMERATION
-cdef object _ANSWER_STRATEGY_POINTER
-cdef object _ANSWER_STRATEGY_ADDRESS
-cdef object _ANSWER_STRATEGY_SERVICE
-cdef object _ANSWER_STRATEGY_TEXT
+cdef unsigned int _ANSWER_STRATEGY_SERVICE_TYPE_ENUMERATION
+cdef unsigned int _ANSWER_STRATEGY_POINTER
+cdef unsigned int _ANSWER_STRATEGY_ADDRESS
+cdef unsigned int _ANSWER_STRATEGY_SERVICE
+cdef unsigned int _ANSWER_STRATEGY_TEXT
 
+cdef list _EMPTY_SERVICES_LIST
+cdef list _EMPTY_TYPES_LIST
 
 cdef class _QueryResponse:
 
@@ -69,7 +71,7 @@ cdef class QueryHandler:
     cdef _add_address_answers(self, list services, cython.dict answer_set, DNSRRSet known_answers, cython.uint type_)
 
     @cython.locals(question_lower_name=str, type_=cython.uint, service=ServiceInfo)
-    cdef cython.dict _answer_question(self, DNSQuestion question, unsigned int strategy_type, object data, DNSRRSet known_answers)
+    cdef cython.dict _answer_question(self, DNSQuestion question, unsigned int strategy_type, list types, list services, DNSRRSet known_answers)
 
     @cython.locals(
         msg=DNSIncoming,

--- a/src/zeroconf/_handlers/query_handler.pxd
+++ b/src/zeroconf/_handlers/query_handler.pxd
@@ -18,11 +18,11 @@ cdef cython.set _ADDRESS_RECORD_TYPES
 cdef object IPVersion, _IPVersion_ALL
 cdef object _TYPE_PTR, _CLASS_IN, _DNS_OTHER_TTL
 
-cdef unsigned int _ANSWER_STRATEGY_SERVICE_TYPE_ENUMERATION
-cdef unsigned int _ANSWER_STRATEGY_POINTER
-cdef unsigned int _ANSWER_STRATEGY_ADDRESS
-cdef unsigned int _ANSWER_STRATEGY_SERVICE
-cdef unsigned int _ANSWER_STRATEGY_TEXT
+cdef object _ANSWER_STRATEGY_SERVICE_TYPE_ENUMERATION
+cdef object _ANSWER_STRATEGY_POINTER
+cdef object _ANSWER_STRATEGY_ADDRESS
+cdef object _ANSWER_STRATEGY_SERVICE
+cdef object _ANSWER_STRATEGY_TEXT
 
 
 cdef class _QueryResponse:
@@ -73,12 +73,16 @@ cdef class QueryHandler:
 
     @cython.locals(
         msg=DNSIncoming,
+        msgs=list,
         question=DNSQuestion,
         answer_set=cython.dict,
         known_answers=DNSRRSet,
         known_answers_set=cython.set,
         is_unicast=bint,
         is_probe=object,
-        now=object
+        now=float
     )
     cpdef async_response(self, cython.list msgs, cython.bint unicast_source)
+
+    @cython.locals(name=str, question_lower_name=str)
+    cdef _get_answer_strategies(self, DNSQuestion question)

--- a/src/zeroconf/_handlers/query_handler.pxd
+++ b/src/zeroconf/_handlers/query_handler.pxd
@@ -77,6 +77,7 @@ cdef class QueryHandler:
         answer_set=cython.dict,
         known_answers=DNSRRSet,
         known_answers_set=cython.set,
+        is_unicast=bint,
         is_probe=object,
         now=object
     )

--- a/src/zeroconf/_handlers/query_handler.pxd
+++ b/src/zeroconf/_handlers/query_handler.pxd
@@ -76,6 +76,7 @@ cdef class QueryHandler:
     @cython.locals(
         msg=DNSIncoming,
         msgs=list,
+        strategy=tuple,
         question=DNSQuestion,
         answer_set=cython.dict,
         known_answers=DNSRRSet,

--- a/src/zeroconf/_handlers/query_handler.pxd
+++ b/src/zeroconf/_handlers/query_handler.pxd
@@ -18,6 +18,13 @@ cdef cython.set _ADDRESS_RECORD_TYPES
 cdef object IPVersion, _IPVersion_ALL
 cdef object _TYPE_PTR, _CLASS_IN, _DNS_OTHER_TTL
 
+cdef unsigned int _ANSWER_STRATEGY_SERVICE_TYPE_ENUMERATION
+cdef unsigned int _ANSWER_STRATEGY_POINTER
+cdef unsigned int _ANSWER_STRATEGY_ADDRESS
+cdef unsigned int _ANSWER_STRATEGY_SERVICE
+cdef unsigned int _ANSWER_STRATEGY_TEXT
+
+
 cdef class _QueryResponse:
 
     cdef bint _is_probe
@@ -53,16 +60,16 @@ cdef class QueryHandler:
     cdef QuestionHistory question_history
 
     @cython.locals(service=ServiceInfo)
-    cdef _add_service_type_enumeration_query_answers(self, cython.dict answer_set, DNSRRSet known_answers)
+    cdef _add_service_type_enumeration_query_answers(self, list types, cython.dict answer_set, DNSRRSet known_answers)
 
     @cython.locals(service=ServiceInfo)
-    cdef _add_pointer_answers(self, str lower_name, cython.dict answer_set, DNSRRSet known_answers)
+    cdef _add_pointer_answers(self, list services, cython.dict answer_set, DNSRRSet known_answers)
 
     @cython.locals(service=ServiceInfo, dns_address=DNSAddress)
-    cdef _add_address_answers(self, str lower_name, cython.dict answer_set, DNSRRSet known_answers, cython.uint type_)
+    cdef _add_address_answers(self, list services, cython.dict answer_set, DNSRRSet known_answers, cython.uint type_)
 
     @cython.locals(question_lower_name=str, type_=cython.uint, service=ServiceInfo)
-    cdef cython.dict _answer_question(self, DNSQuestion question, DNSRRSet known_answers)
+    cdef cython.dict _answer_question(self, DNSQuestion question, unsigned int strategy_type, object data, DNSRRSet known_answers)
 
     @cython.locals(
         msg=DNSIncoming,

--- a/src/zeroconf/_handlers/query_handler.py
+++ b/src/zeroconf/_handlers/query_handler.py
@@ -204,7 +204,8 @@ class QueryHandler:
             answer_set[dns_pointer] = {
                 service._dns_service(None),
                 service._dns_text(None),
-            } | service._get_address_and_nsec_records(None)
+                *service._get_address_and_nsec_records(None),
+            }
 
     def _add_address_answers(
         self,
@@ -305,12 +306,16 @@ class QueryHandler:
         query_res = _QueryResponse(self.cache, questions, is_probe, now)
         known_answers = DNSRRSet(answers)
         known_answers_set: Optional[Set[DNSRecord]] = None
-        for question, strategy_type, types, services in strategies:
+        for strategy in strategies:
+            question = strategy[0]
             is_unicast = question.unique is True  # unique and unicast are the same flag
             if not is_unicast:
                 if known_answers_set is None:  # pragma: no branch
                     known_answers_set = known_answers.lookup_set()
                 self.question_history.add_question_at_time(question, now, known_answers_set)
+            strategy_type = strategy[1]
+            types = strategy[2]
+            services = strategy[3]
             answer_set = self._answer_question(question, strategy_type, types, services, known_answers)
             if not ucast_source and is_unicast:  # unique and unicast are the same flag
                 query_res.add_qu_question_response(answer_set)

--- a/src/zeroconf/_handlers/query_handler.py
+++ b/src/zeroconf/_handlers/query_handler.py
@@ -260,14 +260,13 @@ class QueryHandler:
     ) -> _AnswerWithAdditionalsType:
         """Answer a question."""
         answer_set: _AnswerWithAdditionalsType = {}
-        type_ = question.type
 
         if strategy_type == _ANSWER_STRATEGY_SERVICE_TYPE_ENUMERATION:
             self._add_service_type_enumeration_query_answers(types, answer_set, known_answers)
         elif strategy_type == _ANSWER_STRATEGY_POINTER:
             self._add_pointer_answers(services, answer_set, known_answers)
         elif strategy_type == _ANSWER_STRATEGY_ADDRESS:
-            self._add_address_answers(services, answer_set, known_answers, type_)
+            self._add_address_answers(services, answer_set, known_answers, question.type)
         elif strategy_type == _ANSWER_STRATEGY_SERVICE:
             # Add recommended additional answers according to
             # https://tools.ietf.org/html/rfc6763#section-12.2.

--- a/src/zeroconf/_handlers/query_handler.py
+++ b/src/zeroconf/_handlers/query_handler.py
@@ -333,7 +333,7 @@ class QueryHandler:
             answer_set = self._answer_question(
                 question, strategy.strategy_type, strategy.types, strategy.services, known_answers
             )
-            if not ucast_source and is_unicast:  # unique and unicast are the same flag
+            if not ucast_source and is_unicast:
                 query_res.add_qu_question_response(answer_set)
                 continue
             if ucast_source:

--- a/src/zeroconf/_handlers/query_handler.py
+++ b/src/zeroconf/_handlers/query_handler.py
@@ -269,7 +269,7 @@ class QueryHandler:
     def _answer_question(
         self,
         question: DNSQuestion,
-        strategy_type: int,
+        strategy_type: _int,
         data: Union[List[str], ServiceInfo, List[ServiceInfo]],
         known_answers: DNSRRSet,
     ) -> _AnswerWithAdditionalsType:

--- a/src/zeroconf/_handlers/query_handler.py
+++ b/src/zeroconf/_handlers/query_handler.py
@@ -266,13 +266,13 @@ class QueryHandler:
             self._add_service_type_enumeration_query_answers(types, answer_set, known_answers)
             return answer_set
 
-        if strategy_type == _ANSWER_STRATEGY_POINTER:
+        elif strategy_type == _ANSWER_STRATEGY_POINTER:
             self._add_pointer_answers(services, answer_set, known_answers)
 
-        if strategy_type == _ANSWER_STRATEGY_ADDRESS:
+        elif strategy_type == _ANSWER_STRATEGY_ADDRESS:
             self._add_address_answers(services, answer_set, known_answers, type_)
 
-        if strategy_type == _ANSWER_STRATEGY_SERVICE:
+        elif strategy_type == _ANSWER_STRATEGY_SERVICE:
             # Add recommended additional answers according to
             # https://tools.ietf.org/html/rfc6763#section-12.2.
             service = services[0]
@@ -280,7 +280,7 @@ class QueryHandler:
             if known_answers.suppresses(dns_service) is False:
                 answer_set[dns_service] = service._get_address_and_nsec_records(None)
 
-        if strategy_type == _ANSWER_STRATEGY_TEXT:
+        elif strategy_type == _ANSWER_STRATEGY_TEXT:
             service = services[0]
             dns_text = service._dns_text(None)
             if known_answers.suppresses(dns_text) is False:

--- a/src/zeroconf/_handlers/query_handler.py
+++ b/src/zeroconf/_handlers/query_handler.py
@@ -46,6 +46,8 @@ from ..const import (
 )
 from .answers import QuestionAnswers, _AnswerWithAdditionalsType
 
+AnswerStrategyType = Tuple[DNSQuestion, int, Union[List[str], ServiceInfo, List[ServiceInfo]]]
+
 _RESPOND_IMMEDIATE_TYPES = {_TYPE_NSEC, _TYPE_SRV, *_ADDRESS_RECORD_TYPES}
 _LOGGER = logging.getLogger(__name__)
 
@@ -233,11 +235,11 @@ class QueryHandler:
     def _get_answer_strategies(
         self,
         question: DNSQuestion,
-    ) -> List[Tuple[DNSQuestion, int, Union[List[str], ServiceInfo, List[ServiceInfo]]]]:
+    ) -> List[AnswerStrategyType]:
         """Collect strategies to answer a question."""
         question_lower_name = question.name.lower()
         type_ = question.type
-        strategies: List[Tuple[DNSQuestion, int, Union[List[str], ServiceInfo, List[ServiceInfo]]]] = []
+        strategies: List[AnswerStrategyType] = []
 
         if type_ == _TYPE_PTR and question_lower_name == _SERVICE_TYPE_ENUMERATION_NAME:
             types = self.registry.async_get_types()
@@ -322,7 +324,7 @@ class QueryHandler:
         query_res = _QueryResponse(self.cache, questions, is_probe, now)
         known_answers_set: Optional[Set[DNSRecord]] = None
 
-        strategies: List[Tuple[DNSQuestion, int, Union[List[str], ServiceInfo, List[ServiceInfo]]]] = []
+        strategies: List[AnswerStrategyType] = []
         for msg in msgs:
             for question in msg.questions:
                 strategies.extend(self._get_answer_strategies(question))

--- a/src/zeroconf/_handlers/query_handler.py
+++ b/src/zeroconf/_handlers/query_handler.py
@@ -20,7 +20,6 @@
     USA
 """
 
-import logging
 from typing import TYPE_CHECKING, List, Optional, Set, cast
 
 from .._cache import DNSCache, _UniqueRecordsType
@@ -47,7 +46,6 @@ from ..const import (
 from .answers import QuestionAnswers, _AnswerWithAdditionalsType
 
 _RESPOND_IMMEDIATE_TYPES = {_TYPE_NSEC, _TYPE_SRV, *_ADDRESS_RECORD_TYPES}
-_LOGGER = logging.getLogger(__name__)
 
 _EMPTY_SERVICES_LIST: List[ServiceInfo] = []
 _EMPTY_TYPES_LIST: List[str] = []

--- a/src/zeroconf/_handlers/query_handler.py
+++ b/src/zeroconf/_handlers/query_handler.py
@@ -302,6 +302,9 @@ class QueryHandler:
                 strategies.extend(self._get_answer_strategies(question))
 
         if not strategies:
+            # We have no way to answer the question because we have
+            # nothing in the ServiceRegistry that matches or we do not
+            # understand the question.
             return None
 
         is_probe = False

--- a/src/zeroconf/_handlers/query_handler.py
+++ b/src/zeroconf/_handlers/query_handler.py
@@ -362,6 +362,7 @@ class QueryHandler:
                         question, _ANSWER_STRATEGY_SERVICE_TYPE_ENUMERATION, types, _EMPTY_SERVICES_LIST
                     )
                 )
+            return strategies
 
         if type_ in (_TYPE_PTR, _TYPE_ANY):
             services = self.registry.async_get_infos_type(question_lower_name)

--- a/src/zeroconf/_handlers/query_handler.py
+++ b/src/zeroconf/_handlers/query_handler.py
@@ -307,9 +307,7 @@ class QueryHandler:
             return None
 
         is_probe = False
-        msg = msgs[0]
         questions = msg.questions
-        now = msg.now
         # Only decode known answers if we are not a probe and we have
         # at least one answer strategy
         answers: List[DNSRecord] = []
@@ -319,9 +317,11 @@ class QueryHandler:
             else:
                 answers.extend(msg.answers())
 
-        query_res = _QueryResponse(self.cache, questions, is_probe, now)
+        msg = msgs[0]
+        query_res = _QueryResponse(self.cache, questions, is_probe, msg.now)
         known_answers = DNSRRSet(answers)
         known_answers_set: Optional[Set[DNSRecord]] = None
+        now = msg.now
         for strategy in strategies:
             question = strategy.question
             is_unicast = question.unique is True  # unique and unicast are the same flag

--- a/src/zeroconf/_handlers/query_handler.py
+++ b/src/zeroconf/_handlers/query_handler.py
@@ -346,6 +346,8 @@ class QueryHandler:
             # TODO: return None
             return query_res.answers()
 
+        # Only decode known answers if we are not a probe and we have
+        # at least one answer strategy
         answers: List[DNSRecord] = []
         if not is_probe:
             for msg in msgs:

--- a/src/zeroconf/_handlers/query_handler.py
+++ b/src/zeroconf/_handlers/query_handler.py
@@ -329,7 +329,6 @@ class QueryHandler:
         This function must be run in the event loop as it is not
         threadsafe.
         """
-        answers: List[DNSRecord] = []
         is_probe = False
         msg = msgs[0]
         questions = msg.questions
@@ -346,6 +345,11 @@ class QueryHandler:
         if not strategies:
             # TODO: return None
             return query_res.answers()
+
+        answers: List[DNSRecord] = []
+        if not is_probe:
+            for msg in msgs:
+                answers.extend(msg.answers())
 
         known_answers = DNSRRSet(answers)
         known_answers_set: Optional[Set[DNSRecord]] = None

--- a/src/zeroconf/_handlers/query_handler.py
+++ b/src/zeroconf/_handlers/query_handler.py
@@ -274,7 +274,7 @@ class QueryHandler:
             dns_service = service._dns_service(None)
             if known_answers.suppresses(dns_service) is False:
                 answer_set[dns_service] = service._get_address_and_nsec_records(None)
-        elif strategy_type == _ANSWER_STRATEGY_TEXT:
+        elif strategy_type == _ANSWER_STRATEGY_TEXT:  # pragma: no branch
             service = services[0]
             dns_text = service._dns_text(None)
             if known_answers.suppresses(dns_text) is False:

--- a/src/zeroconf/_handlers/query_handler.py
+++ b/src/zeroconf/_handlers/query_handler.py
@@ -264,14 +264,10 @@ class QueryHandler:
 
         if strategy_type == _ANSWER_STRATEGY_SERVICE_TYPE_ENUMERATION:
             self._add_service_type_enumeration_query_answers(types, answer_set, known_answers)
-            return answer_set
-
         elif strategy_type == _ANSWER_STRATEGY_POINTER:
             self._add_pointer_answers(services, answer_set, known_answers)
-
         elif strategy_type == _ANSWER_STRATEGY_ADDRESS:
             self._add_address_answers(services, answer_set, known_answers, type_)
-
         elif strategy_type == _ANSWER_STRATEGY_SERVICE:
             # Add recommended additional answers according to
             # https://tools.ietf.org/html/rfc6763#section-12.2.
@@ -279,7 +275,6 @@ class QueryHandler:
             dns_service = service._dns_service(None)
             if known_answers.suppresses(dns_service) is False:
                 answer_set[dns_service] = service._get_address_and_nsec_records(None)
-
         elif strategy_type == _ANSWER_STRATEGY_TEXT:
             service = services[0]
             dns_text = service._dns_text(None)

--- a/src/zeroconf/_handlers/query_handler.py
+++ b/src/zeroconf/_handlers/query_handler.py
@@ -342,7 +342,8 @@ class QueryHandler:
         question: DNSQuestion,
     ) -> List[AnswerStrategyType]:
         """Collect strategies to answer a question."""
-        question_lower_name = question.name.lower()
+        name = question.name
+        question_lower_name = name.lower()
         type_ = question.type
         strategies: List[AnswerStrategyType] = []
 

--- a/src/zeroconf/_handlers/query_handler.py
+++ b/src/zeroconf/_handlers/query_handler.py
@@ -333,7 +333,6 @@ class QueryHandler:
         msg = msgs[0]
         questions = msg.questions
         now = msg.now
-        query_res = _QueryResponse(self.cache, questions, is_probe, now)
 
         strategies: List[AnswerStrategyType] = []
         for msg in msgs:
@@ -341,6 +340,8 @@ class QueryHandler:
                 is_probe = True
             for question in msg.questions:
                 strategies.extend(self._get_answer_strategies(question))
+
+        query_res = _QueryResponse(self.cache, questions, is_probe, now)
 
         if not strategies:
             # TODO: return None

--- a/src/zeroconf/_handlers/query_handler.py
+++ b/src/zeroconf/_handlers/query_handler.py
@@ -232,40 +232,6 @@ class QueryHandler:
                 assert service.server is not None, "Service server must be set for NSEC record."
                 answer_set[service._dns_nsec(list(missing_types), None)] = set()
 
-    def _get_answer_strategies(
-        self,
-        question: DNSQuestion,
-    ) -> List[AnswerStrategyType]:
-        """Collect strategies to answer a question."""
-        question_lower_name = question.name.lower()
-        type_ = question.type
-        strategies: List[AnswerStrategyType] = []
-
-        if type_ == _TYPE_PTR and question_lower_name == _SERVICE_TYPE_ENUMERATION_NAME:
-            types = self.registry.async_get_types()
-            if types:
-                strategies.append((question, _ANSWER_STRATEGY_SERVICE_TYPE_ENUMERATION, types))
-
-        if type_ in (_TYPE_PTR, _TYPE_ANY):
-            services = self.registry.async_get_infos_type(question_lower_name)
-            if services:
-                strategies.append((question, _ANSWER_STRATEGY_POINTER, services))
-
-        if type_ in (_TYPE_A, _TYPE_AAAA, _TYPE_ANY):
-            services = self.registry.async_get_infos_server(question_lower_name)
-            if services:
-                strategies.append((question, _ANSWER_STRATEGY_ADDRESS, services))
-
-        if type_ in (_TYPE_SRV, _TYPE_TXT, _TYPE_ANY):
-            service = self.registry.async_get_info_name(question_lower_name)
-            if service is not None:
-                if type_ in (_TYPE_SRV, _TYPE_ANY):
-                    strategies.append((question, _ANSWER_STRATEGY_SERVICE, service))
-                if type_ in (_TYPE_TXT, _TYPE_ANY):
-                    strategies.append((question, _ANSWER_STRATEGY_TEXT, service))
-
-        return strategies
-
     def _answer_question(
         self,
         question: DNSQuestion,
@@ -373,3 +339,37 @@ class QueryHandler:
             query_res.add_mcast_question_response(answer_set)
 
         return query_res.answers()
+
+    def _get_answer_strategies(
+        self,
+        question: DNSQuestion,
+    ) -> List[AnswerStrategyType]:
+        """Collect strategies to answer a question."""
+        question_lower_name = question.name.lower()
+        type_ = question.type
+        strategies: List[AnswerStrategyType] = []
+
+        if type_ == _TYPE_PTR and question_lower_name == _SERVICE_TYPE_ENUMERATION_NAME:
+            types = self.registry.async_get_types()
+            if types:
+                strategies.append((question, _ANSWER_STRATEGY_SERVICE_TYPE_ENUMERATION, types))
+
+        if type_ in (_TYPE_PTR, _TYPE_ANY):
+            services = self.registry.async_get_infos_type(question_lower_name)
+            if services:
+                strategies.append((question, _ANSWER_STRATEGY_POINTER, services))
+
+        if type_ in (_TYPE_A, _TYPE_AAAA, _TYPE_ANY):
+            services = self.registry.async_get_infos_server(question_lower_name)
+            if services:
+                strategies.append((question, _ANSWER_STRATEGY_ADDRESS, services))
+
+        if type_ in (_TYPE_SRV, _TYPE_TXT, _TYPE_ANY):
+            service = self.registry.async_get_info_name(question_lower_name)
+            if service is not None:
+                if type_ in (_TYPE_SRV, _TYPE_ANY):
+                    strategies.append((question, _ANSWER_STRATEGY_SERVICE, service))
+                if type_ in (_TYPE_TXT, _TYPE_ANY):
+                    strategies.append((question, _ANSWER_STRATEGY_TEXT, service))
+
+        return strategies

--- a/src/zeroconf/_handlers/query_handler.py
+++ b/src/zeroconf/_handlers/query_handler.py
@@ -57,6 +57,13 @@ _IPVersion_ALL = IPVersion.All
 _int = int
 
 
+_ANSWER_STRATEGY_SERVICE_TYPE_ENUMERATION = 0
+_ANSWER_STRATEGY_POINTER = 1
+_ANSWER_STRATEGY_ADDRESS = 2
+_ANSWER_STRATEGY_SERVICE = 3
+_ANSWER_STRATEGY_TEXT = 4
+
+
 class _AnswerStrategy:
 
     __slots__ = ("question", "strategy_type", "types", "services")
@@ -173,13 +180,6 @@ class _QueryResponse:
             record = cast(_UniqueRecordsType, record)
         maybe_entry = self._cache.async_get_unique(record)
         return bool(maybe_entry is not None and self._now - maybe_entry.created < _ONE_SECOND)
-
-
-_ANSWER_STRATEGY_SERVICE_TYPE_ENUMERATION = 0
-_ANSWER_STRATEGY_POINTER = 1
-_ANSWER_STRATEGY_ADDRESS = 2
-_ANSWER_STRATEGY_SERVICE = 3
-_ANSWER_STRATEGY_TEXT = 4
 
 
 class QueryHandler:

--- a/src/zeroconf/_record_update.py
+++ b/src/zeroconf/_record_update.py
@@ -26,7 +26,6 @@ from ._dns import DNSRecord
 
 
 class RecordUpdate:
-
     __slots__ = ("new", "old")
 
     def __init__(self, new: DNSRecord, old: Optional[DNSRecord] = None):

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1347,6 +1347,7 @@ async def test_questions_query_handler_does_not_put_qu_questions_in_history():
     packets = generated.packets()
     question_answers = zc.query_handler.async_response([r.DNSIncoming(packet) for packet in packets], False)
     assert question_answers
+    assert "qu._hap._tcp.local." in str(question_answers)
     assert not question_answers.ucast  # has not multicast recently
     assert question_answers.mcast_now
     assert not question_answers.mcast_aggregate

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -107,6 +107,7 @@ class TestRegistrar(unittest.TestCase):
         question_answers = zc.query_handler.async_response(
             [r.DNSIncoming(packet) for packet in query.packets()], False
         )
+        assert question_answers
         _process_outgoing_packet(construct_outgoing_multicast_answers(question_answers.mcast_aggregate))
 
         # The additonals should all be suppresed since they are all in the answers section
@@ -145,6 +146,7 @@ class TestRegistrar(unittest.TestCase):
         question_answers = zc.query_handler.async_response(
             [r.DNSIncoming(packet) for packet in query.packets()], False
         )
+        assert question_answers
         _process_outgoing_packet(construct_outgoing_multicast_answers(question_answers.mcast_aggregate))
 
         # There will be one NSEC additional to indicate the lack of AAAA record
@@ -244,6 +246,7 @@ def test_ptr_optimization():
     question_answers = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in query.packets()], False
     )
+    assert question_answers
     assert not question_answers.ucast
     assert not question_answers.mcast_now
     assert not question_answers.mcast_aggregate
@@ -260,6 +263,7 @@ def test_ptr_optimization():
     question_answers = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in query.packets()], False
     )
+    assert question_answers
     assert not question_answers.ucast
     assert not question_answers.mcast_now
     assert not question_answers.mcast_aggregate_last_second
@@ -305,6 +309,7 @@ def test_any_query_for_ptr():
     generated.add_question(question)
     packets = generated.packets()
     question_answers = zc.query_handler.async_response([r.DNSIncoming(packet) for packet in packets], False)
+    assert question_answers
     mcast_answers = list(question_answers.mcast_aggregate)
     assert mcast_answers[0].name == type_
     assert mcast_answers[0].alias == registration_name  # type: ignore[attr-defined]
@@ -332,6 +337,7 @@ def test_aaaa_query():
     generated.add_question(question)
     packets = generated.packets()
     question_answers = zc.query_handler.async_response([r.DNSIncoming(packet) for packet in packets], False)
+    assert question_answers
     mcast_answers = list(question_answers.mcast_now)
     assert mcast_answers[0].address == ipv6_address  # type: ignore[attr-defined]
     # unregister
@@ -358,6 +364,7 @@ def test_aaaa_query_upper_case():
     generated.add_question(question)
     packets = generated.packets()
     question_answers = zc.query_handler.async_response([r.DNSIncoming(packet) for packet in packets], False)
+    assert question_answers
     mcast_answers = list(question_answers.mcast_now)
     assert mcast_answers[0].address == ipv6_address  # type: ignore[attr-defined]
     # unregister
@@ -391,6 +398,7 @@ def test_a_and_aaaa_record_fate_sharing():
     generated.add_question(question)
     packets = generated.packets()
     question_answers = zc.query_handler.async_response([r.DNSIncoming(packet) for packet in packets], False)
+    assert question_answers
     additionals = set().union(*question_answers.mcast_now.values())
     assert aaaa_record in question_answers.mcast_now
     assert a_record in additionals
@@ -403,6 +411,7 @@ def test_a_and_aaaa_record_fate_sharing():
     generated.add_question(question)
     packets = generated.packets()
     question_answers = zc.query_handler.async_response([r.DNSIncoming(packet) for packet in packets], False)
+    assert question_answers
     additionals = set().union(*question_answers.mcast_now.values())
     assert a_record in question_answers.mcast_now
     assert aaaa_record in additionals
@@ -437,6 +446,7 @@ def test_unicast_response():
     question_answers = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in query.packets()], True
     )
+    assert question_answers
     for answers in (question_answers.ucast, question_answers.mcast_aggregate):
         has_srv = has_txt = has_a = has_aaaa = has_nsec = False
         nbr_additionals = 0
@@ -486,6 +496,7 @@ async def test_probe_answered_immediately():
     question_answers = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in query.packets()], False
     )
+    assert question_answers
     assert not question_answers.ucast
     assert not question_answers.mcast_aggregate
     assert not question_answers.mcast_aggregate_last_second
@@ -499,6 +510,7 @@ async def test_probe_answered_immediately():
     question_answers = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in query.packets()], False
     )
+    assert question_answers
     assert question_answers.ucast
     assert question_answers.mcast_now
     assert not question_answers.mcast_aggregate
@@ -528,6 +540,7 @@ async def test_probe_answered_immediately_with_uppercase_name():
     question_answers = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in query.packets()], False
     )
+    assert question_answers
     assert not question_answers.ucast
     assert not question_answers.mcast_aggregate
     assert not question_answers.mcast_aggregate_last_second
@@ -541,6 +554,7 @@ async def test_probe_answered_immediately_with_uppercase_name():
     question_answers = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in query.packets()], False
     )
+    assert question_answers
     assert question_answers.ucast
     assert question_answers.mcast_now
     assert not question_answers.mcast_aggregate
@@ -607,6 +621,7 @@ def test_qu_response():
     question_answers = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in query.packets()], False
     )
+    assert question_answers
     _validate_complete_response(question_answers.ucast)
     assert not question_answers.mcast_now
     assert not question_answers.mcast_aggregate
@@ -622,6 +637,7 @@ def test_qu_response():
     question_answers = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in query.packets()], False
     )
+    assert question_answers
     assert not question_answers.ucast
     assert not question_answers.mcast_aggregate
     assert not question_answers.mcast_aggregate
@@ -637,6 +653,7 @@ def test_qu_response():
     question_answers = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in query.packets()], False
     )
+    assert question_answers
     _validate_complete_response(question_answers.ucast)
     _validate_complete_response(question_answers.mcast_now)
 
@@ -652,6 +669,7 @@ def test_qu_response():
     question_answers = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in query.packets()], False
     )
+    assert question_answers
     assert not question_answers.mcast_now
     assert not question_answers.mcast_aggregate
     assert not question_answers.mcast_aggregate_last_second
@@ -681,6 +699,7 @@ def test_known_answer_supression():
     generated.add_question(question)
     packets = generated.packets()
     question_answers = zc.query_handler.async_response([r.DNSIncoming(packet) for packet in packets], False)
+    assert question_answers
     assert not question_answers.ucast
     assert not question_answers.mcast_now
     assert question_answers.mcast_aggregate
@@ -692,6 +711,7 @@ def test_known_answer_supression():
     generated.add_answer_at_time(info.dns_pointer(), now)
     packets = generated.packets()
     question_answers = zc.query_handler.async_response([r.DNSIncoming(packet) for packet in packets], False)
+    assert question_answers
     assert not question_answers.ucast
     assert not question_answers.mcast_now
     assert not question_answers.mcast_aggregate
@@ -703,6 +723,7 @@ def test_known_answer_supression():
     generated.add_question(question)
     packets = generated.packets()
     question_answers = zc.query_handler.async_response([r.DNSIncoming(packet) for packet in packets], False)
+    assert question_answers
     assert not question_answers.ucast
     assert question_answers.mcast_now
     assert not question_answers.mcast_aggregate
@@ -715,6 +736,7 @@ def test_known_answer_supression():
         generated.add_answer_at_time(dns_address, now)
     packets = generated.packets()
     question_answers = zc.query_handler.async_response([r.DNSIncoming(packet) for packet in packets], False)
+    assert question_answers
     assert not question_answers.ucast
     assert not question_answers.mcast_now
     assert not question_answers.mcast_aggregate
@@ -728,6 +750,7 @@ def test_known_answer_supression():
         generated.add_answer_at_time(dns_address, now)
     packets = generated.packets()
     question_answers = zc.query_handler.async_response([r.DNSIncoming(packet) for packet in packets], False)
+    assert question_answers
     assert not question_answers.ucast
     expected_nsec_record = cast(r.DNSNsec, list(question_answers.mcast_now)[0])
     assert const._TYPE_A not in expected_nsec_record.rdtypes
@@ -741,6 +764,7 @@ def test_known_answer_supression():
     generated.add_question(question)
     packets = generated.packets()
     question_answers = zc.query_handler.async_response([r.DNSIncoming(packet) for packet in packets], False)
+    assert question_answers
     assert not question_answers.ucast
     assert question_answers.mcast_now
     assert not question_answers.mcast_aggregate
@@ -752,6 +776,7 @@ def test_known_answer_supression():
     generated.add_answer_at_time(info.dns_service(), now)
     packets = generated.packets()
     question_answers = zc.query_handler.async_response([r.DNSIncoming(packet) for packet in packets], False)
+    assert question_answers
     assert not question_answers.ucast
     assert not question_answers.mcast_now
     assert not question_answers.mcast_aggregate
@@ -763,6 +788,7 @@ def test_known_answer_supression():
     generated.add_question(question)
     packets = generated.packets()
     question_answers = zc.query_handler.async_response([r.DNSIncoming(packet) for packet in packets], False)
+    assert question_answers
     assert not question_answers.ucast
     assert not question_answers.mcast_now
     assert question_answers.mcast_aggregate
@@ -774,6 +800,7 @@ def test_known_answer_supression():
     generated.add_answer_at_time(info.dns_text(), now)
     packets = generated.packets()
     question_answers = zc.query_handler.async_response([r.DNSIncoming(packet) for packet in packets], False)
+    assert question_answers
     assert not question_answers.ucast
     assert not question_answers.mcast_now
     assert not question_answers.mcast_aggregate
@@ -827,6 +854,7 @@ def test_multi_packet_known_answer_supression():
     packets = generated.packets()
     assert len(packets) > 1
     question_answers = zc.query_handler.async_response([r.DNSIncoming(packet) for packet in packets], False)
+    assert question_answers
     assert not question_answers.ucast
     assert not question_answers.mcast_now
     assert not question_answers.mcast_aggregate
@@ -868,6 +896,7 @@ def test_known_answer_supression_service_type_enumeration_query():
     generated.add_question(question)
     packets = generated.packets()
     question_answers = zc.query_handler.async_response([r.DNSIncoming(packet) for packet in packets], False)
+    assert question_answers
     assert not question_answers.ucast
     assert not question_answers.mcast_now
     assert question_answers.mcast_aggregate
@@ -898,6 +927,7 @@ def test_known_answer_supression_service_type_enumeration_query():
     )
     packets = generated.packets()
     question_answers = zc.query_handler.async_response([r.DNSIncoming(packet) for packet in packets], False)
+    assert question_answers
     assert not question_answers.ucast
     assert not question_answers.mcast_now
     assert not question_answers.mcast_aggregate
@@ -938,6 +968,7 @@ def test_upper_case_enumeration_query():
     generated.add_question(question)
     packets = generated.packets()
     question_answers = zc.query_handler.async_response([r.DNSIncoming(packet) for packet in packets], False)
+    assert question_answers
     assert not question_answers.ucast
     assert not question_answers.mcast_now
     assert question_answers.mcast_aggregate
@@ -1000,6 +1031,7 @@ async def test_qu_response_only_sends_additionals_if_sends_answer():
     question_answers = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in query.packets()], False
     )
+    assert question_answers
     assert not question_answers.mcast_now
     assert not question_answers.mcast_aggregate
     assert not question_answers.mcast_aggregate_last_second
@@ -1024,6 +1056,7 @@ async def test_qu_response_only_sends_additionals_if_sends_answer():
     question_answers = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in query.packets()], False
     )
+    assert question_answers
     assert not question_answers.mcast_now
     assert not question_answers.mcast_aggregate
     assert not question_answers.mcast_aggregate_last_second
@@ -1047,6 +1080,7 @@ async def test_qu_response_only_sends_additionals_if_sends_answer():
     question_answers = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in query.packets()], False
     )
+    assert question_answers
     assert not question_answers.ucast
     assert not question_answers.mcast_aggregate
     assert not question_answers.mcast_aggregate_last_second
@@ -1075,6 +1109,7 @@ async def test_qu_response_only_sends_additionals_if_sends_answer():
     question_answers = zc.query_handler.async_response(
         [r.DNSIncoming(packet) for packet in query.packets()], False
     )
+    assert question_answers
     assert not question_answers.mcast_aggregate
     assert not question_answers.mcast_aggregate_last_second
 
@@ -1235,8 +1270,22 @@ async def test_questions_query_handler_populates_the_question_history_from_qm_qu
     now = current_time_millis()
     _clear_cache(zc)
 
+    aiozc.zeroconf.registry.async_add(
+        ServiceInfo(
+            "_hap._tcp.local.",
+            "other._hap._tcp.local.",
+            80,
+            0,
+            0,
+            {"md": "known"},
+            "ash-2.local.",
+            addresses=[socket.inet_aton("1.2.3.4")],
+        )
+    )
+    services = aiozc.zeroconf.registry.async_get_infos_type("_hap._tcp.local.")
+    assert len(services) == 1
     generated = r.DNSOutgoing(const._FLAGS_QR_QUERY)
-    question = r.DNSQuestion("_hap._tcp._local.", const._TYPE_PTR, const._CLASS_IN)
+    question = r.DNSQuestion("_hap._tcp.local.", const._TYPE_PTR, const._CLASS_IN)
     question.unicast = False
     known_answer = r.DNSPointer(
         "_hap._tcp.local.", const._TYPE_PTR, const._CLASS_IN, 10000, 'known-to-other._hap._tcp.local.'
@@ -1246,9 +1295,10 @@ async def test_questions_query_handler_populates_the_question_history_from_qm_qu
     now = r.current_time_millis()
     packets = generated.packets()
     question_answers = zc.query_handler.async_response([r.DNSIncoming(packet) for packet in packets], False)
+    assert question_answers
     assert not question_answers.ucast
     assert not question_answers.mcast_now
-    assert not question_answers.mcast_aggregate
+    assert question_answers.mcast_aggregate
     assert not question_answers.mcast_aggregate_last_second
     assert zc.question_history.suppresses(question, now, {known_answer})
 
@@ -1273,10 +1323,8 @@ async def test_questions_query_handler_does_not_put_qu_questions_in_history():
     now = r.current_time_millis()
     packets = generated.packets()
     question_answers = zc.query_handler.async_response([r.DNSIncoming(packet) for packet in packets], False)
-    assert not question_answers.ucast
-    assert not question_answers.mcast_now
-    assert not question_answers.mcast_aggregate
-    assert not question_answers.mcast_aggregate_last_second
+    assert question_answers
+    assert not question_answers
     assert not zc.question_history.suppresses(question, now, {known_answer})
 
     await aiozc.async_close()


### PR DESCRIPTION
Inspired by #1307

In most cases were won't be able to answer the questions because we don't have an answer in the ServiceRegistry for the question since we only know how to answer for entries we have. In this case we can avoid building a set of answers and parsing the known answers in the incoming packet in the majority of cases. 

**This is a significant speed up since parsing incoming packets is the most expensive thing zeroconf does.**