### PR TITLE
fix: avoid including scope_id in IPv6Address object if its zero

### DIFF
--- a/src/zeroconf/_utils/ipaddress.py
+++ b/src/zeroconf/_utils/ipaddress.py
@@ -104,7 +104,7 @@ cached_ip_addresses = cached_ip_addresses_wrapper
 
 def get_ip_address_object_from_record(record: DNSAddress) -> Optional[Union[IPv4Address, IPv6Address]]:
     """Get the IP address object from the record."""
-    if IPADDRESS_SUPPORTS_SCOPE_ID and record.type == _TYPE_AAAA and record.scope_id is not None:
+    if IPADDRESS_SUPPORTS_SCOPE_ID and record.type == _TYPE_AAAA and record.scope_id:
         return ip_bytes_and_scope_to_address(record.address, record.scope_id)
     return cached_ip_addresses_wrapper(record.address)
 

--- a/tests/utils/test_ipaddress.py
+++ b/tests/utils/test_ipaddress.py
@@ -2,6 +2,8 @@
 
 """Unit tests for zeroconf._utils.ipaddress."""
 
+import sys
+
 import pytest
 
 from zeroconf import const
@@ -40,7 +42,7 @@ def test_cached_ip_addresses_wrapper():
     assert ipv6.is_unspecified is True
 
 
-@pytest.mark.skipif(not ipaddress.IPADDRESS_SUPPORTS_SCOPE_ID, reason='scope_id is not supported')
+@pytest.mark.skipif(sys.version_info < (3, 9, 0), reason='scope_id is not supported')
 def test_get_ip_address_object_from_record():
     """Test the get_ip_address_object_from_record."""
     # not link local

--- a/tests/utils/test_ipaddress.py
+++ b/tests/utils/test_ipaddress.py
@@ -2,6 +2,10 @@
 
 """Unit tests for zeroconf._utils.ipaddress."""
 
+import pytest
+
+from zeroconf import const
+from zeroconf._dns import DNSAddress
 from zeroconf._utils import ipaddress
 
 
@@ -34,3 +38,34 @@ def test_cached_ip_addresses_wrapper():
     assert ipv6 is not None
     assert ipv6.is_link_local is False
     assert ipv6.is_unspecified is True
+
+
+@pytest.mark.skipif(not ipaddress.IPADDRESS_SUPPORTS_SCOPE_ID, reason='scope_id is not supported')
+def test_get_ip_address_object_from_record():
+    """Test the get_ip_address_object_from_record."""
+    # not link local
+    packed = b'&\x06(\x00\x02 \x00\x01\x02H\x18\x93%\xc8\x19F'
+    record = DNSAddress(
+        'domain.local', const._TYPE_AAAA, const._CLASS_IN | const._CLASS_UNIQUE, 1, packed, scope_id=3
+    )
+    assert record.scope_id == 3
+    assert ipaddress.get_ip_address_object_from_record(record) == ipaddress.IPv6Address(
+        '2606:2800:220:1:248:1893:25c8:1946'
+    )
+
+    # link local
+    packed = b'\xfe\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01'
+    record = DNSAddress(
+        'domain.local', const._TYPE_AAAA, const._CLASS_IN | const._CLASS_UNIQUE, 1, packed, scope_id=3
+    )
+    assert record.scope_id == 3
+    assert ipaddress.get_ip_address_object_from_record(record) == ipaddress.IPv6Address('fe80::1%3')
+    record = DNSAddress('domain.local', const._TYPE_AAAA, const._CLASS_IN | const._CLASS_UNIQUE, 1, packed)
+    assert record.scope_id is None
+    assert ipaddress.get_ip_address_object_from_record(record) == ipaddress.IPv6Address('fe80::1')
+    record = DNSAddress(
+        'domain.local', const._TYPE_A, const._CLASS_IN | const._CLASS_UNIQUE, 1, packed, scope_id=0
+    )
+    assert record.scope_id == 0
+    # Ensure scope_id of 0 is not appended to the address
+    assert ipaddress.get_ip_address_object_from_record(record) == ipaddress.IPv6Address('fe80::1')


### PR DESCRIPTION
If the scope_id is 0 it should not be included in the IPv6Address object

fixes #1361