### PR TITLE
feat: speed up outgoing packet writer

### DIFF
--- a/bench/outgoing.py
+++ b/bench/outgoing.py
@@ -158,9 +158,10 @@ out = generate_packets()
 
 
 def make_outgoing_message() -> None:
+    out.packets()
     out.state = State.init.value
     out.finished = False
-    out.packets()
+    out._reset_for_next_packet()
 
 
 count = 100000

--- a/src/zeroconf/_protocol/outgoing.pxd
+++ b/src/zeroconf/_protocol/outgoing.pxd
@@ -15,7 +15,10 @@ cdef cython.uint _FLAGS_TC
 cdef cython.uint _MAX_MSG_ABSOLUTE
 cdef cython.uint _MAX_MSG_TYPICAL
 
+
 cdef bint TYPE_CHECKING
+
+cdef unsigned int SHORT_CACHE_MAX
 
 cdef object PACK_BYTE
 cdef object PACK_SHORT

--- a/src/zeroconf/_protocol/outgoing.pxd
+++ b/src/zeroconf/_protocol/outgoing.pxd
@@ -46,7 +46,7 @@ cdef class DNSOutgoing:
     cdef public cython.list authorities
     cdef public cython.list additionals
 
-    cdef _reset_for_next_packet(self)
+    cpdef _reset_for_next_packet(self)
 
     cdef _write_byte(self, object value)
 
@@ -78,7 +78,7 @@ cdef class DNSOutgoing:
 
     cdef _write_records_from_offset(self, cython.list records, object offset)
 
-    cdef _has_more_to_add(self, object questions_offset, object answer_offset, object authority_offset, object additional_offset)
+    cdef bint _has_more_to_add(self, object questions_offset, object answer_offset, object authority_offset, object additional_offset)
 
     cdef _write_ttl(self, DNSRecord record, object now)
 
@@ -102,6 +102,7 @@ cdef class DNSOutgoing:
     @cython.locals(
         debug_enable=bint,
         made_progress=bint,
+        has_more_to_add=bint,
         questions_offset=object,
         answer_offset=object,
         authority_offset=object,

--- a/src/zeroconf/_protocol/outgoing.pxd
+++ b/src/zeroconf/_protocol/outgoing.pxd
@@ -105,6 +105,7 @@ cdef class DNSOutgoing:
 
     cpdef write_string(self, cython.bytes value)
 
+    @cython.locals(utfstr=bytes)
     cpdef _write_utf(self, cython.str value)
 
     @cython.locals(

--- a/src/zeroconf/_protocol/outgoing.pxd
+++ b/src/zeroconf/_protocol/outgoing.pxd
@@ -28,6 +28,7 @@ cdef object LOGGING_IS_ENABLED_FOR
 cdef object LOGGING_DEBUG
 
 cdef cython.tuple BYTE_TABLE
+cdef cython.tuple SHORT_LOOKUP
 
 cdef class DNSOutgoing:
 
@@ -48,11 +49,13 @@ cdef class DNSOutgoing:
 
     cpdef _reset_for_next_packet(self)
 
-    cdef _write_byte(self, object value)
+    cdef _write_byte(self, cython.uint value)
 
-    cdef _insert_short_at_start(self, object value)
+    cdef void _insert_short_at_start(self, unsigned int value)
 
-    cdef _replace_short(self, object index, object value)
+    cdef _replace_short(self, cython.uint index, cython.uint value)
+
+    cdef _get_short(self, cython.uint value)
 
     cdef _write_int(self, object value)
 
@@ -61,10 +64,12 @@ cdef class DNSOutgoing:
     @cython.locals(
         d=cython.bytes,
         data_view=cython.list,
+        index=cython.uint,
         length=cython.uint
     )
     cdef cython.bint _write_record(self, DNSRecord record, object now)
 
+    @cython.locals(class_=cython.uint)
     cdef _write_record_class(self, DNSEntry record)
 
     @cython.locals(
@@ -72,13 +77,16 @@ cdef class DNSOutgoing:
     )
     cdef cython.bint _check_data_limit_or_rollback(self, cython.uint start_data_length, cython.uint start_size)
 
-    cdef _write_questions_from_offset(self, object questions_offset)
+    @cython.locals(questions_written=cython.uint)
+    cdef cython.uint _write_questions_from_offset(self, unsigned int questions_offset)
 
-    cdef _write_answers_from_offset(self, object answer_offset)
+    @cython.locals(answers_written=cython.uint)
+    cdef cython.uint _write_answers_from_offset(self, unsigned int answer_offset)
 
-    cdef _write_records_from_offset(self, cython.list records, object offset)
+    @cython.locals(records_written=cython.uint)
+    cdef cython.uint _write_records_from_offset(self, cython.list records, unsigned int offset)
 
-    cdef bint _has_more_to_add(self, object questions_offset, object answer_offset, object authority_offset, object additional_offset)
+    cdef bint _has_more_to_add(self, unsigned int questions_offset, unsigned int answer_offset, unsigned int authority_offset, unsigned int additional_offset)
 
     cdef _write_ttl(self, DNSRecord record, object now)
 
@@ -93,7 +101,7 @@ cdef class DNSOutgoing:
 
     cdef _write_link_to_name(self, unsigned int index)
 
-    cpdef write_short(self, object value)
+    cpdef write_short(self, cython.uint value)
 
     cpdef write_string(self, cython.bytes value)
 
@@ -103,14 +111,14 @@ cdef class DNSOutgoing:
         debug_enable=bint,
         made_progress=bint,
         has_more_to_add=bint,
-        questions_offset=object,
-        answer_offset=object,
-        authority_offset=object,
-        additional_offset=object,
-        questions_written=object,
-        answers_written=object,
-        authorities_written=object,
-        additionals_written=object,
+        questions_offset="unsigned int",
+        answer_offset="unsigned int",
+        authority_offset="unsigned int",
+        additional_offset="unsigned int",
+        questions_written="unsigned int",
+        answers_written="unsigned int",
+        authorities_written="unsigned int",
+        additionals_written="unsigned int",
     )
     cpdef packets(self)
 

--- a/src/zeroconf/_protocol/outgoing.py
+++ b/src/zeroconf/_protocol/outgoing.py
@@ -22,9 +22,8 @@
 
 import enum
 import logging
-from collections.abc import Sequence
 from struct import Struct
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Tuple, Union
 
 from .._cache import DNSCache
 from .._dns import DNSPointer, DNSQuestion, DNSRecord

--- a/src/zeroconf/_protocol/outgoing.py
+++ b/src/zeroconf/_protocol/outgoing.py
@@ -425,7 +425,7 @@ class DNSOutgoing:
         authority_offset = 0
         additional_offset = 0
         # we have to at least write out the question
-        debug_enable = LOGGING_IS_ENABLED_FOR(LOGGING_DEBUG)
+        debug_enable = LOGGING_IS_ENABLED_FOR(LOGGING_DEBUG) is True
         has_more_to_add = True
 
         while has_more_to_add:

--- a/src/zeroconf/_protocol/outgoing.py
+++ b/src/zeroconf/_protocol/outgoing.py
@@ -53,8 +53,10 @@ PACK_BYTE = Struct('>B').pack
 PACK_SHORT = Struct('>H').pack
 PACK_LONG = Struct('>L').pack
 
+SHORT_CACHE_MAX = 128
+
 BYTE_TABLE = tuple(PACK_BYTE(i) for i in range(256))
-SHORT_LOOKUP = tuple(PACK_SHORT(i) for i in range(32))
+SHORT_LOOKUP = tuple(PACK_SHORT(i) for i in range(SHORT_CACHE_MAX))
 
 
 class State(enum.Enum):
@@ -223,7 +225,7 @@ class DNSOutgoing:
 
     def _get_short(self, value: int_) -> bytes:
         """Gets an unsigned short from a certain position in the packet"""
-        if value < 32:
+        if value < SHORT_CACHE_MAX:
             return SHORT_LOOKUP[value]
         return PACK_SHORT(value)
 

--- a/src/zeroconf/_protocol/outgoing.py
+++ b/src/zeroconf/_protocol/outgoing.py
@@ -224,10 +224,8 @@ class DNSOutgoing:
         self.size += 1
 
     def _get_short(self, value: int_) -> bytes:
-        """Gets an unsigned short from a certain position in the packet"""
-        if value < SHORT_CACHE_MAX:
-            return SHORT_LOOKUP[value]
-        return PACK_SHORT(value)
+        """Convert an unsigned short to 2 bytes."""
+        return SHORT_LOOKUP[value] if value < SHORT_CACHE_MAX else PACK_SHORT(value)
 
     def _insert_short_at_start(self, value: int_) -> None:
         """Inserts an unsigned short at the start of the packet"""


### PR DESCRIPTION
- refactor the loop to only call `_has_more_to_add` once per loop when its a query
- add some more cython types
- cache common shorts

This is a ~22% speed up