### PR TITLE
fix: ensure question history suppresses duplicates

### DIFF
--- a/src/zeroconf/_history.pxd
+++ b/src/zeroconf/_history.pxd
@@ -9,10 +9,10 @@ cdef class QuestionHistory:
 
     cdef cython.dict _history
 
-    cpdef add_question_at_time(self, DNSQuestion question, float now, cython.set known_answers)
+    cpdef add_question_at_time(self, DNSQuestion question, double now, cython.set known_answers)
 
-    @cython.locals(than=cython.double, previous_question=cython.tuple, previous_known_answers=cython.set)
-    cpdef bint suppresses(self, DNSQuestion question, cython.double now, cython.set known_answers)
+    @cython.locals(than=double, previous_question=cython.tuple, previous_known_answers=cython.set)
+    cpdef bint suppresses(self, DNSQuestion question, double now, cython.set known_answers)
 
-    @cython.locals(than=cython.double, now_known_answers=cython.tuple)
-    cpdef async_expire(self, cython.double now)
+    @cython.locals(than=double, now_known_answers=cython.tuple)
+    cpdef async_expire(self, double now)

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -47,11 +47,16 @@ def test_question_suppression():
 def test_question_expire():
     history = QuestionHistory()
 
-    question = r.DNSQuestion("_hap._tcp._local.", const._TYPE_PTR, const._CLASS_IN)
     now = r.current_time_millis()
+    question = r.DNSQuestion("_hap._tcp._local.", const._TYPE_PTR, const._CLASS_IN)
     other_known_answers: Set[r.DNSRecord] = {
         r.DNSPointer(
-            "_hap._tcp.local.", const._TYPE_PTR, const._CLASS_IN, 10000, 'known-to-other._hap._tcp.local.'
+            "_hap._tcp.local.",
+            const._TYPE_PTR,
+            const._CLASS_IN,
+            10000,
+            'known-to-other._hap._tcp.local.',
+            created=now,
         )
     }
     history.add_question_at_time(question, now, other_known_answers)


### PR DESCRIPTION
There was a bug in the cython conversion logic that would loose precision on the float to double conversion