### PR TITLE
feat: small speed up to processing incoming dns records

### DIFF
--- a/src/zeroconf/_cache.pxd
+++ b/src/zeroconf/_cache.pxd
@@ -24,7 +24,7 @@ cdef class DNSCache:
     cdef public cython.dict cache
     cdef public cython.dict service_cache
 
-    cpdef async_add_records(self, object entries)
+    cpdef bint async_add_records(self, object entries)
 
     cpdef async_remove_records(self, object entries)
 

--- a/src/zeroconf/_dns.pxd
+++ b/src/zeroconf/_dns.pxd
@@ -80,8 +80,8 @@ cdef class DNSAddress(DNSRecord):
 cdef class DNSHinfo(DNSRecord):
 
     cdef public cython.int _hash
-    cdef public object cpu
-    cdef public object os
+    cdef public str cpu
+    cdef public str os
 
     cdef bint _eq(self, DNSHinfo other)
 

--- a/src/zeroconf/_dns.pxd
+++ b/src/zeroconf/_dns.pxd
@@ -135,7 +135,7 @@ cdef class DNSRRSet:
     cdef cython.dict _lookup
 
     @cython.locals(other=DNSRecord)
-    cpdef suppresses(self, DNSRecord record)
+    cpdef bint suppresses(self, DNSRecord record)
 
     @cython.locals(
         record=DNSRecord,

--- a/src/zeroconf/_dns.pxd
+++ b/src/zeroconf/_dns.pxd
@@ -28,7 +28,7 @@ cdef class DNSEntry:
     cdef public str name
     cdef public cython.uint type
     cdef public cython.uint class_
-    cdef public cython.uint unique
+    cdef public bint unique
 
     cdef _set_class(self, cython.uint class_)
 

--- a/src/zeroconf/_dns.pxd
+++ b/src/zeroconf/_dns.pxd
@@ -4,19 +4,21 @@ import cython
 from ._protocol.outgoing cimport DNSOutgoing
 
 
-cdef object _LEN_BYTE
-cdef object _LEN_SHORT
-cdef object _LEN_INT
+cdef cython.uint _LEN_BYTE
+cdef cython.uint _LEN_SHORT
+cdef cython.uint _LEN_INT
 
-cdef object _NAME_COMPRESSION_MIN_SIZE
-cdef object _BASE_MAX_SIZE
+cdef cython.uint _NAME_COMPRESSION_MIN_SIZE
+cdef cython.uint _BASE_MAX_SIZE
 
 cdef cython.uint _EXPIRE_FULL_TIME_MS
 cdef cython.uint _EXPIRE_STALE_TIME_MS
 cdef cython.uint _RECENT_TIME_MS
 
-cdef object _CLASS_UNIQUE
-cdef object _CLASS_MASK
+cdef cython.uint _TYPE_ANY
+
+cdef cython.uint _CLASS_UNIQUE
+cdef cython.uint _CLASS_MASK
 
 cdef object current_time_millis
 
@@ -25,10 +27,12 @@ cdef class DNSEntry:
     cdef public str key
     cdef public str name
     cdef public cython.uint type
-    cdef public object class_
-    cdef public object unique
+    cdef public cython.uint class_
+    cdef public cython.uint unique
 
-    cdef _dns_entry_matches(self, DNSEntry other)
+    cdef _set_class(self, cython.uint class_)
+
+    cdef bint _dns_entry_matches(self, DNSEntry other)
 
 cdef class DNSQuestion(DNSEntry):
 
@@ -68,7 +72,7 @@ cdef class DNSAddress(DNSRecord):
     cdef public object address
     cdef public object scope_id
 
-    cdef _eq(self, DNSAddress other)
+    cdef bint _eq(self, DNSAddress other)
 
     cpdef write(self, DNSOutgoing out)
 
@@ -79,7 +83,7 @@ cdef class DNSHinfo(DNSRecord):
     cdef public object cpu
     cdef public object os
 
-    cdef _eq(self, DNSHinfo other)
+    cdef bint _eq(self, DNSHinfo other)
 
     cpdef write(self, DNSOutgoing out)
 
@@ -89,7 +93,7 @@ cdef class DNSPointer(DNSRecord):
     cdef public str alias
     cdef public str alias_key
 
-    cdef _eq(self, DNSPointer other)
+    cdef bint _eq(self, DNSPointer other)
 
     cpdef write(self, DNSOutgoing out)
 
@@ -98,7 +102,7 @@ cdef class DNSText(DNSRecord):
     cdef public cython.int _hash
     cdef public object text
 
-    cdef _eq(self, DNSText other)
+    cdef bint _eq(self, DNSText other)
 
     cpdef write(self, DNSOutgoing out)
 
@@ -111,7 +115,7 @@ cdef class DNSService(DNSRecord):
     cdef public str server
     cdef public str server_key
 
-    cdef _eq(self, DNSService other)
+    cdef bint _eq(self, DNSService other)
 
     cpdef write(self, DNSOutgoing out)
 
@@ -121,7 +125,7 @@ cdef class DNSNsec(DNSRecord):
     cdef public object next_name
     cdef public cython.list rdtypes
 
-    cdef _eq(self, DNSNsec other)
+    cdef bint _eq(self, DNSNsec other)
 
     cpdef write(self, DNSOutgoing out)
 

--- a/src/zeroconf/_dns.pxd
+++ b/src/zeroconf/_dns.pxd
@@ -100,7 +100,7 @@ cdef class DNSPointer(DNSRecord):
 cdef class DNSText(DNSRecord):
 
     cdef public cython.int _hash
-    cdef public object text
+    cdef public bytes text
 
     cdef bint _eq(self, DNSText other)
 
@@ -109,9 +109,9 @@ cdef class DNSText(DNSRecord):
 cdef class DNSService(DNSRecord):
 
     cdef public cython.int _hash
-    cdef public object priority
-    cdef public object weight
-    cdef public object port
+    cdef public cython.uint priority
+    cdef public cython.uint weight
+    cdef public cython.uint port
     cdef public str server
     cdef public str server_key
 

--- a/src/zeroconf/_dns.pxd
+++ b/src/zeroconf/_dns.pxd
@@ -39,22 +39,22 @@ cdef class DNSRecord(DNSEntry):
     cdef public cython.float ttl
     cdef public cython.float created
 
-    cdef _suppressed_by_answer(self, DNSRecord answer)
+    cdef bint _suppressed_by_answer(self, DNSRecord answer)
 
     @cython.locals(
         answers=cython.list,
     )
-    cpdef suppressed_by(self, object msg)
+    cpdef bint suppressed_by(self, object msg)
 
     cpdef get_remaining_ttl(self, cython.float now)
 
     cpdef get_expiration_time(self, cython.uint percent)
 
-    cpdef is_expired(self, cython.float now)
+    cpdef bint is_expired(self, cython.float now)
 
-    cpdef is_stale(self, cython.float now)
+    cpdef bint is_stale(self, cython.float now)
 
-    cpdef is_recent(self, cython.float now)
+    cpdef bint is_recent(self, cython.float now)
 
     cpdef reset_ttl(self, DNSRecord other)
 

--- a/src/zeroconf/_dns.pxd
+++ b/src/zeroconf/_dns.pxd
@@ -34,6 +34,8 @@ cdef class DNSQuestion(DNSEntry):
 
     cdef public cython.int _hash
 
+    cpdef bint answered_by(self, DNSRecord rec)
+
 cdef class DNSRecord(DNSEntry):
 
     cdef public cython.float ttl

--- a/src/zeroconf/_dns.py
+++ b/src/zeroconf/_dns.py
@@ -139,7 +139,7 @@ class DNSQuestion(DNSEntry):
         unique shares the same mask as the one
         used for unicast.
         """
-        return self.unique
+        return bool(self.unique)
 
     @unicast.setter
     def unicast(self, value: bool) -> None:

--- a/src/zeroconf/_dns.py
+++ b/src/zeroconf/_dns.py
@@ -114,7 +114,7 @@ class DNSQuestion(DNSEntry):
 
     def __init__(self, name: str, type_: int, class_: int) -> None:
         super().__init__(name, type_, class_)
-        self._hash = hash((self.key, type_, class_))
+        self._hash = hash((self.key, type_, self.class_))
 
     def answered_by(self, rec: 'DNSRecord') -> bool:
         """Returns true if the question is answered by the record"""
@@ -251,7 +251,7 @@ class DNSAddress(DNSRecord):
         super().__init__(name, type_, class_, ttl, created)
         self.address = address
         self.scope_id = scope_id
-        self._hash = hash((self.key, type_, class_, address, scope_id))
+        self._hash = hash((self.key, type_, self.class_, address, scope_id))
 
     def write(self, out: 'DNSOutgoing') -> None:
         """Used in constructing an outgoing packet"""
@@ -296,7 +296,7 @@ class DNSHinfo(DNSRecord):
         super().__init__(name, type_, class_, ttl, created)
         self.cpu = cpu
         self.os = os
-        self._hash = hash((self.key, type_, class_, cpu, os))
+        self._hash = hash((self.key, type_, self.class_, cpu, os))
 
     def write(self, out: 'DNSOutgoing') -> None:
         """Used in constructing an outgoing packet"""
@@ -332,7 +332,7 @@ class DNSPointer(DNSRecord):
         super().__init__(name, type_, class_, ttl, created)
         self.alias = alias
         self.alias_key = alias.lower()
-        self._hash = hash((self.key, type_, class_, self.alias_key))
+        self._hash = hash((self.key, type_, self.class_, self.alias_key))
 
     @property
     def max_size_compressed(self) -> int:
@@ -376,7 +376,7 @@ class DNSText(DNSRecord):
     ) -> None:
         super().__init__(name, type_, class_, ttl, created)
         self.text = text
-        self._hash = hash((self.key, type_, class_, text))
+        self._hash = hash((self.key, type_, self.class_, text))
 
     def write(self, out: 'DNSOutgoing') -> None:
         """Used in constructing an outgoing packet"""
@@ -425,7 +425,7 @@ class DNSService(DNSRecord):
         self.port = port
         self.server = server
         self.server_key = server.lower()
-        self._hash = hash((self.key, type_, class_, priority, weight, port, self.server_key))
+        self._hash = hash((self.key, type_, self.class_, priority, weight, port, self.server_key))
 
     def write(self, out: 'DNSOutgoing') -> None:
         """Used in constructing an outgoing packet"""
@@ -476,7 +476,7 @@ class DNSNsec(DNSRecord):
         super().__init__(name, type_, class_, ttl, created)
         self.next_name = next_name
         self.rdtypes = sorted(rdtypes)
-        self._hash = hash((self.key, type_, class_, next_name, *self.rdtypes))
+        self._hash = hash((self.key, type_, self.class_, next_name, *self.rdtypes))
 
     def write(self, out: 'DNSOutgoing') -> None:
         """Used in constructing an outgoing packet."""

--- a/src/zeroconf/_dns.py
+++ b/src/zeroconf/_dns.py
@@ -67,10 +67,13 @@ class DNSEntry:
 
     __slots__ = ('key', 'name', 'type', 'class_', 'unique')
 
-    def __init__(self, name: str, type_: _int, class_: _int) -> None:
+    def __init__(self, name: str, type_: int, class_: int) -> None:
         self.name = name
         self.key = name.lower()
         self.type = type_
+        self._set_class(class_)
+
+    def _set_class(self, class_: _int) -> None:
         self.class_ = class_ & _CLASS_MASK
         self.unique = (class_ & _CLASS_UNIQUE) != 0
 

--- a/src/zeroconf/_dns.py
+++ b/src/zeroconf/_dns.py
@@ -139,7 +139,7 @@ class DNSQuestion(DNSEntry):
         unique shares the same mask as the one
         used for unicast.
         """
-        return bool(self.unique)
+        return self.unique
 
     @unicast.setter
     def unicast(self, value: bool) -> None:

--- a/src/zeroconf/_dns.py
+++ b/src/zeroconf/_dns.py
@@ -114,7 +114,7 @@ class DNSQuestion(DNSEntry):
 
     def __init__(self, name: str, type_: int, class_: int) -> None:
         super().__init__(name, type_, class_)
-        self._hash = hash((self.key, type_, self.class_))
+        self._hash = hash((self.key, type_, class_))
 
     def answered_by(self, rec: 'DNSRecord') -> bool:
         """Returns true if the question is answered by the record"""
@@ -251,7 +251,7 @@ class DNSAddress(DNSRecord):
         super().__init__(name, type_, class_, ttl, created)
         self.address = address
         self.scope_id = scope_id
-        self._hash = hash((self.key, type_, self.class_, address, scope_id))
+        self._hash = hash((self.key, type_, class_, address, scope_id))
 
     def write(self, out: 'DNSOutgoing') -> None:
         """Used in constructing an outgoing packet"""
@@ -296,7 +296,7 @@ class DNSHinfo(DNSRecord):
         super().__init__(name, type_, class_, ttl, created)
         self.cpu = cpu
         self.os = os
-        self._hash = hash((self.key, type_, self.class_, cpu, os))
+        self._hash = hash((self.key, type_, class_, cpu, os))
 
     def write(self, out: 'DNSOutgoing') -> None:
         """Used in constructing an outgoing packet"""
@@ -332,7 +332,7 @@ class DNSPointer(DNSRecord):
         super().__init__(name, type_, class_, ttl, created)
         self.alias = alias
         self.alias_key = alias.lower()
-        self._hash = hash((self.key, type_, self.class_, self.alias_key))
+        self._hash = hash((self.key, type_, class_, self.alias_key))
 
     @property
     def max_size_compressed(self) -> int:
@@ -376,7 +376,7 @@ class DNSText(DNSRecord):
     ) -> None:
         super().__init__(name, type_, class_, ttl, created)
         self.text = text
-        self._hash = hash((self.key, type_, self.class_, text))
+        self._hash = hash((self.key, type_, class_, text))
 
     def write(self, out: 'DNSOutgoing') -> None:
         """Used in constructing an outgoing packet"""
@@ -425,7 +425,7 @@ class DNSService(DNSRecord):
         self.port = port
         self.server = server
         self.server_key = server.lower()
-        self._hash = hash((self.key, type_, self.class_, priority, weight, port, self.server_key))
+        self._hash = hash((self.key, type_, class_, priority, weight, port, self.server_key))
 
     def write(self, out: 'DNSOutgoing') -> None:
         """Used in constructing an outgoing packet"""
@@ -476,7 +476,7 @@ class DNSNsec(DNSRecord):
         super().__init__(name, type_, class_, ttl, created)
         self.next_name = next_name
         self.rdtypes = sorted(rdtypes)
-        self._hash = hash((self.key, type_, self.class_, next_name, *self.rdtypes))
+        self._hash = hash((self.key, type_, class_, next_name, *self.rdtypes))
 
     def write(self, out: 'DNSOutgoing') -> None:
         """Used in constructing an outgoing packet."""

--- a/src/zeroconf/_dns.py
+++ b/src/zeroconf/_dns.py
@@ -374,7 +374,6 @@ class DNSText(DNSRecord):
     def __init__(
         self, name: str, type_: int, class_: int, ttl: int, text: bytes, created: Optional[float] = None
     ) -> None:
-        assert isinstance(text, (bytes, type(None)))
         super().__init__(name, type_, class_, ttl, created)
         self.text = text
         self._hash = hash((self.key, type_, self.class_, text))

--- a/src/zeroconf/_handlers/query_handler.py
+++ b/src/zeroconf/_handlers/query_handler.py
@@ -202,7 +202,7 @@ class QueryHandler:
             dns_pointer = DNSPointer(
                 _SERVICE_TYPE_ENUMERATION_NAME, _TYPE_PTR, _CLASS_IN, _DNS_OTHER_TTL, stype, 0.0
             )
-            if known_answers.suppresses(dns_pointer):
+            if not known_answers.suppresses(dns_pointer):
                 answer_set[dns_pointer] = set()
 
     def _add_pointer_answers(
@@ -237,7 +237,7 @@ class QueryHandler:
                 seen_types.add(dns_address.type)
                 if dns_address.type != type_:
                     additionals.add(dns_address)
-                elif known_answers.suppresses(dns_address):
+                elif not known_answers.suppresses(dns_address):
                     answers.append(dns_address)
             missing_types: Set[int] = _ADDRESS_RECORD_TYPES - seen_types
             if answers:
@@ -272,7 +272,7 @@ class QueryHandler:
             # https://tools.ietf.org/html/rfc6763#section-12.2.
             service = services[0]
             dns_service = service._dns_service(None)
-            if known_answers.suppresses(dns_service):
+            if not known_answers.suppresses(dns_service):
                 answer_set[dns_service] = service._get_address_and_nsec_records(None)
         elif strategy_type == _ANSWER_STRATEGY_TEXT:  # pragma: no branch
             service = services[0]

--- a/src/zeroconf/_handlers/query_handler.py
+++ b/src/zeroconf/_handlers/query_handler.py
@@ -277,7 +277,7 @@ class QueryHandler:
         elif strategy_type == _ANSWER_STRATEGY_TEXT:  # pragma: no branch
             service = services[0]
             dns_text = service._dns_text(None)
-            if known_answers.suppresses(dns_text):
+            if not known_answers.suppresses(dns_text):
                 answer_set[dns_text] = set()
 
         return answer_set

--- a/src/zeroconf/_handlers/query_handler.py
+++ b/src/zeroconf/_handlers/query_handler.py
@@ -167,7 +167,7 @@ class _QueryResponse:
         if TYPE_CHECKING:
             record = cast(_UniqueRecordsType, record)
         maybe_entry = self._cache.async_get_unique(record)
-        return bool(maybe_entry is not None and maybe_entry.is_recent(self._now) is True)
+        return bool(maybe_entry is not None and maybe_entry.is_recent(self._now))
 
     def _has_mcast_record_in_last_second(self, record: DNSRecord) -> bool:
         """Check if an answer was seen in the last second.
@@ -202,7 +202,7 @@ class QueryHandler:
             dns_pointer = DNSPointer(
                 _SERVICE_TYPE_ENUMERATION_NAME, _TYPE_PTR, _CLASS_IN, _DNS_OTHER_TTL, stype, 0.0
             )
-            if known_answers.suppresses(dns_pointer) is False:
+            if known_answers.suppresses(dns_pointer):
                 answer_set[dns_pointer] = set()
 
     def _add_pointer_answers(
@@ -213,7 +213,7 @@ class QueryHandler:
             # Add recommended additional answers according to
             # https://tools.ietf.org/html/rfc6763#section-12.1.
             dns_pointer = service._dns_pointer(None)
-            if known_answers.suppresses(dns_pointer) is True:
+            if known_answers.suppresses(dns_pointer):
                 continue
             answer_set[dns_pointer] = {
                 service._dns_service(None),
@@ -237,7 +237,7 @@ class QueryHandler:
                 seen_types.add(dns_address.type)
                 if dns_address.type != type_:
                     additionals.add(dns_address)
-                elif known_answers.suppresses(dns_address) is False:
+                elif known_answers.suppresses(dns_address):
                     answers.append(dns_address)
             missing_types: Set[int] = _ADDRESS_RECORD_TYPES - seen_types
             if answers:
@@ -272,12 +272,12 @@ class QueryHandler:
             # https://tools.ietf.org/html/rfc6763#section-12.2.
             service = services[0]
             dns_service = service._dns_service(None)
-            if known_answers.suppresses(dns_service) is False:
+            if known_answers.suppresses(dns_service):
                 answer_set[dns_service] = service._get_address_and_nsec_records(None)
         elif strategy_type == _ANSWER_STRATEGY_TEXT:  # pragma: no branch
             service = services[0]
             dns_text = service._dns_text(None)
-            if known_answers.suppresses(dns_text) is False:
+            if known_answers.suppresses(dns_text):
                 answer_set[dns_text] = set()
 
         return answer_set
@@ -307,7 +307,7 @@ class QueryHandler:
         # at least one answer strategy
         answers: List[DNSRecord] = []
         for msg in msgs:
-            if msg.is_probe() is True:
+            if msg.is_probe():
                 is_probe = True
             else:
                 answers.extend(msg.answers())
@@ -319,7 +319,7 @@ class QueryHandler:
         now = msg.now
         for strategy in strategies:
             question = strategy.question
-            is_unicast = question.unique is True  # unique and unicast are the same flag
+            is_unicast = question.unique  # unique and unicast are the same flag
             if not is_unicast:
                 if known_answers_set is None:  # pragma: no branch
                     known_answers_set = known_answers.lookup_set()

--- a/src/zeroconf/_handlers/record_manager.py
+++ b/src/zeroconf/_handlers/record_manager.py
@@ -113,7 +113,7 @@ class RecordManager:
                 record = cast(_UniqueRecordsType, record)
 
             maybe_entry = cache.async_get_unique(record)
-            if record.is_expired(now_float) is False:
+            if record.is_expired(now_float):
                 if maybe_entry is not None:
                     maybe_entry.reset_ttl(record)
                 else:

--- a/src/zeroconf/_handlers/record_manager.py
+++ b/src/zeroconf/_handlers/record_manager.py
@@ -106,7 +106,7 @@ class RecordManager:
                 )
                 record.set_created_ttl(record.created, _DNS_PTR_MIN_TTL)
 
-            if record.unique is True:  # https://tools.ietf.org/html/rfc6762#section-10.2
+            if record.unique:  # https://tools.ietf.org/html/rfc6762#section-10.2
                 unique_types.add((record.name, record_type, record.class_))
 
             if TYPE_CHECKING:
@@ -151,7 +151,7 @@ class RecordManager:
         new = False
         if other_adds or address_adds:
             new = cache.async_add_records(address_adds)
-            if cache.async_add_records(other_adds) is True:
+            if cache.async_add_records(other_adds):
                 new = True
         # Removes are processed last since
         # ServiceInfo could generate an un-needed query

--- a/src/zeroconf/_handlers/record_manager.py
+++ b/src/zeroconf/_handlers/record_manager.py
@@ -113,7 +113,7 @@ class RecordManager:
                 record = cast(_UniqueRecordsType, record)
 
             maybe_entry = cache.async_get_unique(record)
-            if record.is_expired(now_float):
+            if not record.is_expired(now_float):
                 if maybe_entry is not None:
                     maybe_entry.reset_ttl(record)
                 else:

--- a/src/zeroconf/_history.pxd
+++ b/src/zeroconf/_history.pxd
@@ -12,7 +12,7 @@ cdef class QuestionHistory:
     cpdef add_question_at_time(self, DNSQuestion question, float now, cython.set known_answers)
 
     @cython.locals(than=cython.double, previous_question=cython.tuple, previous_known_answers=cython.set)
-    cpdef suppresses(self, DNSQuestion question, cython.double now, cython.set known_answers)
+    cpdef bint suppresses(self, DNSQuestion question, cython.double now, cython.set known_answers)
 
     @cython.locals(than=cython.double, now_known_answers=cython.tuple)
     cpdef async_expire(self, cython.double now)

--- a/src/zeroconf/_listener.py
+++ b/src/zeroconf/_listener.py
@@ -113,7 +113,7 @@ class AsyncListener:
             self.data == data
             and (now - _DUPLICATE_PACKET_SUPPRESSION_INTERVAL) < self.last_time
             and self.last_message is not None
-            and self.last_message.has_qu_question()
+            and not self.last_message.has_qu_question()
         ):
             # Guard against duplicate packets
             if debug:
@@ -169,7 +169,7 @@ class AsyncListener:
                 )
             return
 
-        if msg.is_query():
+        if not msg.is_query():
             self._record_manager.async_updates_from_response(msg)
             return
 

--- a/src/zeroconf/_listener.py
+++ b/src/zeroconf/_listener.py
@@ -113,7 +113,7 @@ class AsyncListener:
             self.data == data
             and (now - _DUPLICATE_PACKET_SUPPRESSION_INTERVAL) < self.last_time
             and self.last_message is not None
-            and self.last_message.has_qu_question() is False
+            and self.last_message.has_qu_question()
         ):
             # Guard against duplicate packets
             if debug:
@@ -169,7 +169,7 @@ class AsyncListener:
                 )
             return
 
-        if msg.is_query() is False:
+        if msg.is_query():
             self._record_manager.async_updates_from_response(msg)
             return
 

--- a/src/zeroconf/_protocol/incoming.pxd
+++ b/src/zeroconf/_protocol/incoming.pxd
@@ -53,7 +53,7 @@ cdef class DNSIncoming:
     cdef const unsigned char [:] view
     cdef unsigned int _data_len
     cdef cython.dict _name_cache
-    cdef public cython.list questions
+    cdef cython.list _questions
     cdef cython.list _answers
     cdef public cython.uint id
     cdef cython.uint _num_questions

--- a/src/zeroconf/_protocol/incoming.pxd
+++ b/src/zeroconf/_protocol/incoming.pxd
@@ -69,15 +69,15 @@ cdef class DNSIncoming:
     @cython.locals(
         question=DNSQuestion
     )
-    cpdef has_qu_question(self)
+    cpdef bint has_qu_question(self)
 
-    cpdef is_query(self)
+    cpdef bint is_query(self)
 
-    cpdef is_probe(self)
+    cpdef bint is_probe(self)
 
     cpdef answers(self)
 
-    cpdef is_response(self)
+    cpdef bint is_response(self)
 
     @cython.locals(
         off=cython.uint,

--- a/src/zeroconf/_protocol/incoming.pxd
+++ b/src/zeroconf/_protocol/incoming.pxd
@@ -65,7 +65,7 @@ cdef class DNSIncoming:
     cdef cython.float _now_float
     cdef public object scope_id
     cdef public object source
-    cdef public bint _has_qu_question
+    cdef bint _has_qu_question
 
     @cython.locals(
         question=DNSQuestion

--- a/src/zeroconf/_protocol/incoming.pxd
+++ b/src/zeroconf/_protocol/incoming.pxd
@@ -55,12 +55,12 @@ cdef class DNSIncoming:
     cdef public cython.dict name_cache
     cdef public cython.list questions
     cdef cython.list _answers
-    cdef public object id
+    cdef public cython.uint id
     cdef public cython.uint num_questions
     cdef public cython.uint num_answers
     cdef public cython.uint num_authorities
     cdef public cython.uint num_additionals
-    cdef public object valid
+    cdef public bint valid
     cdef public object now
     cdef cython.float _now_float
     cdef public object scope_id

--- a/src/zeroconf/_protocol/incoming.pxd
+++ b/src/zeroconf/_protocol/incoming.pxd
@@ -52,14 +52,14 @@ cdef class DNSIncoming:
     cdef public bytes data
     cdef const unsigned char [:] view
     cdef unsigned int _data_len
-    cdef public cython.dict name_cache
+    cdef cython.dict _name_cache
     cdef public cython.list questions
     cdef cython.list _answers
     cdef public cython.uint id
-    cdef public cython.uint num_questions
-    cdef public cython.uint num_answers
-    cdef public cython.uint num_authorities
-    cdef public cython.uint num_additionals
+    cdef cython.uint _num_questions
+    cdef cython.uint _num_answers
+    cdef cython.uint _num_authorities
+    cdef cython.uint _num_additionals
     cdef public bint valid
     cdef public object now
     cdef cython.float _now_float

--- a/src/zeroconf/_protocol/incoming.pxd
+++ b/src/zeroconf/_protocol/incoming.pxd
@@ -65,6 +65,7 @@ cdef class DNSIncoming:
     cdef cython.float _now_float
     cdef public object scope_id
     cdef public object source
+    cdef public bint _has_qu_question
 
     @cython.locals(
         question=DNSQuestion

--- a/src/zeroconf/_protocol/incoming.py
+++ b/src/zeroconf/_protocol/incoming.py
@@ -222,7 +222,7 @@ class DNSIncoming:
             type_, class_ = UNPACK_HH(self.data, self.offset)
             self.offset += 4
             question = DNSQuestion(name, type_, class_)
-            if question.unique:
+            if question.unique:  # QU questions use the same bit as unique
                 self._has_qu_question = True
             self.questions.append(question)
 

--- a/src/zeroconf/_protocol/incoming.py
+++ b/src/zeroconf/_protocol/incoming.py
@@ -203,7 +203,7 @@ class DNSIncoming:
                 'n_ans=%s' % self._num_answers,
                 'n_auth=%s' % self._num_authorities,
                 'n_add=%s' % self._num_additionals,
-                'questions=%s' % self.questions,
+                'questions=%s' % self._questions,
                 'answers=%s' % self.answers(),
             ]
         )
@@ -222,6 +222,7 @@ class DNSIncoming:
 
     def _read_questions(self) -> None:
         """Reads questions section of packet"""
+        questions = self._questions
         for _ in range(self._num_questions):
             name = self._read_name()
             type_, class_ = UNPACK_HH(self.data, self.offset)
@@ -229,7 +230,7 @@ class DNSIncoming:
             question = DNSQuestion(name, type_, class_)
             if question.unique:  # QU questions use the same bit as unique
                 self._has_qu_question = True
-            self.questions.append(question)
+            questions.append(question)
 
     def _read_character_string(self) -> str:
         """Reads a character string from the packet"""

--- a/src/zeroconf/_protocol/incoming.py
+++ b/src/zeroconf/_protocol/incoming.py
@@ -93,6 +93,7 @@ class DNSIncoming:
         '_now_float',
         'scope_id',
         'source',
+        '_has_qu_question',
     )
 
     def __init__(
@@ -122,6 +123,7 @@ class DNSIncoming:
         self._now_float = self.now
         self.source = source
         self.scope_id = scope_id
+        self._has_qu_question = False
         try:
             self._initial_parse()
         except DECODE_EXCEPTIONS:
@@ -142,13 +144,7 @@ class DNSIncoming:
 
     def has_qu_question(self) -> bool:
         """Returns true if any question is a QU question."""
-        if not self.num_questions:
-            return False
-        for question in self.questions:
-            # QU questions use the same bit as unique
-            if question.unique:
-                return True
-        return False
+        return self._has_qu_question
 
     @property
     def truncated(self) -> bool:
@@ -226,6 +222,8 @@ class DNSIncoming:
             type_, class_ = UNPACK_HH(self.data, self.offset)
             self.offset += 4
             question = DNSQuestion(name, type_, class_)
+            if question.unique:
+                self._has_qu_question = True
             self.questions.append(question)
 
     def _read_character_string(self) -> str:

--- a/src/zeroconf/_protocol/incoming.py
+++ b/src/zeroconf/_protocol/incoming.py
@@ -156,6 +156,26 @@ class DNSIncoming:
         """Questions in the packet."""
         return self._questions
 
+    @property
+    def num_questions(self) -> int:
+        """Number of questions in the packet."""
+        return self._num_questions
+
+    @property
+    def num_answers(self) -> int:
+        """Number of answers in the packet."""
+        return self._num_answers
+
+    @property
+    def num_authorities(self) -> int:
+        """Number of authorities in the packet."""
+        return self._num_authorities
+
+    @property
+    def num_additionals(self) -> int:
+        """Number of additionals in the packet."""
+        return self._num_additionals
+
     def _initial_parse(self) -> None:
         """Parse the data needed to initalize the packet object."""
         self._read_header()

--- a/src/zeroconf/_protocol/incoming.py
+++ b/src/zeroconf/_protocol/incoming.py
@@ -81,7 +81,7 @@ class DNSIncoming:
         'view',
         '_data_len',
         '_name_cache',
-        'questions',
+        '_questions',
         '_answers',
         'id',
         '_num_questions',
@@ -110,7 +110,7 @@ class DNSIncoming:
         self.view = data
         self._data_len = len(data)
         self._name_cache: Dict[int, List[str]] = {}
-        self.questions: List[DNSQuestion] = []
+        self._questions: List[DNSQuestion] = []
         self._answers: List[DNSRecord] = []
         self.id = 0
         self._num_questions = 0
@@ -150,6 +150,11 @@ class DNSIncoming:
     def truncated(self) -> bool:
         """Returns true if this is a truncated."""
         return (self.flags & _FLAGS_TC) == _FLAGS_TC
+
+    @property
+    def questions(self) -> List[DNSQuestion]:
+        """Questions in the packet."""
+        return self._questions
 
     def _initial_parse(self) -> None:
         """Parse the data needed to initalize the packet object."""

--- a/src/zeroconf/_protocol/outgoing.py
+++ b/src/zeroconf/_protocol/outgoing.py
@@ -331,7 +331,7 @@ class DNSOutgoing:
     def _write_record_class(self, record: Union[DNSQuestion_, DNSRecord_]) -> None:
         """Write out the record class including the unique/unicast (QU) bit."""
         class_ = record.class_
-        if record.unique is True and self.multicast is True:
+        if record.unique is True and self.multicast:
             self.write_short(class_ | _CLASS_UNIQUE)
         else:
             self.write_short(class_)

--- a/src/zeroconf/_services/browser.pxd
+++ b/src/zeroconf/_services/browser.pxd
@@ -25,7 +25,7 @@ cdef class _DNSPointerOutgoingBucket:
 
     cpdef add(self, cython.uint max_compressed_size, DNSQuestion question, cython.set answers)
 
-@cython.locals(cache=DNSCache, question_history=QuestionHistory, record=DNSRecord)
+@cython.locals(cache=DNSCache, question_history=QuestionHistory, record=DNSRecord, qu_question=bint)
 cpdef generate_service_query(
     object zc,
     float now,

--- a/src/zeroconf/_services/browser.py
+++ b/src/zeroconf/_services/browser.py
@@ -185,7 +185,7 @@ def generate_service_query(
         else:
             pointer_known_answers = known_answers
         questions_with_known_answers[question] = pointer_known_answers
-        if qu_question is False:
+        if not qu_question:
             question_history.add_question_at_time(question, now, known_answers)
 
     return _group_ptr_queries_with_known_answers(now, multicast, questions_with_known_answers)

--- a/src/zeroconf/_services/browser.py
+++ b/src/zeroconf/_services/browser.py
@@ -175,7 +175,9 @@ def generate_service_query(
         question = DNSQuestion(type_, _TYPE_PTR, _CLASS_IN)
         question.unicast = qu_question
         known_answers = {
-            record for record in cache.get_all_by_details(type_, _TYPE_PTR, _CLASS_IN) if record.is_stale(now)
+            record
+            for record in cache.get_all_by_details(type_, _TYPE_PTR, _CLASS_IN)
+            if not record.is_stale(now)
         }
         if not qu_question and question_history.suppresses(question, now, known_answers):
             log.debug("Asking %s was suppressed by the question history", question)

--- a/src/zeroconf/_services/browser.py
+++ b/src/zeroconf/_services/browser.py
@@ -175,9 +175,7 @@ def generate_service_query(
         question = DNSQuestion(type_, _TYPE_PTR, _CLASS_IN)
         question.unicast = qu_question
         known_answers = {
-            record
-            for record in cache.get_all_by_details(type_, _TYPE_PTR, _CLASS_IN)
-            if record.is_stale(now) is False
+            record for record in cache.get_all_by_details(type_, _TYPE_PTR, _CLASS_IN) if record.is_stale(now)
         }
         if not qu_question and question_history.suppresses(question, now, known_answers):
             log.debug("Asking %s was suppressed by the question history", question)
@@ -440,7 +438,7 @@ class _ServiceBrowserBase(RecordUpdateListener):
                 continue
 
             # If its expired or already exists in the cache it cannot be updated.
-            if old_record is not None or record.is_expired(now) is True:
+            if old_record is not None or record.is_expired(now):
                 continue
 
             if record_type in _ADDRESS_RECORD_TYPES:

--- a/src/zeroconf/_services/info.pxd
+++ b/src/zeroconf/_services/info.pxd
@@ -61,7 +61,7 @@ cdef class ServiceInfo(RecordUpdateListener):
     cpdef async_update_records(self, object zc, cython.float now, cython.list records)
 
     @cython.locals(cache=DNSCache)
-    cpdef _load_from_cache(self, object zc, cython.float now)
+    cpdef bint _load_from_cache(self, object zc, cython.float now)
 
     cdef _unpack_text_into_properties(self)
 

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -779,7 +779,7 @@ class ServiceInfo(RecordUpdateListener):
 
         now = current_time_millis()
 
-        if self._load_from_cache(zc, now) is True:
+        if self._load_from_cache(zc, now):
             return True
 
         if TYPE_CHECKING:

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -420,7 +420,7 @@ class ServiceInfo(RecordUpdateListener):
         """Set IPv6 addresses from the cache."""
         address_list: List[Union[IPv4Address, IPv6Address]] = []
         for record in self._get_address_records_from_cache_by_type(zc, type):
-            if record.is_expired(now) is True:
+            if record.is_expired(now):
                 continue
             ip_addr = _cached_ip_addresses_wrapper(record.address)
             if ip_addr is not None:
@@ -463,7 +463,7 @@ class ServiceInfo(RecordUpdateListener):
 
         Returns True if a new record was added.
         """
-        if record.is_expired(now) is True:
+        if record.is_expired(now):
             return False
 
         record_key = record.key

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -316,6 +316,7 @@ class PacketGeneration(unittest.TestCase):
         parsed1 = r.DNSIncoming(packets[0])
         assert parsed1.questions[0].unicast is True
         assert len(parsed1.questions) == 30
+        assert parsed1.num_questions == 30
         assert parsed1.num_authorities == 88
         assert parsed1.truncated
         parsed2 = r.DNSIncoming(packets[1])


### PR DESCRIPTION
roughly a ~7% speed up for incoming
before: Parsing 100000 incoming messages took 2.558975583058782 seconds
after: Parsing 100000 incoming messages took 2.3616396670695394 seconds

roughly a ~2% speed up for outgoing (mostly a side effect)
before: Construction 100000 outgoing messages took 1.9390459168935195 seconds
after: Construction 100000 outgoing messages took 1.8946991249686107 seconds