### PR TITLE
chore(tests): replace `lru_cache` with `cache`

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -23,7 +23,7 @@ USA
 import asyncio
 import socket
 import time
-from functools import lru_cache
+from functools import cache
 from typing import List, Optional, Set
 from unittest import mock
 
@@ -62,7 +62,7 @@ def _wait_for_start(zc: Zeroconf) -> None:
     asyncio.run_coroutine_threadsafe(zc.async_wait_for_start(), zc.loop).result()
 
 
-@lru_cache(maxsize=None)
+@cache
 def has_working_ipv6():
     """Return True if if the system can bind an IPv6 address."""
     if not socket.has_ipv6:


### PR DESCRIPTION
Naming was simplified with py3.9

### Reference

Require py3.9 #1451