### PR TITLE
feat: add simple address resolvers and examples

### DIFF
--- a/examples/resolve_address.py
+++ b/examples/resolve_address.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+"""Example of resolving a name to an IPv4 address."""
+
+import asyncio
+import logging
+import sys
+
+from zeroconf import AddressResolver, IPVersion
+from zeroconf.asyncio import AsyncZeroconf
+
+
+async def resolve_name(name: str) -> None:
+    aiozc = AsyncZeroconf(interfaces=["127.0.0.1"])
+    await aiozc.zeroconf.async_wait_for_start()
+    resolver = AddressResolver(name)
+    if await resolver.async_request(aiozc.zeroconf, 3000):
+        print(f"{name} IP addresses:", resolver.ip_addresses_by_version(IPVersion.All))
+    else:
+        print(f"Name {name} not resolved")
+    await aiozc.async_close()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    argv = sys.argv.copy()
+    if "--debug" in argv:
+        logging.getLogger("zeroconf").setLevel(logging.DEBUG)
+        argv.remove("--debug")
+
+    if len(argv) < 2 or not argv[1]:
+        raise ValueError("Usage: resolve_address.py [--debug] <name>")
+
+    name = argv[1]
+    if not name.endswith("."):
+        name += "."
+
+    asyncio.run(resolve_name(name))

--- a/examples/resolve_address.py
+++ b/examples/resolve_address.py
@@ -11,7 +11,7 @@ from zeroconf.asyncio import AsyncZeroconf
 
 
 async def resolve_name(name: str) -> None:
-    aiozc = AsyncZeroconf(interfaces=["127.0.0.1"])
+    aiozc = AsyncZeroconf()
     await aiozc.zeroconf.async_wait_for_start()
     resolver = AddressResolver(name)
     if await resolver.async_request(aiozc.zeroconf, 3000):

--- a/examples/resolve_address.py
+++ b/examples/resolve_address.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-"""Example of resolving a name to an IPv4 address."""
+"""Example of resolving a name to an IP address."""
 
 import asyncio
 import logging

--- a/src/zeroconf/__init__.py
+++ b/src/zeroconf/__init__.py
@@ -58,6 +58,9 @@ from ._services import (  # noqa # import needed for backwards compat
 from ._services.browser import ServiceBrowser
 from ._services.info import (  # noqa # import needed for backwards compat
     ServiceInfo,
+    AddressResolver,
+    AddressResolverIPv4,
+    AddressResolverIPv6,
     instance_name_from_service_info,
 )
 from ._services.registry import (  # noqa # import needed for backwards compat

--- a/src/zeroconf/_services/info.pxd
+++ b/src/zeroconf/_services/info.pxd
@@ -22,6 +22,9 @@ from .._utils.ipaddress cimport (
 )
 from .._utils.time cimport current_time_millis
 
+cdef cython.set _TYPE_AAAA_RECORDS
+cdef cython.set _TYPE_A_RECORDS
+cdef cython.set _TYPE_A_AAAA_RECORDS
 
 cdef object _resolve_all_futures_to_none
 
@@ -75,6 +78,7 @@ cdef class ServiceInfo(RecordUpdateListener):
     cdef public DNSText _dns_text_cache
     cdef public cython.list _dns_address_cache
     cdef public cython.set _get_address_and_nsec_records_cache
+    cdef public cython.set _query_record_types
 
     @cython.locals(record_update=RecordUpdate, update=bint, cache=DNSCache)
     cpdef void async_update_records(self, object zc, double now, cython.list records)
@@ -155,3 +159,12 @@ cdef class ServiceInfo(RecordUpdateListener):
     cdef double _get_initial_delay(self)
 
     cdef double _get_random_delay(self)
+
+cdef class AddressResolver(ServiceInfo):
+    pass
+
+cdef class AddressResolverIPv6(ServiceInfo):
+    pass
+
+cdef class AddressResolverIPv4(ServiceInfo):
+    pass

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -88,6 +88,10 @@ _IPVersion_V4Only_value = IPVersion.V4Only.value
 # the A/AAAA/SRV records for a host.
 _AVOID_SYNC_DELAY_RANDOM_INTERVAL = (20, 120)
 
+_TYPE_AAAA_RECORDS = {_TYPE_AAAA}
+_TYPE_A_RECORDS = {_TYPE_A}
+_TYPE_A_AAAA_RECORDS = {_TYPE_A, _TYPE_AAAA}
+
 bytes_ = bytes
 float_ = float
 int_ = int
@@ -968,7 +972,7 @@ class AddressResolver(ServiceInfo):
     def __init__(self, server: str) -> None:
         """Initialize the AddressResolver."""
         super().__init__(server, server, server=server)
-        self._query_record_types = {_TYPE_A, _TYPE_AAAA}
+        self._query_record_types = _TYPE_A_AAAA_RECORDS
 
     @property
     def _is_complete(self) -> bool:
@@ -982,7 +986,7 @@ class AddressResolverIPv6(ServiceInfo):
     def __init__(self, server: str) -> None:
         """Initialize the AddressResolver."""
         super().__init__(server, server, server=server)
-        self._query_record_types = {_TYPE_AAAA}
+        self._query_record_types = _TYPE_AAAA_RECORDS
 
     @property
     def _is_complete(self) -> bool:
@@ -996,7 +1000,7 @@ class AddressResolverIPv4(ServiceInfo):
     def __init__(self, server: str) -> None:
         """Initialize the AddressResolver."""
         super().__init__(server, server, server=server)
-        self._query_record_types = {_TYPE_A}
+        self._query_record_types = _TYPE_A_RECORDS
 
     @property
     def _is_complete(self) -> bool:


### PR DESCRIPTION
This pattern gets copied into a lot of downstream likes including `aioesphomeapi`, `esphome`, https://github.com/aio-libs/aiohttp-asyncmdnsresolver, etc

We can provide these as built-ins since its a common use case

```
(zeroconf-py3.12) bdraco@Mac python-zeroconf % python3 examples/resolve_address.py homeassistant.local.
DEBUG:asyncio:Using selector: KqueueSelector
homeassistant.local. IP addresses: [ZeroconfIPv4Address('192.168.x.x')]
(zeroconf-py3.12) bdraco@Mac python-zeroconf % 
```