### PR TITLE
fix: move wheel builds to macos-13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-2019, macos-12, macos-latest]
+        os: [ubuntu-latest, windows-2019, macos-13, macos-latest]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/10721