### PR TITLE
feat: small speed up to writing outgoing packets

### DIFF
--- a/src/zeroconf/_dns.pxd
+++ b/src/zeroconf/_dns.pxd
@@ -69,7 +69,7 @@ cdef class DNSRecord(DNSEntry):
 cdef class DNSAddress(DNSRecord):
 
     cdef public cython.int _hash
-    cdef public object address
+    cdef public bytes address
     cdef public object scope_id
 
     cdef bint _eq(self, DNSAddress other)

--- a/src/zeroconf/_dns.pxd
+++ b/src/zeroconf/_dns.pxd
@@ -69,7 +69,7 @@ cdef class DNSRecord(DNSEntry):
 cdef class DNSAddress(DNSRecord):
 
     cdef public cython.int _hash
-    cdef public bytes address
+    cdef public object address
     cdef public object scope_id
 
     cdef bint _eq(self, DNSAddress other)

--- a/src/zeroconf/_protocol/outgoing.pxd
+++ b/src/zeroconf/_protocol/outgoing.pxd
@@ -109,8 +109,6 @@ cdef class DNSOutgoing:
 
     cpdef write_string(self, cython.bytes value)
 
-    cpdef write_character_string(self, cython.bytes value)
-
     @cython.locals(utfstr=bytes)
     cpdef _write_utf(self, cython.str value)
 

--- a/src/zeroconf/_protocol/outgoing.pxd
+++ b/src/zeroconf/_protocol/outgoing.pxd
@@ -32,6 +32,7 @@ cdef object LOGGING_DEBUG
 
 cdef cython.tuple BYTE_TABLE
 cdef cython.tuple SHORT_LOOKUP
+cdef cython.dict LONG_LOOKUP
 
 cdef class DNSOutgoing:
 

--- a/src/zeroconf/_protocol/outgoing.pxd
+++ b/src/zeroconf/_protocol/outgoing.pxd
@@ -109,6 +109,8 @@ cdef class DNSOutgoing:
 
     cpdef write_string(self, cython.bytes value)
 
+    cpdef write_character_string(self, cython.bytes value)
+
     @cython.locals(utfstr=bytes)
     cpdef _write_utf(self, cython.str value)
 

--- a/src/zeroconf/_protocol/outgoing.pxd
+++ b/src/zeroconf/_protocol/outgoing.pxd
@@ -70,7 +70,7 @@ cdef class DNSOutgoing:
         index=cython.uint,
         length=cython.uint
     )
-    cdef cython.bint _write_record(self, DNSRecord record, object now)
+    cdef cython.bint _write_record(self, DNSRecord record, float now)
 
     @cython.locals(class_=cython.uint)
     cdef _write_record_class(self, DNSEntry record)
@@ -91,7 +91,7 @@ cdef class DNSOutgoing:
 
     cdef bint _has_more_to_add(self, unsigned int questions_offset, unsigned int answer_offset, unsigned int authority_offset, unsigned int additional_offset)
 
-    cdef _write_ttl(self, DNSRecord record, object now)
+    cdef _write_ttl(self, DNSRecord record, float now)
 
     @cython.locals(
         labels=cython.list,


### PR DESCRIPTION
This is ~ 6.5 % speed up

before: Construction 100000 outgoing messages took 1.9130162500077859 seconds
after: Construction 100000 outgoing messages took 1.7759123329306021 second