### PR TITLE
feat: speed up AsyncServiceInfo

### DIFF
--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -955,5 +955,7 @@ class ServiceInfo(RecordUpdateListener):
         )
 
 
-class AsyncServiceInfo(ServiceInfo):
-    """An async version of ServiceInfo."""
+# Alias for backwards compatibility since
+# all async methods are now available on the
+# ServiceInfo object itself.
+AsyncServiceInfo = ServiceInfo


### PR DESCRIPTION
previously we subclassed ServiceInfo for AsyncServiceInfo but since its the same now, its faster to assign it as it avoids the slowdown of subclassed objects with cython