### PR TITLE
fix: update references to minimum-supported python version of 3.8

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,8 +45,8 @@ Compared to some other Zeroconf/Bonjour/Avahi Python packages, python-zeroconf:
 Python compatibility
 --------------------
 
-* CPython 3.7+
-* PyPy3.7 7.3+
+* CPython 3.8+
+* PyPy3.8 7.3+
 
 Versioning
 ----------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,11 +16,11 @@ classifiers=[
 	'Operating System :: POSIX :: Linux',
 	'Operating System :: MacOS :: MacOS X',
 	'Topic :: Software Development :: Libraries',
-	'Programming Language :: Python :: 3.7',
 	'Programming Language :: Python :: 3.8',
 	'Programming Language :: Python :: 3.9',
 	'Programming Language :: Python :: 3.10',
 	'Programming Language :: Python :: 3.11',
+	'Programming Language :: Python :: 3.12',
 	'Programming Language :: Python :: Implementation :: CPython',
 	'Programming Language :: Python :: Implementation :: PyPy',
 ]


### PR DESCRIPTION
Drop support for python3.7 as according to 4877829e6442de5426db152d11827b1ba85dbf59 and add explicit support for python3.12