### PR TITLE
feat: ensure ServiceInfo.properties always returns bytes

### DIFF
--- a/src/zeroconf/_services/info.pxd
+++ b/src/zeroconf/_services/info.pxd
@@ -72,6 +72,7 @@ cdef class ServiceInfo(RecordUpdateListener):
     @cython.locals(length="unsigned char", index="unsigned int", key_value=bytes, key_sep_value=tuple)
     cdef void _unpack_text_into_properties(self)
 
+    @cython.locals(properties_contain_str=bint)
     cpdef _set_properties(self, cython.dict properties)
 
     cdef _set_text(self, cython.bytes text)

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -161,7 +161,7 @@ class ServiceInfo(RecordUpdateListener):
         port: Optional[int] = None,
         weight: int = 0,
         priority: int = 0,
-        properties: Union[bytes, Dict[Union[str, bytes], Optional[Union[str, bytes]]]] = b'',
+        properties: Union[bytes, Dict] = b'',
         server: Optional[str] = None,
         host_ttl: int = _DNS_HOST_TTL,
         other_ttl: int = _DNS_OTHER_TTL,

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -161,7 +161,7 @@ class ServiceInfo(RecordUpdateListener):
         port: Optional[int] = None,
         weight: int = 0,
         priority: int = 0,
-        properties: Union[bytes, Dict] = b'',
+        properties: Union[bytes, Dict[Union[str, bytes], Optional[Union[str, bytes]]]] = b'',
         server: Optional[str] = None,
         host_ttl: int = _DNS_HOST_TTL,
         other_ttl: int = _DNS_OTHER_TTL,

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -191,7 +191,7 @@ class ServiceInfo(RecordUpdateListener):
         self.priority = priority
         self.server = server if server else None
         self.server_key = server.lower() if server else None
-        self._properties: Optional[Dict[Union[str, bytes], Optional[Union[str, bytes]]]] = None
+        self._properties: Optional[Dict[bytes, Optional[bytes]]] = None
         if isinstance(properties, bytes):
             self._set_text(properties)
         else:
@@ -260,14 +260,8 @@ class ServiceInfo(RecordUpdateListener):
                 self._ipv6_addresses.append(addr)
 
     @property
-    def properties(self) -> Dict[Union[str, bytes], Optional[Union[str, bytes]]]:
-        """If properties were set in the constructor this property returns the original dictionary
-        of type `Dict[Union[bytes, str], Any]`.
-
-        If properties are coming from the network, after decoding a TXT record, the keys are always
-        bytes and the values are either bytes, if there was a value, even empty, or `None`, if there
-        was none. No further decoding is attempted. The type returned is `Dict[bytes, Optional[bytes]]`.
-        """
+    def properties(self) -> Dict[bytes, Optional[bytes]]:
+        """Return properties as bytes."""
         if self._properties is None:
             self._unpack_text_into_properties()
         if TYPE_CHECKING:
@@ -356,21 +350,31 @@ class ServiceInfo(RecordUpdateListener):
 
     def _set_properties(self, properties: Dict[Union[str, bytes], Optional[Union[str, bytes]]]) -> None:
         """Sets properties and text of this info from a dictionary"""
-        self._properties = properties
         list_: List[bytes] = []
+        properties_contain_str = False
         result = b''
         for key, value in properties.items():
             if isinstance(key, str):
                 key = key.encode('utf-8')
+                properties_contain_str = True
 
             record = key
             if value is not None:
                 if not isinstance(value, bytes):
                     value = str(value).encode('utf-8')
+                    properties_contain_str = True
                 record += b'=' + value
             list_.append(record)
         for item in list_:
             result = b''.join((result, bytes((len(item),)), item))
+        if not properties_contain_str:
+            # If there are no str keys or values, we can use the properties
+            # as-is, without decoding them, otherwise calling
+            # self.properties will lazy decode them, which is expensive.
+            if TYPE_CHECKING:
+                self._properties = cast("Dict[bytes, Optional[bytes]]", properties)
+            else:
+                self._properties = properties
         self.text = result
 
     def _set_text(self, text: bytes) -> None:
@@ -392,7 +396,7 @@ class ServiceInfo(RecordUpdateListener):
             return
 
         index = 0
-        properties: Dict[Union[str, bytes], Optional[Union[str, bytes]]] = {}
+        properties: Dict[bytes, Optional[bytes]] = {}
         while index < end:
             length = text[index]
             index += 1

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -133,6 +133,7 @@ class ListenerTest(unittest.TestCase):
             assert info.properties[b'prop_blank'] == properties['prop_blank']
             assert info.properties[b'prop_true'] == b'1'
             assert info.properties[b'prop_false'] == b'0'
+
             assert info.addresses == addresses[:1]  # no V6 by default
             assert set(info.addresses_by_version(r.IPVersion.All)) == set(addresses)
 


### PR DESCRIPTION
Clean up `ServiceInfo.properties` to always return `bytes`.

This is a technically breaking change. Its seems unlikely anyone is using it this way, but there is always someone. The type for the incoming `Dict` is missing which makes the interface unclear, and we ended up with a messy mix internally.  This PR aims to correct that. Adding the type would likely cause more pain so its not done in this PR

We continue to allow passing in properties as a mix of bytes and str with the type `Union[bytes, Dict[Union[str, bytes], Optional[Union[str, bytes]]]]`, but we will now convert any `str` to `bytes`

The typing on properties was very confusing because it could have a mix of bytes and str types, but only bytes would ever come back from the backend and cache. The only way str could happen is if someone manually passed it in. We now ensure all passed in data is converted to bytes which allows downstream to remove a significant amount of code that tried to deal with the mismatched str/bytes values.