### PR TITLE
chore(deps): bump cython to >= 3.0.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,7 +151,7 @@ ignore_errors = true
 
 [build-system]
 # 1.5.2 required for https://github.com/python-poetry/poetry/issues/7505
-requires = ['setuptools>=65.4.1', 'wheel', 'Cython', "poetry-core>=1.5.2"]
+requires = ['setuptools>=65.4.1', 'wheel', 'Cython>=3.0.5', "poetry-core>=1.5.2"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.codespell]


### PR DESCRIPTION
cython 0.29.x is no longer recommended by cython and since 3.x fixes so many issues, we don't want people stumbling with the wrong cython version.