### PR TITLE
feat: make async_get_service_info available on the Zeroconf object

### DIFF
--- a/src/zeroconf/_core.py
+++ b/src/zeroconf/_core.py
@@ -39,7 +39,11 @@ from ._logger import QuietLogger, log
 from ._protocol.outgoing import DNSOutgoing
 from ._services import ServiceListener
 from ._services.browser import ServiceBrowser
-from ._services.info import ServiceInfo, instance_name_from_service_info
+from ._services.info import (
+    AsyncServiceInfo,
+    ServiceInfo,
+    instance_name_from_service_info,
+)
 from ._services.registry import ServiceRegistry
 from ._transport import _WrappedTransport
 from ._updates import RecordUpdateListener
@@ -359,6 +363,23 @@ class Zeroconf(QuietLogger):
         service."""
         self.registry.async_update(info)
         return asyncio.ensure_future(self._async_broadcast_service(info, _REGISTER_TIME, None))
+
+    async def async_get_service_info(
+        self, type_: str, name: str, timeout: int = 3000, question_type: Optional[DNSQuestionType] = None
+    ) -> Optional[AsyncServiceInfo]:
+        """Returns network's service information for a particular
+        name and type, or None if no service matches by the timeout,
+        which defaults to 3 seconds.
+
+        :param type_: fully qualified service type name
+        :param name: the name of the service
+        :param timeout: milliseconds to wait for a response
+        :param question_type: The type of questions to ask (DNSQuestionType.QM or DNSQuestionType.QU)
+        """
+        info = AsyncServiceInfo(type_, name)
+        if await info.async_request(self, timeout, question_type):
+            return info
+        return None
 
     async def _async_broadcast_service(
         self,

--- a/src/zeroconf/_core.py
+++ b/src/zeroconf/_core.py
@@ -265,7 +265,13 @@ class Zeroconf(QuietLogger):
     ) -> Optional[ServiceInfo]:
         """Returns network's service information for a particular
         name and type, or None if no service matches by the timeout,
-        which defaults to 3 seconds."""
+        which defaults to 3 seconds.
+
+        :param type_: fully qualified service type name
+        :param name: the name of the service
+        :param timeout: milliseconds to wait for a response
+        :param question_type: The type of questions to ask (DNSQuestionType.QM or DNSQuestionType.QU)
+        """
         info = ServiceInfo(type_, name)
         if info.request(self, timeout, question_type):
             return info

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -770,6 +770,12 @@ class ServiceInfo(RecordUpdateListener):
         While it is not expected during normal operation,
         this function may raise EventLoopBlocked if the underlying
         call to `async_request` cannot be completed.
+
+        :param zc: Zeroconf instance
+        :param timeout: time in milliseconds to wait for a response
+        :param question_type: question type to ask
+        :param addr: address to send the request to
+        :param port: port to send the request to
         """
         assert zc.loop is not None and zc.loop.is_running()
         if zc.loop == get_running_loop():
@@ -803,6 +809,12 @@ class ServiceInfo(RecordUpdateListener):
         mDNS multicast address and port. This is useful for directing
         requests to a specific host that may be able to respond across
         subnets.
+
+        :param zc: Zeroconf instance
+        :param timeout: time in milliseconds to wait for a response
+        :param question_type: question type to ask
+        :param addr: address to send the request to
+        :param port: port to send the request to
         """
         if not zc.started:
             await zc.async_wait_for_start()
@@ -924,3 +936,7 @@ class ServiceInfo(RecordUpdateListener):
                 )
             ),
         )
+
+
+class AsyncServiceInfo(ServiceInfo):
+    """An async version of ServiceInfo."""

--- a/src/zeroconf/asyncio.py
+++ b/src/zeroconf/asyncio.py
@@ -28,7 +28,7 @@ from ._core import Zeroconf
 from ._dns import DNSQuestionType
 from ._services import ServiceListener
 from ._services.browser import _ServiceBrowserBase
-from ._services.info import ServiceInfo
+from ._services.info import AsyncServiceInfo, ServiceInfo
 from ._services.types import ZeroconfServiceTypes
 from ._utils.net import InterfaceChoice, InterfacesType, IPVersion
 from .const import _BROWSER_TIME, _MDNS_PORT, _SERVICE_TYPE_ENUMERATION_NAME
@@ -39,10 +39,6 @@ __all__ = [
     "AsyncServiceBrowser",
     "AsyncZeroconfServiceTypes",
 ]
-
-
-class AsyncServiceInfo(ServiceInfo):
-    """An async version of ServiceInfo."""
 
 
 class AsyncServiceBrowser(_ServiceBrowserBase):
@@ -239,11 +235,14 @@ class AsyncZeroconf:
     ) -> Optional[AsyncServiceInfo]:
         """Returns network's service information for a particular
         name and type, or None if no service matches by the timeout,
-        which defaults to 3 seconds."""
-        info = AsyncServiceInfo(type_, name)
-        if await info.async_request(self.zeroconf, timeout, question_type):
-            return info
-        return None
+        which defaults to 3 seconds.
+
+        :param type_: fully qualified service type name
+        :param name: the name of the service
+        :param timeout: milliseconds to wait for a response
+        :param question_type: The type of questions to ask (DNSQuestionType.QM or DNSQuestionType.QU)
+        """
+        return await self.zeroconf.async_get_service_info(type_, name, timeout, question_type)
 
     async def async_add_service_listener(self, type_: str, listener: ServiceListener) -> None:
         """Adds a listener for a particular service type.  This object

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -680,6 +680,10 @@ async def test_service_info_async_request() -> None:
     assert aiosinfo is not None
     assert aiosinfo.addresses == [socket.inet_aton("10.0.1.3")]
 
+    aiosinfo = await aiozc.zeroconf.async_get_service_info(type_, registration_name)
+    assert aiosinfo is not None
+    assert aiosinfo.addresses == [socket.inet_aton("10.0.1.3")]
+
     aiosinfos = await asyncio.gather(
         aiozc.async_get_service_info(type_, registration_name),
         aiozc.async_get_service_info(type_, registration_name2),


### PR DESCRIPTION
Since the AsyncServiceBrowser will return a Zeroconf object, it was not obvious how to do an async lookup because only get_service_info was exposed on the Zeroconf object. async_get_service_info has been moved to the Zeroconf object, and AsyncZeroconf.async_get_service_info now wraps this method

related issue #1286