### PR TITLE
chore: remove legacy code <py39

### DIFF
--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -22,7 +22,6 @@ USA
 
 import asyncio
 import random
-import sys
 from typing import TYPE_CHECKING, Dict, List, Optional, Set, Union, cast
 
 from .._cache import DNSCache
@@ -76,8 +75,6 @@ from ..const import (
     _TYPE_SRV,
     _TYPE_TXT,
 )
-
-IPADDRESS_SUPPORTS_SCOPE_ID = sys.version_info >= (3, 9, 0)
 
 _IPVersion_All_value = IPVersion.All.value
 _IPVersion_V4Only_value = IPVersion.V4Only.value
@@ -250,7 +247,7 @@ class ServiceInfo(RecordUpdateListener):
         self._get_address_and_nsec_records_cache = None
 
         for address in value:
-            if IPADDRESS_SUPPORTS_SCOPE_ID and len(address) == 16 and self.interface_index is not None:
+            if len(address) == 16 and self.interface_index is not None:
                 addr = ip_bytes_and_scope_to_address(address, self.interface_index)
             else:
                 addr = cached_ip_addresses(address)

--- a/src/zeroconf/_utils/ipaddress.py
+++ b/src/zeroconf/_utils/ipaddress.py
@@ -20,22 +20,15 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
 USA
 """
 
-import sys
-from functools import lru_cache
+from functools import cache, lru_cache
 from ipaddress import AddressValueError, IPv4Address, IPv6Address, NetmaskValueError
 from typing import Any, Optional, Union
 
 from .._dns import DNSAddress
 from ..const import _TYPE_AAAA
 
-if sys.version_info >= (3, 9, 0):
-    from functools import cache
-else:
-    cache = lru_cache(maxsize=None)
-
 bytes_ = bytes
 int_ = int
-IPADDRESS_SUPPORTS_SCOPE_ID = sys.version_info >= (3, 9, 0)
 
 
 class ZeroconfIPv4Address(IPv4Address):
@@ -128,7 +121,7 @@ def get_ip_address_object_from_record(
     record: DNSAddress,
 ) -> Optional[Union[ZeroconfIPv4Address, ZeroconfIPv6Address]]:
     """Get the IP address object from the record."""
-    if IPADDRESS_SUPPORTS_SCOPE_ID and record.type == _TYPE_AAAA and record.scope_id:
+    if record.type == _TYPE_AAAA and record.scope_id:
         return ip_bytes_and_scope_to_address(record.address, record.scope_id)
     return cached_ip_addresses_wrapper(record.address)
 
@@ -146,7 +139,7 @@ def ip_bytes_and_scope_to_address(
 
 def str_without_scope_id(addr: Union[ZeroconfIPv4Address, ZeroconfIPv6Address]) -> str:
     """Return the string representation of the address without the scope id."""
-    if IPADDRESS_SUPPORTS_SCOPE_ID and addr.version == 6:
+    if addr.version == 6:
         address_str = str(addr)
         return address_str.partition("%")[0]
     return str(addr)

--- a/tests/services/test_info.py
+++ b/tests/services/test_info.py
@@ -7,7 +7,6 @@ import asyncio
 import logging
 import os
 import socket
-import sys
 import threading
 import unittest
 from ipaddress import ip_address
@@ -704,7 +703,6 @@ def test_multiple_addresses():
     assert info.addresses == [address, address]
     assert info.parsed_addresses() == [address_parsed, address_parsed]
     assert info.parsed_scoped_addresses() == [address_parsed, address_parsed]
-    ipaddress_supports_scope_id = sys.version_info >= (3, 9, 0)
 
     if has_working_ipv6() and not os.environ.get("SKIP_IPV6"):
         address_v6_parsed = "2001:db8::1"
@@ -751,9 +749,7 @@ def test_multiple_addresses():
             assert info.ip_addresses_by_version(r.IPVersion.All) == [
                 ip_address(address),
                 ip_address(address_v6),
-                ip_address(address_v6_ll_scoped_parsed)
-                if ipaddress_supports_scope_id
-                else ip_address(address_v6_ll),
+                ip_address(address_v6_ll_scoped_parsed),
             ]
             assert info.addresses_by_version(r.IPVersion.V4Only) == [address]
             assert info.ip_addresses_by_version(r.IPVersion.V4Only) == [ip_address(address)]
@@ -763,9 +759,7 @@ def test_multiple_addresses():
             ]
             assert info.ip_addresses_by_version(r.IPVersion.V6Only) == [
                 ip_address(address_v6),
-                ip_address(address_v6_ll_scoped_parsed)
-                if ipaddress_supports_scope_id
-                else ip_address(address_v6_ll),
+                ip_address(address_v6_ll_scoped_parsed),
             ]
             assert info.parsed_addresses() == [
                 address_parsed,
@@ -780,16 +774,15 @@ def test_multiple_addresses():
             assert info.parsed_scoped_addresses() == [
                 address_parsed,
                 address_v6_parsed,
-                address_v6_ll_scoped_parsed if ipaddress_supports_scope_id else address_v6_ll_parsed,
+                address_v6_ll_scoped_parsed,
             ]
             assert info.parsed_scoped_addresses(r.IPVersion.V4Only) == [address_parsed]
             assert info.parsed_scoped_addresses(r.IPVersion.V6Only) == [
                 address_v6_parsed,
-                address_v6_ll_scoped_parsed if ipaddress_supports_scope_id else address_v6_ll_parsed,
+                address_v6_ll_scoped_parsed,
             ]
 
 
-@unittest.skipIf(sys.version_info < (3, 9, 0), "Requires newer python")
 def test_scoped_addresses_from_cache():
     type_ = "_http._tcp.local."
     registration_name = f"scoped.{type_}"

--- a/tests/utils/test_ipaddress.py
+++ b/tests/utils/test_ipaddress.py
@@ -2,10 +2,6 @@
 
 """Unit tests for zeroconf._utils.ipaddress."""
 
-import sys
-
-import pytest
-
 from zeroconf import const
 from zeroconf._dns import DNSAddress
 from zeroconf._utils import ipaddress
@@ -52,7 +48,6 @@ def test_cached_ip_addresses_wrapper():
     assert ipv6.is_unspecified is True
 
 
-@pytest.mark.skipif(sys.version_info < (3, 9, 0), reason="scope_id is not supported")
 def test_get_ip_address_object_from_record():
     """Test the get_ip_address_object_from_record."""
     # not link local


### PR DESCRIPTION
Code for older python 3.9 is not required any more.

## Reference

#1451