### PR TITLE
feat: speed up unpacking TXT record data in ServiceInfo

### DIFF
--- a/bench/txt_properties.py
+++ b/bench/txt_properties.py
@@ -1,0 +1,22 @@
+import timeit
+
+from zeroconf import ServiceInfo
+
+info = ServiceInfo(
+    "_test._tcp.local.",
+    "test._test._tcp.local.",
+    properties=(
+        b"\x19md=AlexanderHomeAssistant\x06pv=1.0\x14id=59:8A:0B:74:65:1D\x05"
+        b"c#=14\x04s#=1\x04ff=0\x04ci=2\x04sf=0\x0bsh=ccZLPA=="
+    ),
+)
+
+
+def process_properties() -> None:
+    info._properties = None
+    info.properties
+
+
+count = 100000
+time = timeit.Timer(process_properties).timeit(count)
+print(f"Processing {count} properties took {time} seconds")

--- a/src/zeroconf/_protocol/incoming.pxd
+++ b/src/zeroconf/_protocol/incoming.pxd
@@ -86,19 +86,19 @@ cdef class DNSIncoming:
     cdef unsigned int _decode_labels_at_offset(self, unsigned int off, cython.list labels, cython.set seen_pointers)
 
     @cython.locals(offset="unsigned int")
-    cdef void _read_header(self)
+    cdef _read_header(self)
 
-    cdef void _initial_parse(self)
+    cdef _initial_parse(self)
 
     @cython.locals(
         end="unsigned int",
         length="unsigned int",
         offset="unsigned int"
     )
-    cdef void _read_others(self)
+    cdef _read_others(self)
 
     @cython.locals(offset="unsigned int")
-    cdef void _read_questions(self)
+    cdef _read_questions(self)
 
     @cython.locals(
         length="unsigned int",

--- a/src/zeroconf/_protocol/incoming.pxd
+++ b/src/zeroconf/_protocol/incoming.pxd
@@ -86,19 +86,19 @@ cdef class DNSIncoming:
     cdef unsigned int _decode_labels_at_offset(self, unsigned int off, cython.list labels, cython.set seen_pointers)
 
     @cython.locals(offset="unsigned int")
-    cdef _read_header(self)
+    cdef void _read_header(self)
 
-    cdef _initial_parse(self)
+    cdef void _initial_parse(self)
 
     @cython.locals(
         end="unsigned int",
         length="unsigned int",
         offset="unsigned int"
     )
-    cdef _read_others(self)
+    cdef void _read_others(self)
 
     @cython.locals(offset="unsigned int")
-    cdef _read_questions(self)
+    cdef void _read_questions(self)
 
     @cython.locals(
         length="unsigned int",

--- a/src/zeroconf/_services/info.pxd
+++ b/src/zeroconf/_services/info.pxd
@@ -63,7 +63,8 @@ cdef class ServiceInfo(RecordUpdateListener):
     @cython.locals(cache=DNSCache)
     cpdef bint _load_from_cache(self, object zc, cython.float now)
 
-    cdef _unpack_text_into_properties(self)
+    @cython.locals(length="unsigned char", index="unsigned int", key_value=bytes, key_sep_value=tuple)
+    cdef void _unpack_text_into_properties(self)
 
     cdef _set_properties(self, cython.dict properties)
 

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -404,8 +404,7 @@ class ServiceInfo(RecordUpdateListener):
             key_sep_value = key_value.partition(b'=')
             key = key_sep_value[0]
             if key not in properties:
-                value = key_sep_value[2]
-                properties[key] = None if len(value) == 0 else value
+                properties[key] = key_sep_value[2] or None
             index += length
 
         self._properties = properties

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -388,14 +388,14 @@ class ServiceInfo(RecordUpdateListener):
     def _unpack_text_into_properties(self) -> None:
         """Unpacks the text field into properties"""
         text = self.text
-        if not text:
+        end = len(text)
+        if end == 0:
             # Properties should be set atomically
             # in case another thread is reading them
             self._properties = {}
             return
 
         index = 0
-        end = len(text)
         properties: Dict[Union[str, bytes], Optional[Union[str, bytes]]] = {}
         while index < end:
             length = text[index]

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -404,7 +404,8 @@ class ServiceInfo(RecordUpdateListener):
             key_sep_value = key_value.partition(b'=')
             key = key_sep_value[0]
             if key not in properties:
-                properties[key] = None if length == 0 else key_sep_value[2]
+                value = key_sep_value[2]
+                properties[key] = None if len(value) == 0 else value
             index += length
 
         self._properties = properties

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -24,7 +24,7 @@ import asyncio
 import random
 from functools import lru_cache
 from ipaddress import IPv4Address, IPv6Address, _BaseAddress, ip_address
-from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple, Union, cast
+from typing import TYPE_CHECKING, Dict, List, Optional, Set, Union, cast
 
 from .._dns import (
     DNSAddress,
@@ -396,17 +396,18 @@ class ServiceInfo(RecordUpdateListener):
 
         index = 0
         end = len(text)
-        pairs: List[Tuple[bytes, Optional[bytes]]] = []
+        properties: Dict[Union[str, bytes], Optional[Union[str, bytes]]] = {}
         while index < end:
             length = text[index]
             index += 1
             key_value = text[index : index + length]
             key_sep_value = key_value.partition(b'=')
-            pairs.append((key_sep_value[0], key_sep_value[2] or None))
+            key = key_sep_value[0]
+            if key not in properties:
+                properties[key] = None if length == 0 else key_sep_value[2]
             index += length
 
-        pairs.reverse()
-        self._properties = dict(pairs)
+        self._properties = properties
 
     def get_name(self) -> str:
         """Name accessor"""


### PR DESCRIPTION
This is ~43% speed up

before
Processing 100000 properties took 0.1892200000002049 seconds

after
Processing 100000 properties took 0.10781029199961267 seconds


