### PR TITLE
feat: speed up incoming packet reader

### DIFF
--- a/src/zeroconf/_dns.py
+++ b/src/zeroconf/_dns.py
@@ -241,7 +241,6 @@ class DNSAddress(DNSRecord):
         class_: int,
         ttl: int,
         address: bytes,
-        *,
         scope_id: Optional[int] = None,
         created: Optional[float] = None,
     ) -> None:

--- a/src/zeroconf/_protocol/incoming.pxd
+++ b/src/zeroconf/_protocol/incoming.pxd
@@ -75,10 +75,10 @@ cdef class DNSIncoming:
     cpdef is_response(self)
 
     @cython.locals(offset="unsigned char")
-    cdef unsigned int _read_short(self)
+    cdef unsigned int _read_network_order_unsigned_short(self)
 
     @cython.locals(offset="unsigned char")
-    cdef unsigned int _read_long(self)
+    cdef unsigned int _read_network_order_unsigned_long(self)
 
     @cython.locals(
         off=cython.uint,

--- a/src/zeroconf/_protocol/incoming.pxd
+++ b/src/zeroconf/_protocol/incoming.pxd
@@ -74,10 +74,10 @@ cdef class DNSIncoming:
 
     cpdef is_response(self)
 
-    @cython.locals(offset="unsigned char")
+    @cython.locals(offset="unsigned int")
     cdef unsigned int _read_network_order_unsigned_short(self)
 
-    @cython.locals(offset="unsigned char")
+    @cython.locals(offset="unsigned int")
     cdef unsigned int _read_network_order_unsigned_long(self)
 
     @cython.locals(
@@ -116,9 +116,9 @@ cdef class DNSIncoming:
     cdef _read_record(self, object domain, unsigned int type_, object class_, object ttl, unsigned int length)
 
     @cython.locals(
-        offset="unsigned char",
-        offset_plus_one="unsigned char",
-        offset_plus_two="unsigned char",
+        offset="unsigned int",
+        offset_plus_one="unsigned int",
+        offset_plus_two="unsigned int",
         window=cython.uint,
         bit=cython.uint,
         byte=cython.uint,

--- a/src/zeroconf/_protocol/incoming.pxd
+++ b/src/zeroconf/_protocol/incoming.pxd
@@ -74,12 +74,6 @@ cdef class DNSIncoming:
 
     cpdef bint is_response(self)
 
-    @cython.locals(offset="unsigned int")
-    cdef unsigned int _read_network_order_unsigned_short(self)
-
-    @cython.locals(offset="unsigned int")
-    cdef unsigned int _read_network_order_unsigned_long(self)
-
     @cython.locals(
         off="unsigned int",
         label_idx="unsigned int",
@@ -91,16 +85,19 @@ cdef class DNSIncoming:
     )
     cdef unsigned int _decode_labels_at_offset(self, unsigned int off, cython.list labels, cython.set seen_pointers)
 
+    @cython.locals(offset="unsigned int")
     cdef _read_header(self)
 
     cdef _initial_parse(self)
 
     @cython.locals(
         end="unsigned int",
-        length="unsigned int"
+        length="unsigned int",
+        offset="unsigned int"
     )
     cdef _read_others(self)
 
+    @cython.locals(offset="unsigned int")
     cdef _read_questions(self)
 
     @cython.locals(
@@ -111,7 +108,8 @@ cdef class DNSIncoming:
     cdef bytes _read_string(self, unsigned int length)
 
     @cython.locals(
-        name_start="unsigned int"
+        name_start="unsigned int",
+        offset="unsigned int"
     )
     cdef _read_record(self, object domain, unsigned int type_, unsigned int class_, unsigned int ttl, unsigned int length)
 

--- a/src/zeroconf/_protocol/incoming.pxd
+++ b/src/zeroconf/_protocol/incoming.pxd
@@ -74,10 +74,10 @@ cdef class DNSIncoming:
 
     cpdef bint is_response(self)
 
-    @cython.locals(offset="unsigned int")
+    @cython.locals(offset="unsigned char")
     cdef unsigned int _read_network_order_unsigned_short(self)
 
-    @cython.locals(offset="unsigned int")
+    @cython.locals(offset="unsigned char")
     cdef unsigned int _read_network_order_unsigned_long(self)
 
     @cython.locals(
@@ -116,9 +116,9 @@ cdef class DNSIncoming:
     cdef _read_record(self, object domain, unsigned int type_, unsigned int class_, unsigned int ttl, unsigned int length)
 
     @cython.locals(
-        offset="unsigned int",
-        offset_plus_one="unsigned int",
-        offset_plus_two="unsigned int",
+        offset="unsigned char",
+        offset_plus_one="unsigned char",
+        offset_plus_two="unsigned char",
         window=cython.uint,
         bit=cython.uint,
         byte=cython.uint,

--- a/src/zeroconf/_protocol/incoming.pxd
+++ b/src/zeroconf/_protocol/incoming.pxd
@@ -113,7 +113,7 @@ cdef class DNSIncoming:
     @cython.locals(
         name_start=cython.uint
     )
-    cdef _read_record(self, object domain, unsigned int type_, object class_, object ttl, unsigned int length)
+    cdef _read_record(self, object domain, unsigned int type_, unsigned int class_, unsigned int ttl, unsigned int length)
 
     @cython.locals(
         offset="unsigned int",

--- a/src/zeroconf/_protocol/incoming.pxd
+++ b/src/zeroconf/_protocol/incoming.pxd
@@ -21,11 +21,6 @@ cdef cython.uint _FLAGS_TC
 cdef cython.uint _FLAGS_QR_QUERY
 cdef cython.uint _FLAGS_QR_RESPONSE
 
-cdef object UNPACK_3H
-cdef object UNPACK_6H
-cdef object UNPACK_HH
-cdef object UNPACK_HHiH
-
 cdef object DECODE_EXCEPTIONS
 
 cdef object IncomingDecodeError
@@ -78,6 +73,12 @@ cdef class DNSIncoming:
     cpdef answers(self)
 
     cpdef is_response(self)
+
+    @cython.locals(offset="unsigned char")
+    cdef unsigned int _read_short(self)
+
+    @cython.locals(offset="unsigned char")
+    cdef unsigned int _read_long(self)
 
     @cython.locals(
         off=cython.uint,

--- a/src/zeroconf/_protocol/incoming.pxd
+++ b/src/zeroconf/_protocol/incoming.pxd
@@ -74,56 +74,56 @@ cdef class DNSIncoming:
 
     cpdef bint is_response(self)
 
-    @cython.locals(offset="unsigned char")
+    @cython.locals(offset="unsigned int")
     cdef unsigned int _read_network_order_unsigned_short(self)
 
-    @cython.locals(offset="unsigned char")
+    @cython.locals(offset="unsigned int")
     cdef unsigned int _read_network_order_unsigned_long(self)
 
     @cython.locals(
-        off=cython.uint,
-        label_idx=cython.uint,
-        length=cython.uint,
-        link=cython.uint,
-        link_data=cython.uint,
+        off="unsigned int",
+        label_idx="unsigned int",
+        length="unsigned int",
+        link="unsigned int",
+        link_data="unsigned int",
         link_py_int=object,
         linked_labels=cython.list
     )
-    cdef cython.uint _decode_labels_at_offset(self, unsigned int off, cython.list labels, cython.set seen_pointers)
+    cdef unsigned int _decode_labels_at_offset(self, unsigned int off, cython.list labels, cython.set seen_pointers)
 
     cdef _read_header(self)
 
     cdef _initial_parse(self)
 
     @cython.locals(
-        end=cython.uint,
-        length=cython.uint
+        end="unsigned int",
+        length="unsigned int"
     )
     cdef _read_others(self)
 
     cdef _read_questions(self)
 
     @cython.locals(
-        length=cython.uint,
+        length="unsigned int",
     )
     cdef str _read_character_string(self)
 
     cdef bytes _read_string(self, unsigned int length)
 
     @cython.locals(
-        name_start=cython.uint
+        name_start="unsigned int"
     )
     cdef _read_record(self, object domain, unsigned int type_, unsigned int class_, unsigned int ttl, unsigned int length)
 
     @cython.locals(
-        offset="unsigned char",
-        offset_plus_one="unsigned char",
-        offset_plus_two="unsigned char",
-        window=cython.uint,
-        bit=cython.uint,
-        byte=cython.uint,
-        i=cython.uint,
-        bitmap_length=cython.uint,
+        offset="unsigned int",
+        offset_plus_one="unsigned int",
+        offset_plus_two="unsigned int",
+        window="unsigned int",
+        bit="unsigned int",
+        byte="unsigned int",
+        i="unsigned int",
+        bitmap_length="unsigned int",
     )
     cdef _read_bitmap(self, unsigned int end)
 

--- a/src/zeroconf/_protocol/incoming.pxd
+++ b/src/zeroconf/_protocol/incoming.pxd
@@ -116,9 +116,9 @@ cdef class DNSIncoming:
     cdef _read_record(self, object domain, unsigned int type_, object class_, object ttl, unsigned int length)
 
     @cython.locals(
-        offset=cython.uint,
-        offset_plus_one=cython.uint,
-        offset_plus_two=cython.uint,
+        offset="unsigned char",
+        offset_plus_one="unsigned char",
+        offset_plus_two="unsigned char",
         window=cython.uint,
         bit=cython.uint,
         byte=cython.uint,

--- a/src/zeroconf/_protocol/incoming.pxd
+++ b/src/zeroconf/_protocol/incoming.pxd
@@ -64,15 +64,15 @@ cdef class DNSIncoming:
     @cython.locals(
         question=DNSQuestion
     )
-    cpdef has_qu_question(self)
+    cpdef bint has_qu_question(self)
 
-    cpdef is_query(self)
+    cpdef bint is_query(self)
 
-    cpdef is_probe(self)
+    cpdef bint is_probe(self)
 
     cpdef answers(self)
 
-    cpdef is_response(self)
+    cpdef bint is_response(self)
 
     @cython.locals(offset="unsigned int")
     cdef unsigned int _read_network_order_unsigned_short(self)

--- a/src/zeroconf/_protocol/incoming.pxd
+++ b/src/zeroconf/_protocol/incoming.pxd
@@ -57,7 +57,6 @@ cdef class DNSIncoming:
     cdef public cython.uint num_additionals
     cdef public object valid
     cdef public object now
-    cdef cython.float _now_float
     cdef public object scope_id
     cdef public object source
 

--- a/src/zeroconf/_protocol/incoming.py
+++ b/src/zeroconf/_protocol/incoming.py
@@ -230,10 +230,10 @@ class DNSIncoming:
         # The header has 6 unsigned shorts in network order
         self.id = view[offset] << 8 | view[offset + 1]
         self.flags = view[offset + 2] << 8 | view[offset + 3]
-        self.num_questions = view[offset + 4] << 8 | view[offset + 5]
-        self.num_answers = view[offset + 6] << 8 | view[offset + 7]
-        self.num_authorities = view[offset + 8] << 8 | view[offset + 9]
-        self.num_additionals = view[offset + 10] << 8 | view[offset + 11]
+        self._num_questions = view[offset + 4] << 8 | view[offset + 5]
+        self._num_answers = view[offset + 6] << 8 | view[offset + 7]
+        self._num_authorities = view[offset + 8] << 8 | view[offset + 9]
+        self._num_additionals = view[offset + 10] << 8 | view[offset + 11]
 
     def _read_questions(self) -> None:
         """Reads questions section of packet"""

--- a/src/zeroconf/_protocol/incoming.py
+++ b/src/zeroconf/_protocol/incoming.py
@@ -101,7 +101,7 @@ class DNSIncoming:
         self.flags = 0
         self.offset = 0
         self.data = data
-        self.view = memoryview(data)
+        self.view = data
         self._data_len = len(data)
         self.name_cache: Dict[int, List[str]] = {}
         self.questions: List[DNSQuestion] = []

--- a/src/zeroconf/_protocol/incoming.py
+++ b/src/zeroconf/_protocol/incoming.py
@@ -345,12 +345,13 @@ class DNSIncoming:
     def _read_bitmap(self, end: _int) -> List[int]:
         """Reads an NSEC bitmap from the packet."""
         rdtypes = []
+        view = self.view
         while self.offset < end:
             offset = self.offset
             offset_plus_one = offset + 1
             offset_plus_two = offset + 2
-            window = self.view[offset]
-            bitmap_length = self.view[offset_plus_one]
+            window = view[offset]
+            bitmap_length = view[offset_plus_one]
             bitmap_end = offset_plus_two + bitmap_length
             for i, byte in enumerate(self.data[offset_plus_two:bitmap_end]):
                 for bit in range(0, 8):

--- a/src/zeroconf/_protocol/incoming.py
+++ b/src/zeroconf/_protocol/incoming.py
@@ -86,7 +86,6 @@ class DNSIncoming:
         'num_additionals',
         'valid',
         'now',
-        '_now_float',
         'scope_id',
         'source',
     )
@@ -115,7 +114,6 @@ class DNSIncoming:
         self.valid = False
         self._did_read_others = False
         self.now = now or current_time_millis()
-        self._now_float = self.now
         self.source = source
         self.scope_id = scope_id
         try:
@@ -284,9 +282,7 @@ class DNSIncoming:
     ) -> Optional[DNSRecord]:
         """Read known records types and skip unknown ones."""
         if type_ == _TYPE_A:
-            dns_address = DNSAddress(domain, type_, class_, ttl, self._read_string(4))
-            dns_address.created = self._now_float
-            return dns_address
+            return DNSAddress(domain, type_, class_, ttl, self._read_string(4), None, self.now)
         if type_ in (_TYPE_CNAME, _TYPE_PTR):
             return DNSPointer(domain, type_, class_, ttl, self._read_name(), self.now)
         if type_ == _TYPE_TXT:
@@ -321,10 +317,7 @@ class DNSIncoming:
                 self.now,
             )
         if type_ == _TYPE_AAAA:
-            dns_address = DNSAddress(domain, type_, class_, ttl, self._read_string(16))
-            dns_address.created = self._now_float
-            dns_address.scope_id = self.scope_id
-            return dns_address
+            return DNSAddress(domain, type_, class_, ttl, self._read_string(16), self.scope_id, self.now)
         if type_ == _TYPE_NSEC:
             name_start = self.offset
             return DNSNsec(

--- a/src/zeroconf/_protocol/incoming.py
+++ b/src/zeroconf/_protocol/incoming.py
@@ -369,8 +369,9 @@ class DNSIncoming:
 
     def _decode_labels_at_offset(self, off: _int, labels: List[str], seen_pointers: Set[int]) -> int:
         # This is a tight loop that is called frequently, small optimizations can make a difference.
+        view = self.view
         while off < self._data_len:
-            length = self.view[off]
+            length = view[off]
             if length == 0:
                 return off + DNS_COMPRESSION_HEADER_LEN
 
@@ -386,7 +387,7 @@ class DNSIncoming:
                 )
 
             # We have a DNS compression pointer
-            link_data = self.view[off + 1]
+            link_data = view[off + 1]
             link = (length & 0x3F) * 256 + link_data
             link_py_int = link
             if link > self._data_len:

--- a/src/zeroconf/_protocol/incoming.py
+++ b/src/zeroconf/_protocol/incoming.py
@@ -102,7 +102,7 @@ class DNSIncoming:
         self.flags = 0
         self.offset = 0
         self.data = data
-        self.view = data
+        self.view = memoryview(data)
         self._data_len = len(data)
         self.name_cache: Dict[int, List[str]] = {}
         self.questions: List[DNSQuestion] = []
@@ -142,7 +142,7 @@ class DNSIncoming:
             return False
         for question in self.questions:
             # QU questions use the same bit as unique
-            if question.unique:
+            if question.unique is True:
                 return True
         return False
 


### PR DESCRIPTION
This is ~14% speed up

before: Parsing 100000 incoming messages took 2.3616396670695394 seconds
after: Parsing 100000 incoming messages took 2.012439667014405 seconds

