### PR TITLE
chore: add benchmark to create and destroy an instance

### DIFF
--- a/bench/create_destory.py
+++ b/bench/create_destory.py
@@ -1,0 +1,23 @@
+"""Benchmark for AsyncZeroconf."""
+import asyncio
+import time
+
+from zeroconf.asyncio import AsyncZeroconf
+
+iterations = 10000
+
+
+async def _create_destroy(count: int) -> None:
+    for _ in range(count):
+        async with AsyncZeroconf() as zc:
+            await zc.zeroconf.async_wait_for_start()
+
+
+async def _run() -> None:
+    start = time.perf_counter()
+    await _create_destroy(iterations)
+    duration = time.perf_counter() - start
+    print(f"Creating and destroying {iterations} Zeroconf instances took {duration} seconds")
+
+
+asyncio.run(_run())


### PR DESCRIPTION
Its recently come up that many consumers create and destroy zeroconf instances frequently because of their application design so create/destroy time is important.

It turns out most of the time is spent in `ifaddr`

https://github.com/pydron/ifaddr/pull/58 will reduce ipv6 related startup time