### PR TITLE
chore(pre-commit): bump pyupgrade to required python 3.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,10 +34,10 @@ repos:
       - id: prettier
         args: ["--tab-width", "2"]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.18.0
+    rev: v3.19.0
     hooks:
       - id: pyupgrade
-        args: [--py37-plus]
+        args: [--py38-plus]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.7.0
     hooks:


### PR DESCRIPTION
Project requires python 3.8 so it should be used for `pyupgrade`.
No upgrade of the current code required.