### PR TITLE
chore(tests): remove outdated python 3.7 compatibility code

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -13,12 +13,7 @@ import time
 import unittest
 import unittest.mock
 from typing import Tuple, Union, cast
-from unittest.mock import Mock, patch
-
-if sys.version_info[:3][1] < 8:
-    AsyncMock = Mock
-else:
-    from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -748,7 +743,6 @@ def test_shutdown_while_register_in_process():
 
 
 @pytest.mark.asyncio
-@unittest.skipIf(sys.version_info[:3][1] < 8, "Requires Python 3.8 or later to patch _async_setup")
 @patch("zeroconf._core._STARTUP_TIMEOUT", 0)
 @patch("zeroconf._core.AsyncEngine._async_setup", new_callable=AsyncMock)
 async def test_event_loop_blocked(mock_start):


### PR DESCRIPTION
Python 3.8 is required, so no need for compatibility code.