### PR TITLE
Enable building of arm64 macOS builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macOS-11]
+        os: [ubuntu-20.04, windows-2019, macos-12, macos-latest ]
 
     steps:
       - uses: actions/checkout@v3
@@ -162,8 +162,8 @@ jobs:
         uses: pypa/cibuildwheel@v2.17.0
         # to supply options, put them in 'env', like:
         env:
-          CIBW_SKIP: cp36-* cp37-* pp36-* pp37-* *p38-*_aarch64 *p39-*_aarch64 *p310-*_aarch64 pp*_aarch64 *musllinux*_aarch64
-          CIBW_BEFORE_ALL_LINUX: apt-get install -y gcc || yum install -y gcc || apk add gcc
+          CIBW_SKIP: cp36-* cp37-* pp36-* pp37-* *p38-*_aarch64 cp38-*_arm64 *p39-*_aarch64 *p310-*_aarch64 pp*_aarch64 *musllinux*_aarch64
+          CIBW_BEFORE_ALL_LINUX: apt install -y gcc || yum install -y gcc || apk add gcc
           CIBW_ARCHS_LINUX: auto aarch64
           CIBW_BUILD_VERBOSITY: 3
           REQUIRE_CYTHON: 1


### PR DESCRIPTION
Enabling building for macOS arm64 builds is easy to add, because the newest macOS runners build in arm64 by default. Hence the addition of `macos-latest` to the matrix.

Also, since macos-11 runners are deprecated (see [1]), switched to macos-12 for the x86_64 builds.

Incidentally, it seems current Ubuntu runners don't include `apt-get` by default, so switched to using `apt` command.

So to summarize:
  - `macos-12` runners will continue building macOS x86_64 builds
  - `macos-latest` runners will now build macOS arm64 builds

The new files look like this:
```
  zeroconf-0.132.2-cp310-cp310-macosx_14_0_arm64.whl          4,683 kB
  zeroconf-0.132.2-cp311-cp311-macosx_14_0_arm64.whl          4,685 kB
  zeroconf-0.132.2-cp312-cp312-macosx_14_0_arm64.whl          4,704 kB
  zeroconf-0.132.2-cp39-cp39-macosx_14_0_arm64.whl            1,727 kB
  zeroconf-0.132.2-pp310-pypy310_pp73-macosx_14_0_arm64.whl   4,428 kB
  zeroconf-0.132.2-pp38-pypy38_pp73-macosx_14_0_arm64.whl     4,423 kB
  zeroconf-0.132.2-pp39-pypy39_pp73-macosx_14_0_arm64.whl     4,425 kB
```

Unrelated, but it seem all wheels after cp39 include .c source code in them, making the wheels larger. This should probably addressed in a separate PR.

[1] https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/