### PR TITLE
fix: hold a strong reference to the AsyncEngine setup task

### DIFF
--- a/src/zeroconf/_engine.py
+++ b/src/zeroconf/_engine.py
@@ -91,7 +91,8 @@ class AsyncEngine:
         self._async_schedule_next_cache_cleanup()
         await self._async_create_endpoints()
         assert self.running_future is not None
-        self.running_future.set_result(True)
+        if not self.running_future.done():
+            self.running_future.set_result(True)
         if loop_thread_ready:
             loop_thread_ready.set()
 


### PR DESCRIPTION
https://docs.python.org/3/library/asyncio-task.html#creating-tasks
> Important Save a reference to the result of this function, to avoid a task disappearing mid-execution. The event loop only keeps weak references to tasks. A task that isn’t referenced elsewhere may get garbage collected at any time, even before it’s done. For reliable “fire-and-forget” background tasks, gather them in a collection: