### PR TITLE
Close event loop. Fixes file handle leak.

### DIFF
--- a/src/zeroconf/_core.py
+++ b/src/zeroconf/_core.py
@@ -219,7 +219,10 @@ class Zeroconf(QuietLogger):
             self.loop = asyncio.new_event_loop()
             asyncio.set_event_loop(self.loop)
             self.engine.setup(self.loop, loop_thread_ready)
-            self.loop.run_forever()
+            try:
+                self.loop.run_forever()
+            finally:
+                self.loop.close()
 
         self._loop_thread = threading.Thread(target=_run_loop, daemon=True)
         self._loop_thread.start()


### PR DESCRIPTION
When calling close() on the Zeroconf object, self.loop is not closed properly. This introduces a file handle leak. This commit fixes this.