### PR TITLE
chore(ci): increase tested pypy to 3.9 and 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,8 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
-          - "pypy-3.8"
           - "pypy-3.9"
+          - "pypy-3.10"
         os:
           - ubuntu-latest
           - macos-latest
@@ -57,13 +57,13 @@ jobs:
           - os: windows-latest
             extension: use_cython
           - os: windows-latest
-            python-version: "pypy-3.8"
+            python-version: "pypy-3.9"
           - os: windows-latest
-            python-version: "pypy-3.9"
-          - os: macos-latest
-            python-version: "pypy-3.8"
+            python-version: "pypy-3.10"
           - os: macos-latest
             python-version: "pypy-3.9"
+          - os: macos-latest
+            python-version: "pypy-3.10"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Old pypy3.8 can be replaced with current pypy3.10.