### PR TITLE
chore: cleanup typing in net utils

### DIFF
--- a/src/zeroconf/_utils/net.py
+++ b/src/zeroconf/_utils/net.py
@@ -85,7 +85,7 @@ def get_all_addresses_v6() -> list[tuple[tuple[str, int, int], int]]:
     )
 
 
-def ip6_to_address_and_index(adapters: list[Any], ip: str) -> tuple[tuple[str, int, int], int]:
+def ip6_to_address_and_index(adapters: list[ifaddr.Adapter], ip: str) -> tuple[tuple[str, int, int], int]:
     if "%" in ip:
         ip = ip[: ip.index("%")]  # Strip scope_id.
     ipaddr = ipaddress.ip_address(ip)
@@ -101,7 +101,7 @@ def ip6_to_address_and_index(adapters: list[Any], ip: str) -> tuple[tuple[str, i
     raise RuntimeError(f"No adapter found for IP address {ip}")
 
 
-def interface_index_to_ip6_address(adapters: list[Any], index: int) -> tuple[str, int, int]:
+def interface_index_to_ip6_address(adapters: list[ifaddr.Adapter], index: int) -> tuple[str, int, int]:
     for adapter in adapters:
         if adapter.index == index:
             for adapter_ip in adapter.ips:
@@ -414,8 +414,7 @@ def create_sockets(
     return listen_socket, respond_sockets
 
 
-def get_errno(e: Exception) -> int:
-    assert isinstance(e, socket.error)
+def get_errno(e: OSError) -> int:
     return cast(int, e.args[0])
 
 

--- a/src/zeroconf/_utils/net.py
+++ b/src/zeroconf/_utils/net.py
@@ -92,11 +92,12 @@ def ip6_to_address_and_index(adapters: list[ifaddr.Adapter], ip: str) -> tuple[t
     for adapter in adapters:
         for adapter_ip in adapter.ips:
             # IPv6 addresses are represented as tuples
-            if isinstance(adapter_ip.ip, tuple) and ipaddress.ip_address(adapter_ip.ip[0]) == ipaddr:
-                return (
-                    cast(tuple[str, int, int], adapter_ip.ip),
-                    cast(int, adapter.index),
-                )
+            if (
+                adapter.index is not None
+                and isinstance(adapter_ip.ip, tuple)
+                and ipaddress.ip_address(adapter_ip.ip[0]) == ipaddr
+            ):
+                return (adapter_ip.ip, adapter.index)
 
     raise RuntimeError(f"No adapter found for IP address {ip}")
 
@@ -107,7 +108,7 @@ def interface_index_to_ip6_address(adapters: list[ifaddr.Adapter], index: int) -
             for adapter_ip in adapter.ips:
                 # IPv6 addresses are represented as tuples
                 if isinstance(adapter_ip.ip, tuple):
-                    return cast(tuple[str, int, int], adapter_ip.ip)
+                    return adapter_ip.ip
 
     raise RuntimeError(f"No adapter found for index {index}")
 


### PR DESCRIPTION
`ifaddr` didn't use to be typed until https://github.com/ifaddr/ifaddr/pull/53 so we can clean this up a bit now