### PR TITLE
DNM: estimate boundcheck cost

### DIFF
--- a/src/zeroconf/_protocol/incoming.py
+++ b/src/zeroconf/_protocol/incoming.py
@@ -1,3 +1,4 @@
+# cython: language_level=3, boundscheck=False
 """Multicast DNS Service Discovery for Python, v0.14-wmcbrine
 Copyright 2003 Paul Scott-Murphy, 2014 William McBrine
 


### PR DESCRIPTION
We have static data and every byte gets boundchecked.. we could turn it off and do it for the whole block

do not merge: this PR is not safe and only for running benchmarks