### PR TITLE
fix: ensure cache does not return stale created and ttl values

### DIFF
--- a/src/zeroconf/_cache.pxd
+++ b/src/zeroconf/_cache.pxd
@@ -47,12 +47,19 @@ cdef class DNSCache:
     )
     cpdef list async_all_by_details(self, str name, unsigned int type_, unsigned int class_)
 
+    @cython.locals(
+        entries=dict
+    )
     cpdef list async_entries_with_name(self, str name)
 
+    @cython.locals(
+        entries=dict
+    )
     cpdef list async_entries_with_server(self, str name)
 
     @cython.locals(
         cached_entry=DNSRecord,
+        records=dict
     )
     cpdef DNSRecord get_by_details(self, str name, unsigned int type_, unsigned int class_)
 

--- a/src/zeroconf/_cache.pxd
+++ b/src/zeroconf/_cache.pxd
@@ -47,9 +47,9 @@ cdef class DNSCache:
     )
     cpdef list async_all_by_details(self, str name, unsigned int type_, unsigned int class_)
 
-    cpdef cython.dict async_entries_with_name(self, str name)
+    cpdef list async_entries_with_name(self, str name)
 
-    cpdef cython.dict async_entries_with_server(self, str name)
+    cpdef list async_entries_with_server(self, str name)
 
     @cython.locals(
         cached_entry=DNSRecord,

--- a/src/zeroconf/_cache.pxd
+++ b/src/zeroconf/_cache.pxd
@@ -47,14 +47,8 @@ cdef class DNSCache:
     )
     cpdef list async_all_by_details(self, str name, unsigned int type_, unsigned int class_)
 
-    @cython.locals(
-        entries=dict
-    )
     cpdef list async_entries_with_name(self, str name)
 
-    @cython.locals(
-        entries=dict
-    )
     cpdef list async_entries_with_server(self, str name)
 
     @cython.locals(
@@ -86,7 +80,15 @@ cdef class DNSCache:
     )
     cpdef void async_mark_unique_records_older_than_1s_to_expire(self, cython.set unique_types, object answers, double now)
 
-    cpdef entries_with_name(self, str name)
+    @cython.locals(
+        entries=dict
+    )
+    cpdef list entries_with_name(self, str name)
+
+    @cython.locals(
+        entries=dict
+    )
+    cpdef list entries_with_server(self, str server)
 
     @cython.locals(
         record=DNSRecord,

--- a/src/zeroconf/_cache.py
+++ b/src/zeroconf/_cache.py
@@ -149,7 +149,7 @@ class DNSCache:
         matches: List[DNSRecord] = []
         if records is None:
             return matches
-        for record in records:
+        for record in records.values():
             if type_ == record.type and class_ == record.class_:
                 matches.append(record)
         return matches

--- a/src/zeroconf/_cache.py
+++ b/src/zeroconf/_cache.py
@@ -154,21 +154,25 @@ class DNSCache:
                 matches.append(record)
         return matches
 
-    def async_entries_with_name(self, name: str) -> Dict[DNSRecord, DNSRecord]:
+    def async_entries_with_name(self, name: str) -> List[DNSRecord]:
         """Returns a dict of entries whose key matches the name.
 
         This function is not threadsafe and must be called from
         the event loop.
         """
-        return self.cache.get(name.lower()) or {}
+        if entries := self.cache.get(name.lower()):
+            return list(entries.values())
+        return []
 
-    def async_entries_with_server(self, name: str) -> Dict[DNSRecord, DNSRecord]:
+    def async_entries_with_server(self, name: str) -> List[DNSRecord]:
         """Returns a dict of entries whose key matches the server.
 
         This function is not threadsafe and must be called from
         the event loop.
         """
-        return self.service_cache.get(name.lower()) or {}
+        if entries := self.service_cache.get(name.lower()):
+            return list(entries.values())
+        return []
 
     # The below functions are threadsafe and do not need to be run in the
     # event loop, however they all make copies so they significantly
@@ -215,11 +219,11 @@ class DNSCache:
 
     def entries_with_server(self, server: str) -> List[DNSRecord]:
         """Returns a list of entries whose server matches the name."""
-        return list(self.service_cache.get(server.lower(), []))
+        return self.async_entries_with_server(server)
 
     def entries_with_name(self, name: str) -> List[DNSRecord]:
         """Returns a list of entries whose key matches the name."""
-        return list(self.cache.get(name.lower(), []))
+        return self.async_entries_with_name(name)
 
     def current_entry_with_name_and_alias(self, name: str, alias: str) -> Optional[DNSRecord]:
         now = current_time_millis()

--- a/src/zeroconf/_cache.py
+++ b/src/zeroconf/_cache.py
@@ -204,7 +204,7 @@ class DNSCache:
         records = self.cache.get(key)
         if records is None:
             return None
-        for cached_entry in reversed(list(records)):
+        for cached_entry in reversed(list(records.values())):
             if type_ == cached_entry.type and class_ == cached_entry.class_:
                 return cached_entry
         return None

--- a/src/zeroconf/_cache.py
+++ b/src/zeroconf/_cache.py
@@ -183,7 +183,7 @@ class DNSCache:
         matching entry."""
         if isinstance(entry, _UNIQUE_RECORD_TYPES):
             return self.cache.get(entry.key, {}).get(entry)
-        for cached_entry in reversed(self.cache.get(entry.key, {}).values()):
+        for cached_entry in reversed(list(self.cache.get(entry.key, {}).values())):
             if entry.__eq__(cached_entry):
                 return cached_entry
         return None
@@ -215,7 +215,7 @@ class DNSCache:
         records = self.cache.get(key)
         if records is None:
             return []
-        return [entry for entry in records.values() if type_ == entry.type and class_ == entry.class_]
+        return [entry for entry in list(records.values()) if type_ == entry.type and class_ == entry.class_]
 
     def entries_with_server(self, server: str) -> List[DNSRecord]:
         """Returns a list of entries whose server matches the name."""

--- a/src/zeroconf/_cache.py
+++ b/src/zeroconf/_cache.py
@@ -160,9 +160,7 @@ class DNSCache:
         This function is not threadsafe and must be called from
         the event loop.
         """
-        if entries := self.cache.get(name.lower()):
-            return list(entries.values())
-        return []
+        return self.entries_with_name(name)
 
     def async_entries_with_server(self, name: str) -> List[DNSRecord]:
         """Returns a dict of entries whose key matches the server.
@@ -170,9 +168,7 @@ class DNSCache:
         This function is not threadsafe and must be called from
         the event loop.
         """
-        if entries := self.service_cache.get(name.lower()):
-            return list(entries.values())
-        return []
+        return self.entries_with_server(name)
 
     # The below functions are threadsafe and do not need to be run in the
     # event loop, however they all make copies so they significantly
@@ -219,11 +215,15 @@ class DNSCache:
 
     def entries_with_server(self, server: str) -> List[DNSRecord]:
         """Returns a list of entries whose server matches the name."""
-        return self.async_entries_with_server(server)
+        if entries := self.service_cache.get(server.lower()):
+            return list(entries.values())
+        return []
 
     def entries_with_name(self, name: str) -> List[DNSRecord]:
         """Returns a list of entries whose key matches the name."""
-        return self.async_entries_with_name(name)
+        if entries := self.cache.get(name.lower()):
+            return list(entries.values())
+        return []
 
     def current_entry_with_name_and_alias(self, name: str, alias: str) -> Optional[DNSRecord]:
         now = current_time_millis()

--- a/src/zeroconf/_cache.py
+++ b/src/zeroconf/_cache.py
@@ -215,7 +215,7 @@ class DNSCache:
         records = self.cache.get(key)
         if records is None:
             return []
-        return [entry for entry in list(records) if type_ == entry.type and class_ == entry.class_]
+        return [entry for entry in records.values() if type_ == entry.type and class_ == entry.class_]
 
     def entries_with_server(self, server: str) -> List[DNSRecord]:
         """Returns a list of entries whose server matches the name."""

--- a/src/zeroconf/_cache.py
+++ b/src/zeroconf/_cache.py
@@ -183,7 +183,7 @@ class DNSCache:
         matching entry."""
         if isinstance(entry, _UNIQUE_RECORD_TYPES):
             return self.cache.get(entry.key, {}).get(entry)
-        for cached_entry in reversed(list(self.cache.get(entry.key, []))):
+        for cached_entry in reversed(self.cache.get(entry.key, {}).values()):
             if entry.__eq__(cached_entry):
                 return cached_entry
         return None

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -279,3 +279,21 @@ class TestDNSCacheAPI(unittest.TestCase):
         cache = r.DNSCache()
         cache.async_add_records([record1, record2])
         assert cache.names() == ["irrelevant"]
+
+
+def test_async_entries_with_name_returns_newest_record():
+    cache = r.DNSCache()
+    record1 = r.DNSAddress("a", const._TYPE_A, const._CLASS_IN, 1, b"a", created=1.0)
+    record2 = r.DNSAddress("a", const._TYPE_A, const._CLASS_IN, 1, b"a", created=2.0)
+    cache.async_add_records([record1])
+    cache.async_add_records([record2])
+    assert next(iter(cache.async_entries_with_name("a"))) is record2
+
+
+def test_async_entries_with_server_returns_newest_record():
+    cache = r.DNSCache()
+    record1 = r.DNSService("a", const._TYPE_SRV, const._CLASS_IN, 1, 1, 1, 1, "a", created=1.0)
+    record2 = r.DNSService("a", const._TYPE_SRV, const._CLASS_IN, 1, 1, 1, 1, "a", created=2.0)
+    cache.async_add_records([record1])
+    cache.async_add_records([record2])
+    assert next(iter(cache.async_entries_with_server("a"))) is record2

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -308,6 +308,15 @@ def test_async_get_returns_newest_record():
     assert cache.get(record2) is record2
 
 
+def test_async_get_returns_newest_nsec_record():
+    cache = r.DNSCache()
+    record1 = r.DNSNsec("a", const._TYPE_NSEC, const._CLASS_IN, 1, "a", [], created=1.0)
+    record2 = r.DNSNsec("a", const._TYPE_NSEC, const._CLASS_IN, 1, "a", [], created=2.0)
+    cache.async_add_records([record1])
+    cache.async_add_records([record2])
+    assert cache.get(record2) is record2
+
+
 def test_get_by_details_returns_newest_record():
     cache = r.DNSCache()
     record1 = r.DNSAddress("a", const._TYPE_A, const._CLASS_IN, 1, b"a", created=1.0)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -326,3 +326,14 @@ def test_get_all_by_details_returns_newest_record():
     records = cache.get_all_by_details("a", const._TYPE_A, const._CLASS_IN)
     assert len(records) == 1
     assert records[0] is record2
+
+
+def test_async_get_all_by_details_returns_newest_record():
+    cache = r.DNSCache()
+    record1 = r.DNSAddress("a", const._TYPE_A, const._CLASS_IN, 1, b"a", created=1.0)
+    record2 = r.DNSAddress("a", const._TYPE_A, const._CLASS_IN, 1, b"a", created=2.0)
+    cache.async_add_records([record1])
+    cache.async_add_records([record2])
+    records = cache.async_all_by_details("a", const._TYPE_A, const._CLASS_IN)
+    assert len(records) == 1
+    assert records[0] is record2

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -297,3 +297,21 @@ def test_async_entries_with_server_returns_newest_record():
     cache.async_add_records([record1])
     cache.async_add_records([record2])
     assert next(iter(cache.async_entries_with_server("a"))) is record2
+
+
+def test_async_get_returns_newest_record():
+    cache = r.DNSCache()
+    record1 = r.DNSAddress("a", const._TYPE_A, const._CLASS_IN, 1, b"a", created=1.0)
+    record2 = r.DNSAddress("a", const._TYPE_A, const._CLASS_IN, 1, b"a", created=2.0)
+    cache.async_add_records([record1])
+    cache.async_add_records([record2])
+    assert cache.get(record2) is record2
+
+
+def test_get_by_details_returns_newest_record():
+    cache = r.DNSCache()
+    record1 = r.DNSAddress("a", const._TYPE_A, const._CLASS_IN, 1, b"a", created=1.0)
+    record2 = r.DNSAddress("a", const._TYPE_A, const._CLASS_IN, 1, b"a", created=2.0)
+    cache.async_add_records([record1])
+    cache.async_add_records([record2])
+    assert cache.get_by_details("a", const._TYPE_A, const._CLASS_IN) is record2

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -315,3 +315,14 @@ def test_get_by_details_returns_newest_record():
     cache.async_add_records([record1])
     cache.async_add_records([record2])
     assert cache.get_by_details("a", const._TYPE_A, const._CLASS_IN) is record2
+
+
+def test_get_all_by_details_returns_newest_record():
+    cache = r.DNSCache()
+    record1 = r.DNSAddress("a", const._TYPE_A, const._CLASS_IN, 1, b"a", created=1.0)
+    record2 = r.DNSAddress("a", const._TYPE_A, const._CLASS_IN, 1, b"a", created=2.0)
+    cache.async_add_records([record1])
+    cache.async_add_records([record2])
+    records = cache.get_all_by_details("a", const._TYPE_A, const._CLASS_IN)
+    assert len(records) == 1
+    assert records[0] is record2

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -337,3 +337,15 @@ def test_async_get_all_by_details_returns_newest_record():
     records = cache.async_all_by_details("a", const._TYPE_A, const._CLASS_IN)
     assert len(records) == 1
     assert records[0] is record2
+
+
+def test_async_get_unique_returns_newest_record():
+    cache = r.DNSCache()
+    record1 = r.DNSPointer("a", const._TYPE_PTR, const._CLASS_IN, 1, "a", created=1.0)
+    record2 = r.DNSPointer("a", const._TYPE_PTR, const._CLASS_IN, 1, "a", created=2.0)
+    cache.async_add_records([record1])
+    cache.async_add_records([record2])
+    record = cache.async_get_unique(record1)
+    assert record is record2
+    record = cache.async_get_unique(record2)
+    assert record is record2


### PR DESCRIPTION
This PR corrects a severe flaw in the cache design that was noticed while implementing https://github.com/python-zeroconf/python-zeroconf/pull/1465

The cache could return old stale records (incorrect created/ttls -- the contents of the record was correct) when the record was replaced in the underlying dict since the key is not updated (only the value is).

The following functions where affected:

`cache.async_entries_with_name`
`cache.async_entries_with_server`
`cache.async_all_by_details`
`cache.entries_with_name`
`cache.entries_with_server`
`cache.get_all_by_details`
`cache.get_by_details`
`cache.get` (never used)

Technically breaking change:
`async_entries_with_name` and `async_entries_with_server` now return a `list` instead of a `dict` which makes `entries_with_name` and `entries_with_server`. They were likely only used internally