### PR TITLE
fix: correct nsec record writing

### DIFF
--- a/src/zeroconf/_dns.py
+++ b/src/zeroconf/_dns.py
@@ -493,7 +493,8 @@ class DNSNsec(DNSRecord):
             raise ValueError("NSEC must have at least one rdtype")
         out_bytes = bytes(bitmap[0:total_octets])
         out.write_name(self.next_name)
-        out.write_short(len(out_bytes))
+        out._write_byte(0)  # Always window 0
+        out._write_byte(len(out_bytes))
         out.write_string(out_bytes)
 
     def __eq__(self, other: Any) -> bool:

--- a/src/zeroconf/_dns.py
+++ b/src/zeroconf/_dns.py
@@ -485,9 +485,7 @@ class DNSNsec(DNSRecord):
             if rdtype > 255:  # mDNS only supports window 0
                 raise ValueError(f"rdtype {rdtype} is too large for NSEC")
             byte = rdtype // 8
-            octet_pos = byte + 1
-            if octet_pos > total_octets:
-                total_octets = octet_pos
+            total_octets = byte + 1
             bitmap[byte] |= 0x80 >> (rdtype % 8)
         if total_octets == 0:
             # NSEC must have at least one rdtype

--- a/src/zeroconf/_dns.py
+++ b/src/zeroconf/_dns.py
@@ -495,7 +495,7 @@ class DNSNsec(DNSRecord):
             raise ValueError("NSEC must have at least one rdtype")
         out_bytes = bytes(bitmap[0:total_octets])
         out.write_name(self.next_name)
-        out.write_short(0)
+        out.write_short(0)  # Always window 0
         out.write_short(len(out_bytes))
         out.write_string(out_bytes)
 

--- a/src/zeroconf/_dns.py
+++ b/src/zeroconf/_dns.py
@@ -493,7 +493,6 @@ class DNSNsec(DNSRecord):
             raise ValueError("NSEC must have at least one rdtype")
         out_bytes = bytes(bitmap[0:total_octets])
         out.write_name(self.next_name)
-        out.write_short(0)  # Always window 0
         out.write_short(len(out_bytes))
         out.write_string(out_bytes)
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -12,6 +12,8 @@ import unittest
 import unittest.mock
 from typing import cast
 
+import pytest
+
 import zeroconf as r
 from zeroconf import DNSHinfo, DNSIncoming, DNSText, const, current_time_millis
 
@@ -65,7 +67,7 @@ class PacketGeneration(unittest.TestCase):
         parsed = r.DNSIncoming(generated.packets()[0])
         assert answer in parsed.answers()
 
-        # Types > 255 should be ignored
+        # Types > 255 should raise an exception
         answer_invalid_types = r.DNSNsec(
             'eufy HomeBase2-2464._hap._tcp.local.',
             const._TYPE_NSEC,
@@ -76,8 +78,22 @@ class PacketGeneration(unittest.TestCase):
         )
         generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
         generated.add_answer_at_time(answer_invalid_types, 0)
-        parsed = r.DNSIncoming(generated.packets()[0])
-        assert answer in parsed.answers()
+        with pytest.raises(ValueError, match='rdtype 1000 is too large for NSEC'):
+            generated.packets()
+
+        # Empty rdtypes are not allowed
+        answer_invalid_types = r.DNSNsec(
+            'eufy HomeBase2-2464._hap._tcp.local.',
+            const._TYPE_NSEC,
+            const._CLASS_IN | const._CLASS_UNIQUE,
+            const._DNS_OTHER_TTL,
+            'eufy HomeBase2-2464._hap._tcp.local.',
+            [],
+        )
+        generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
+        generated.add_answer_at_time(answer_invalid_types, 0)
+        with pytest.raises(ValueError, match='NSEC must have at least one rdtype'):
+            generated.packets()
 
     def test_parse_own_packet_response(self):
         generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -67,6 +67,21 @@ class PacketGeneration(unittest.TestCase):
         parsed = r.DNSIncoming(generated.packets()[0])
         assert answer in parsed.answers()
 
+        # Now with the higher RD type first
+        answer = r.DNSNsec(
+            'eufy HomeBase2-2464._hap._tcp.local.',
+            const._TYPE_NSEC,
+            const._CLASS_IN | const._CLASS_UNIQUE,
+            const._DNS_OTHER_TTL,
+            'eufy HomeBase2-2464._hap._tcp.local.',
+            [const._TYPE_SRV, const._TYPE_TXT],
+        )
+
+        generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
+        generated.add_answer_at_time(answer, 0)
+        parsed = r.DNSIncoming(generated.packets()[0])
+        assert answer in parsed.answers()
+
         # Types > 255 should raise an exception
         answer_invalid_types = r.DNSNsec(
             'eufy HomeBase2-2464._hap._tcp.local.',


### PR DESCRIPTION
- The window and length should be been a single byte instead of a short per https://datatracker.ietf.org/doc/html/rfc3845#section-2.1.2
- Trying to convert an empty nsec record or one with an rdtype > 255 will now raise a `ValueError` to ensure we cannot write invalid records

dns python can parse the message now
```
>>> import dns.message
>>> dns.message.from_wire(b'\x00\x00\x80\x00\x00\x00\x00\x01\x00\x00\x00\x00\x13eufy HomeBase2-2464\x04_hap\x04_tcp\x05local\x00\x00/\x80\x01\x00\x00\x11\x94\x00\t\xc0\x0c\x00\x05\x00\x00\x80\x00@')
[<dns.wire.Parser object at 0x1029e2060>, 7]
[(0, b'\x00\x00\x80\x00@')]
<DNS message, ID 0>
```

This may be the issue above, or the issues below may be bugs in the mdns stacks that are consuming the NSEC records not allowing the name compression

fixes #1320 *
fixes #1088 *

* The problem may be with the mdns stacks that are consuming the NSEC records and as they may assume that name compression is not allowed but using name compression seems right though since https://stackoverflow.com/questions/42986556/how-to-resolve-a-conflict-between-rfcs