### PR TITLE
fix: ensure IPv6 scoped address construction uses the string cache

### DIFF
--- a/src/zeroconf/_utils/ipaddress.py
+++ b/src/zeroconf/_utils/ipaddress.py
@@ -113,7 +113,8 @@ def ip_bytes_and_scope_to_address(address: bytes_, scope: int_) -> Optional[Unio
     """Convert the bytes and scope to an IP address object."""
     base_address = cached_ip_addresses_wrapper(address)
     if base_address is not None and base_address.is_link_local:
-        return cached_ip_addresses_wrapper(f"{base_address}%{scope}")
+        # Avoid expensive __format__ call by using PyUnicode_Join
+        return cached_ip_addresses_wrapper("".join((str(base_address), "%", str(scope))))
     return base_address
 
 


### PR DESCRIPTION
Instead of using the `__str__` cache on the object it was calling `__format__` which isn't optimized

<img width="661" alt="Screenshot 2023-12-14 at 11 04 06 AM" src="https://github.com/python-zeroconf/python-zeroconf/assets/663432/3cf8489d-f225-4be2-a605-eb3090c7b895">
