### PR TITLE
feat: speed up parsing incoming records

### DIFF
--- a/src/zeroconf/_dns.pxd
+++ b/src/zeroconf/_dns.pxd
@@ -30,7 +30,7 @@ cdef class DNSEntry:
     cdef public cython.uint class_
     cdef public bint unique
 
-    cdef _set_class(self, cython.uint class_)
+    cdef _fast_init_entry(self, str name, cython.uint type_, cython.uint class_)
 
     cdef bint _dns_entry_matches(self, DNSEntry other)
 
@@ -38,12 +38,16 @@ cdef class DNSQuestion(DNSEntry):
 
     cdef public cython.int _hash
 
+    cdef _fast_init(self, str name, cython.uint type_, cython.uint class_)
+
     cpdef bint answered_by(self, DNSRecord rec)
 
 cdef class DNSRecord(DNSEntry):
 
     cdef public cython.float ttl
     cdef public double created
+
+    cdef _fast_init_record(self, str name, cython.uint type_, cython.uint class_, cython.float ttl, double created)
 
     cdef bint _suppressed_by_answer(self, DNSRecord answer)
 
@@ -69,8 +73,10 @@ cdef class DNSRecord(DNSEntry):
 cdef class DNSAddress(DNSRecord):
 
     cdef public cython.int _hash
-    cdef public object address
+    cdef public bytes address
     cdef public object scope_id
+
+    cdef _fast_init(self, str name, cython.uint type_, cython.uint class_, cython.float ttl, bytes address, object scope_id, double created)
 
     cdef bint _eq(self, DNSAddress other)
 
@@ -83,6 +89,8 @@ cdef class DNSHinfo(DNSRecord):
     cdef public str cpu
     cdef public str os
 
+    cdef _fast_init(self, str name, cython.uint type_, cython.uint class_, cython.float ttl, str cpu, str os, double created)
+
     cdef bint _eq(self, DNSHinfo other)
 
     cpdef write(self, DNSOutgoing out)
@@ -93,6 +101,8 @@ cdef class DNSPointer(DNSRecord):
     cdef public str alias
     cdef public str alias_key
 
+    cdef _fast_init(self, str name, cython.uint type_, cython.uint class_, cython.float ttl, str alias, double created)
+
     cdef bint _eq(self, DNSPointer other)
 
     cpdef write(self, DNSOutgoing out)
@@ -101,6 +111,8 @@ cdef class DNSText(DNSRecord):
 
     cdef public cython.int _hash
     cdef public bytes text
+
+    cdef _fast_init(self, str name, cython.uint type_, cython.uint class_, cython.float ttl, bytes text, double created)
 
     cdef bint _eq(self, DNSText other)
 
@@ -115,6 +127,8 @@ cdef class DNSService(DNSRecord):
     cdef public str server
     cdef public str server_key
 
+    cdef _fast_init(self, str name, cython.uint type_, cython.uint class_, cython.float ttl, cython.uint priority, cython.uint weight, cython.uint port, str server, double created)
+
     cdef bint _eq(self, DNSService other)
 
     cpdef write(self, DNSOutgoing out)
@@ -124,6 +138,8 @@ cdef class DNSNsec(DNSRecord):
     cdef public cython.int _hash
     cdef public object next_name
     cdef public cython.list rdtypes
+
+    cdef _fast_init(self, str name, cython.uint type_, cython.uint class_, cython.float ttl, str next_name, cython.list rdtypes, double created)
 
     cdef bint _eq(self, DNSNsec other)
 

--- a/src/zeroconf/_dns.py
+++ b/src/zeroconf/_dns.py
@@ -175,7 +175,7 @@ class DNSRecord(DNSEntry):
     ) -> None:
         self._fast_init_record(name, type_, class_, ttl, created or current_time_millis())
 
-    def _fast_init_record(self, name: str, type_: int, class_: int, ttl: float, created: float) -> None:
+    def _fast_init_record(self, name: str, type_: int, class_: int, ttl: float, created: _float) -> None:
         """Fast init for reuse."""
         super()._fast_init_entry(name, type_, class_)
         self.ttl = ttl
@@ -267,7 +267,7 @@ class DNSAddress(DNSRecord):
         ttl: float,
         address: bytes,
         scope_id: Optional[_int],
-        created: float,
+        created: _float,
     ) -> None:
         """Fast init for reuse."""
         super()._fast_init_record(name, type_, class_, ttl, created)
@@ -325,7 +325,7 @@ class DNSHinfo(DNSRecord):
         self._fast_init(name, type_, class_, ttl, cpu, os, created or current_time_millis())
 
     def _fast_init(
-        self, name: str, type_: int, class_: int, ttl: float, cpu: str, os: str, created: float
+        self, name: str, type_: int, class_: int, ttl: float, cpu: str, os: str, created: _float
     ) -> None:
         """Fast init for reuse."""
         super()._fast_init_record(name, type_, class_, ttl, created)
@@ -371,7 +371,7 @@ class DNSPointer(DNSRecord):
     ) -> None:
         self._fast_init(name, type_, class_, ttl, alias, created or current_time_millis())
 
-    def _fast_init(self, name: str, type_: int, class_: int, ttl: float, alias: str, created: float) -> None:
+    def _fast_init(self, name: str, type_: int, class_: int, ttl: float, alias: str, created: _float) -> None:
         super()._fast_init_record(name, type_, class_, ttl, created)
         self.alias = alias
         self.alias_key = alias.lower()
@@ -424,7 +424,9 @@ class DNSText(DNSRecord):
     ) -> None:
         self._fast_init(name, type_, class_, ttl, text, created or current_time_millis())
 
-    def _fast_init(self, name: str, type_: int, class_: int, ttl: float, text: bytes, created: float) -> None:
+    def _fast_init(
+        self, name: str, type_: int, class_: int, ttl: float, text: bytes, created: _float
+    ) -> None:
         super()._fast_init_record(name, type_, class_, ttl, created)
         self.text = text
         self._hash = hash((self.key, type_, self.class_, text))
@@ -483,7 +485,7 @@ class DNSService(DNSRecord):
         weight: int,
         port: int,
         server: str,
-        created: float,
+        created: _float,
     ) -> None:
         super()._fast_init_record(name, type_, class_, ttl, created)
         self.priority = priority
@@ -548,7 +550,7 @@ class DNSNsec(DNSRecord):
         ttl: float,
         next_name: str,
         rdtypes: List[int],
-        created: float,
+        created: _float,
     ) -> None:
         super()._fast_init_record(name, type_, class_, ttl, created)
         self.next_name = next_name

--- a/src/zeroconf/_dns.py
+++ b/src/zeroconf/_dns.py
@@ -69,7 +69,7 @@ class DNSEntry:
     def __init__(self, name: str, type_: int, class_: int) -> None:
         self._fast_init_entry(name, type_, class_)
 
-    def _fast_init_entry(self, name: str, type_: int, class_: int) -> None:
+    def _fast_init_entry(self, name: str, type_: _int, class_: _int) -> None:
         """Fast init for reuse."""
         self.name = name
         self.key = name.lower()
@@ -114,7 +114,7 @@ class DNSQuestion(DNSEntry):
     def __init__(self, name: str, type_: int, class_: int) -> None:
         self._fast_init(name, type_, class_)
 
-    def _fast_init(self, name: str, type_: int, class_: int) -> None:
+    def _fast_init(self, name: str, type_: _int, class_: _int) -> None:
         """Fast init for reuse."""
         super()._fast_init_entry(name, type_, class_)
         self._hash = hash((self.key, type_, self.class_))
@@ -175,7 +175,7 @@ class DNSRecord(DNSEntry):
     ) -> None:
         self._fast_init_record(name, type_, class_, ttl, created or current_time_millis())
 
-    def _fast_init_record(self, name: str, type_: int, class_: int, ttl: float, created: _float) -> None:
+    def _fast_init_record(self, name: str, type_: _int, class_: _int, ttl: _float, created: _float) -> None:
         """Fast init for reuse."""
         super()._fast_init_entry(name, type_, class_)
         self.ttl = ttl
@@ -262,9 +262,9 @@ class DNSAddress(DNSRecord):
     def _fast_init(
         self,
         name: str,
-        type_: int,
-        class_: int,
-        ttl: float,
+        type_: _int,
+        class_: _int,
+        ttl: _float,
         address: bytes,
         scope_id: Optional[_int],
         created: _float,
@@ -325,7 +325,7 @@ class DNSHinfo(DNSRecord):
         self._fast_init(name, type_, class_, ttl, cpu, os, created or current_time_millis())
 
     def _fast_init(
-        self, name: str, type_: int, class_: int, ttl: float, cpu: str, os: str, created: _float
+        self, name: str, type_: _int, class_: _int, ttl: _float, cpu: str, os: str, created: _float
     ) -> None:
         """Fast init for reuse."""
         super()._fast_init_record(name, type_, class_, ttl, created)
@@ -371,7 +371,9 @@ class DNSPointer(DNSRecord):
     ) -> None:
         self._fast_init(name, type_, class_, ttl, alias, created or current_time_millis())
 
-    def _fast_init(self, name: str, type_: int, class_: int, ttl: float, alias: str, created: _float) -> None:
+    def _fast_init(
+        self, name: str, type_: _int, class_: _int, ttl: _float, alias: str, created: _float
+    ) -> None:
         super()._fast_init_record(name, type_, class_, ttl, created)
         self.alias = alias
         self.alias_key = alias.lower()
@@ -425,7 +427,7 @@ class DNSText(DNSRecord):
         self._fast_init(name, type_, class_, ttl, text, created or current_time_millis())
 
     def _fast_init(
-        self, name: str, type_: int, class_: int, ttl: float, text: bytes, created: _float
+        self, name: str, type_: _int, class_: _int, ttl: _float, text: bytes, created: _float
     ) -> None:
         super()._fast_init_record(name, type_, class_, ttl, created)
         self.text = text
@@ -478,12 +480,12 @@ class DNSService(DNSRecord):
     def _fast_init(
         self,
         name: str,
-        type_: int,
-        class_: int,
-        ttl: float,
-        priority: int,
-        weight: int,
-        port: int,
+        type_: _int,
+        class_: _int,
+        ttl: _float,
+        priority: _int,
+        weight: _int,
+        port: _int,
         server: str,
         created: _float,
     ) -> None:
@@ -535,7 +537,7 @@ class DNSNsec(DNSRecord):
         name: str,
         type_: int,
         class_: int,
-        ttl: int,
+        ttl: Union[int, float],
         next_name: str,
         rdtypes: List[int],
         created: Optional[float] = None,
@@ -545,11 +547,11 @@ class DNSNsec(DNSRecord):
     def _fast_init(
         self,
         name: str,
-        type_: int,
-        class_: int,
-        ttl: float,
+        type_: _int,
+        class_: _int,
+        ttl: _float,
         next_name: str,
-        rdtypes: List[int],
+        rdtypes: List[_int],
         created: _float,
     ) -> None:
         super()._fast_init_record(name, type_, class_, ttl, created)

--- a/src/zeroconf/_dns.py
+++ b/src/zeroconf/_dns.py
@@ -270,7 +270,7 @@ class DNSAddress(DNSRecord):
         created: _float,
     ) -> None:
         """Fast init for reuse."""
-        super()._fast_init_record(name, type_, class_, ttl, created)
+        self._fast_init_record(name, type_, class_, ttl, created)
         self.address = address
         self.scope_id = scope_id
         self._hash = hash((self.key, type_, self.class_, address, scope_id))
@@ -328,7 +328,7 @@ class DNSHinfo(DNSRecord):
         self, name: str, type_: _int, class_: _int, ttl: _float, cpu: str, os: str, created: _float
     ) -> None:
         """Fast init for reuse."""
-        super()._fast_init_record(name, type_, class_, ttl, created)
+        self._fast_init_record(name, type_, class_, ttl, created)
         self.cpu = cpu
         self.os = os
         self._hash = hash((self.key, type_, self.class_, cpu, os))
@@ -374,7 +374,7 @@ class DNSPointer(DNSRecord):
     def _fast_init(
         self, name: str, type_: _int, class_: _int, ttl: _float, alias: str, created: _float
     ) -> None:
-        super()._fast_init_record(name, type_, class_, ttl, created)
+        self._fast_init_record(name, type_, class_, ttl, created)
         self.alias = alias
         self.alias_key = alias.lower()
         self._hash = hash((self.key, type_, self.class_, self.alias_key))
@@ -429,7 +429,7 @@ class DNSText(DNSRecord):
     def _fast_init(
         self, name: str, type_: _int, class_: _int, ttl: _float, text: bytes, created: _float
     ) -> None:
-        super()._fast_init_record(name, type_, class_, ttl, created)
+        self._fast_init_record(name, type_, class_, ttl, created)
         self.text = text
         self._hash = hash((self.key, type_, self.class_, text))
 
@@ -489,7 +489,7 @@ class DNSService(DNSRecord):
         server: str,
         created: _float,
     ) -> None:
-        super()._fast_init_record(name, type_, class_, ttl, created)
+        self._fast_init_record(name, type_, class_, ttl, created)
         self.priority = priority
         self.weight = weight
         self.port = port
@@ -554,7 +554,7 @@ class DNSNsec(DNSRecord):
         rdtypes: List[_int],
         created: _float,
     ) -> None:
-        super()._fast_init_record(name, type_, class_, ttl, created)
+        self._fast_init_record(name, type_, class_, ttl, created)
         self.next_name = next_name
         self.rdtypes = sorted(rdtypes)
         self._hash = hash((self.key, type_, self.class_, next_name, *self.rdtypes))

--- a/src/zeroconf/_dns.py
+++ b/src/zeroconf/_dns.py
@@ -116,7 +116,7 @@ class DNSQuestion(DNSEntry):
 
     def _fast_init(self, name: str, type_: _int, class_: _int) -> None:
         """Fast init for reuse."""
-        super()._fast_init_entry(name, type_, class_)
+        self._fast_init_entry(name, type_, class_)
         self._hash = hash((self.key, type_, self.class_))
 
     def answered_by(self, rec: "DNSRecord") -> bool:
@@ -177,7 +177,7 @@ class DNSRecord(DNSEntry):
 
     def _fast_init_record(self, name: str, type_: _int, class_: _int, ttl: _float, created: _float) -> None:
         """Fast init for reuse."""
-        super()._fast_init_entry(name, type_, class_)
+        self._fast_init_entry(name, type_, class_)
         self.ttl = ttl
         self.created = created
 

--- a/src/zeroconf/_dns.py
+++ b/src/zeroconf/_dns.py
@@ -67,12 +67,13 @@ class DNSEntry:
     __slots__ = ("class_", "key", "name", "type", "unique")
 
     def __init__(self, name: str, type_: int, class_: int) -> None:
+        self._fast_init_entry(name, type_, class_)
+
+    def _fast_init_entry(self, name: str, type_: int, class_: int) -> None:
+        """Fast init for reuse."""
         self.name = name
         self.key = name.lower()
         self.type = type_
-        self._set_class(class_)
-
-    def _set_class(self, class_: _int) -> None:
         self.class_ = class_ & _CLASS_MASK
         self.unique = (class_ & _CLASS_UNIQUE) != 0
 
@@ -111,7 +112,11 @@ class DNSQuestion(DNSEntry):
     __slots__ = ("_hash",)
 
     def __init__(self, name: str, type_: int, class_: int) -> None:
-        super().__init__(name, type_, class_)
+        self._fast_init(name, type_, class_)
+
+    def _fast_init(self, name: str, type_: int, class_: int) -> None:
+        """Fast init for reuse."""
+        super()._fast_init_entry(name, type_, class_)
         self._hash = hash((self.key, type_, self.class_))
 
     def answered_by(self, rec: "DNSRecord") -> bool:
@@ -168,9 +173,13 @@ class DNSRecord(DNSEntry):
         ttl: Union[float, int],
         created: Optional[float] = None,
     ) -> None:
-        super().__init__(name, type_, class_)
+        self._fast_init_record(name, type_, class_, ttl, created or current_time_millis())
+
+    def _fast_init_record(self, name: str, type_: int, class_: int, ttl: float, created: float) -> None:
+        """Fast init for reuse."""
+        super()._fast_init_entry(name, type_, class_)
         self.ttl = ttl
-        self.created = created or current_time_millis()
+        self.created = created
 
     def __eq__(self, other: Any) -> bool:  # pylint: disable=no-self-use
         """Abstract method"""
@@ -248,7 +257,20 @@ class DNSAddress(DNSRecord):
         scope_id: Optional[int] = None,
         created: Optional[float] = None,
     ) -> None:
-        super().__init__(name, type_, class_, ttl, created)
+        self._fast_init(name, type_, class_, ttl, address, scope_id, created or current_time_millis())
+
+    def _fast_init(
+        self,
+        name: str,
+        type_: int,
+        class_: int,
+        ttl: float,
+        address: bytes,
+        scope_id: Optional[_int],
+        created: float,
+    ) -> None:
+        """Fast init for reuse."""
+        super()._fast_init_record(name, type_, class_, ttl, created)
         self.address = address
         self.scope_id = scope_id
         self._hash = hash((self.key, type_, self.class_, address, scope_id))
@@ -300,7 +322,13 @@ class DNSHinfo(DNSRecord):
         os: str,
         created: Optional[float] = None,
     ) -> None:
-        super().__init__(name, type_, class_, ttl, created)
+        self._fast_init(name, type_, class_, ttl, cpu, os, created or current_time_millis())
+
+    def _fast_init(
+        self, name: str, type_: int, class_: int, ttl: float, cpu: str, os: str, created: float
+    ) -> None:
+        """Fast init for reuse."""
+        super()._fast_init_record(name, type_, class_, ttl, created)
         self.cpu = cpu
         self.os = os
         self._hash = hash((self.key, type_, self.class_, cpu, os))
@@ -341,7 +369,10 @@ class DNSPointer(DNSRecord):
         alias: str,
         created: Optional[float] = None,
     ) -> None:
-        super().__init__(name, type_, class_, ttl, created)
+        self._fast_init(name, type_, class_, ttl, alias, created or current_time_millis())
+
+    def _fast_init(self, name: str, type_: int, class_: int, ttl: float, alias: str, created: float) -> None:
+        super()._fast_init_record(name, type_, class_, ttl, created)
         self.alias = alias
         self.alias_key = alias.lower()
         self._hash = hash((self.key, type_, self.class_, self.alias_key))
@@ -391,7 +422,10 @@ class DNSText(DNSRecord):
         text: bytes,
         created: Optional[float] = None,
     ) -> None:
-        super().__init__(name, type_, class_, ttl, created)
+        self._fast_init(name, type_, class_, ttl, text, created or current_time_millis())
+
+    def _fast_init(self, name: str, type_: int, class_: int, ttl: float, text: bytes, created: float) -> None:
+        super()._fast_init_record(name, type_, class_, ttl, created)
         self.text = text
         self._hash = hash((self.key, type_, self.class_, text))
 
@@ -435,7 +469,23 @@ class DNSService(DNSRecord):
         server: str,
         created: Optional[float] = None,
     ) -> None:
-        super().__init__(name, type_, class_, ttl, created)
+        self._fast_init(
+            name, type_, class_, ttl, priority, weight, port, server, created or current_time_millis()
+        )
+
+    def _fast_init(
+        self,
+        name: str,
+        type_: int,
+        class_: int,
+        ttl: float,
+        priority: int,
+        weight: int,
+        port: int,
+        server: str,
+        created: float,
+    ) -> None:
+        super()._fast_init_record(name, type_, class_, ttl, created)
         self.priority = priority
         self.weight = weight
         self.port = port
@@ -488,7 +538,19 @@ class DNSNsec(DNSRecord):
         rdtypes: List[int],
         created: Optional[float] = None,
     ) -> None:
-        super().__init__(name, type_, class_, ttl, created)
+        self._fast_init(name, type_, class_, ttl, next_name, rdtypes, created or current_time_millis())
+
+    def _fast_init(
+        self,
+        name: str,
+        type_: int,
+        class_: int,
+        ttl: float,
+        next_name: str,
+        rdtypes: List[int],
+        created: float,
+    ) -> None:
+        super()._fast_init_record(name, type_, class_, ttl, created)
         self.next_name = next_name
         self.rdtypes = sorted(rdtypes)
         self._hash = hash((self.key, type_, self.class_, next_name, *self.rdtypes))

--- a/src/zeroconf/_protocol/incoming.pxd
+++ b/src/zeroconf/_protocol/incoming.pxd
@@ -109,9 +109,15 @@ cdef class DNSIncoming:
 
     @cython.locals(
         name_start="unsigned int",
-        offset="unsigned int"
+        offset="unsigned int",
+        address_rec=DNSAddress,
+        pointer_rec=DNSPointer,
+        text_rec=DNSText,
+        srv_rec=DNSService,
+        hinfo_rec=DNSHinfo,
+        nsec_rec=DNSNsec,
     )
-    cdef _read_record(self, object domain, unsigned int type_, unsigned int class_, unsigned int ttl, unsigned int length)
+    cdef _read_record(self, str domain, unsigned int type_, unsigned int class_, unsigned int ttl, unsigned int length)
 
     @cython.locals(
         offset="unsigned int",

--- a/src/zeroconf/_protocol/incoming.pxd
+++ b/src/zeroconf/_protocol/incoming.pxd
@@ -97,7 +97,7 @@ cdef class DNSIncoming:
     )
     cdef void _read_others(self)
 
-    @cython.locals(offset="unsigned int")
+    @cython.locals(offset="unsigned int", question=DNSQuestion)
     cdef _read_questions(self)
 
     @cython.locals(

--- a/src/zeroconf/_protocol/incoming.py
+++ b/src/zeroconf/_protocol/incoming.py
@@ -306,11 +306,17 @@ class DNSIncoming:
     ) -> Optional[DNSRecord]:
         """Read known records types and skip unknown ones."""
         if type_ == _TYPE_A:
-            return DNSAddress(domain, type_, class_, ttl, self._read_string(4), None, self.now)
+            address_rec = object.__new__(DNSAddress)
+            address_rec._fast_init(domain, type_, class_, ttl, self._read_string(4), None, self.now)
+            return address_rec
         if type_ in (_TYPE_CNAME, _TYPE_PTR):
-            return DNSPointer(domain, type_, class_, ttl, self._read_name(), self.now)
+            pointer_rec = object.__new__(DNSPointer)
+            pointer_rec._fast_init(domain, type_, class_, ttl, self._read_name(), self.now)
+            return pointer_rec
         if type_ == _TYPE_TXT:
-            return DNSText(domain, type_, class_, ttl, self._read_string(length), self.now)
+            text_rec = object.__new__(DNSText)
+            text_rec._fast_init(domain, type_, class_, ttl, self._read_string(length), self.now)
+            return text_rec
         if type_ == _TYPE_SRV:
             view = self.view
             offset = self.offset
@@ -319,7 +325,8 @@ class DNSIncoming:
             priority = view[offset] << 8 | view[offset + 1]
             weight = view[offset + 2] << 8 | view[offset + 3]
             port = view[offset + 4] << 8 | view[offset + 5]
-            return DNSService(
+            srv_rec = object.__new__(DNSService)
+            srv_rec._fast_init(
                 domain,
                 type_,
                 class_,
@@ -330,8 +337,10 @@ class DNSIncoming:
                 self._read_name(),
                 self.now,
             )
+            return srv_rec
         if type_ == _TYPE_HINFO:
-            return DNSHinfo(
+            hinfo_rec = object.__new__(DNSHinfo)
+            hinfo_rec._fast_init(
                 domain,
                 type_,
                 class_,
@@ -340,8 +349,10 @@ class DNSIncoming:
                 self._read_character_string(),
                 self.now,
             )
+            return hinfo_rec
         if type_ == _TYPE_AAAA:
-            return DNSAddress(
+            address_rec = object.__new__(DNSAddress)
+            address_rec._fast_init(
                 domain,
                 type_,
                 class_,
@@ -350,9 +361,11 @@ class DNSIncoming:
                 self.scope_id,
                 self.now,
             )
+            return address_rec
         if type_ == _TYPE_NSEC:
             name_start = self.offset
-            return DNSNsec(
+            nsec_rec = object.__new__(DNSNsec)
+            nsec_rec._fast_init(
                 domain,
                 type_,
                 class_,
@@ -361,6 +374,7 @@ class DNSIncoming:
                 self._read_bitmap(name_start + length),
                 self.now,
             )
+            return nsec_rec
         # Try to ignore types we don't know about
         # Skip the payload for the resource record so the next
         # records can be parsed correctly

--- a/src/zeroconf/_protocol/incoming.py
+++ b/src/zeroconf/_protocol/incoming.py
@@ -306,15 +306,15 @@ class DNSIncoming:
     ) -> Optional[DNSRecord]:
         """Read known records types and skip unknown ones."""
         if type_ == _TYPE_A:
-            address_rec = object.__new__(DNSAddress)
+            address_rec = DNSAddress.__new__(DNSAddress)
             address_rec._fast_init(domain, type_, class_, ttl, self._read_string(4), None, self.now)
             return address_rec
         if type_ in (_TYPE_CNAME, _TYPE_PTR):
-            pointer_rec = object.__new__(DNSPointer)
+            pointer_rec = DNSPointer.__new__(DNSPointer)
             pointer_rec._fast_init(domain, type_, class_, ttl, self._read_name(), self.now)
             return pointer_rec
         if type_ == _TYPE_TXT:
-            text_rec = object.__new__(DNSText)
+            text_rec = DNSText.__new__(DNSText)
             text_rec._fast_init(domain, type_, class_, ttl, self._read_string(length), self.now)
             return text_rec
         if type_ == _TYPE_SRV:
@@ -325,7 +325,7 @@ class DNSIncoming:
             priority = view[offset] << 8 | view[offset + 1]
             weight = view[offset + 2] << 8 | view[offset + 3]
             port = view[offset + 4] << 8 | view[offset + 5]
-            srv_rec = object.__new__(DNSService)
+            srv_rec = DNSService.__new__(DNSService)
             srv_rec._fast_init(
                 domain,
                 type_,
@@ -339,7 +339,7 @@ class DNSIncoming:
             )
             return srv_rec
         if type_ == _TYPE_HINFO:
-            hinfo_rec = object.__new__(DNSHinfo)
+            hinfo_rec = DNSHinfo.__new__(DNSHinfo)
             hinfo_rec._fast_init(
                 domain,
                 type_,
@@ -351,7 +351,7 @@ class DNSIncoming:
             )
             return hinfo_rec
         if type_ == _TYPE_AAAA:
-            address_rec = object.__new__(DNSAddress)
+            address_rec = DNSAddress.__new__(DNSAddress)
             address_rec._fast_init(
                 domain,
                 type_,
@@ -364,7 +364,7 @@ class DNSIncoming:
             return address_rec
         if type_ == _TYPE_NSEC:
             name_start = self.offset
-            nsec_rec = object.__new__(DNSNsec)
+            nsec_rec = DNSNsec.__new__(DNSNsec)
             nsec_rec._fast_init(
                 domain,
                 type_,

--- a/src/zeroconf/_protocol/incoming.py
+++ b/src/zeroconf/_protocol/incoming.py
@@ -246,7 +246,8 @@ class DNSIncoming:
             # The question has 2 unsigned shorts in network order
             type_ = view[offset] << 8 | view[offset + 1]
             class_ = view[offset + 2] << 8 | view[offset + 3]
-            question = DNSQuestion(name, type_, class_)
+            question = DNSQuestion.__new__(DNSQuestion)
+            question._fast_init(name, type_, class_)
             if question.unique:  # QU questions use the same bit as unique
                 self._has_qu_question = True
             questions.append(question)


### PR DESCRIPTION
Most of the time parsing incoming records is spent in object creation. We can use cython's fast new path, and than use cdefs to create them which avoids all the type conversions.