### PR TITLE
chore: benchmark string slicing options

### DIFF
--- a/src/zeroconf/_protocol/incoming.pxd
+++ b/src/zeroconf/_protocol/incoming.pxd
@@ -102,9 +102,13 @@ cdef class DNSIncoming:
 
     @cython.locals(
         length="unsigned int",
+        cstr="const unsigned char *"
     )
     cdef str _read_character_string(self)
 
+    @cython.locals(
+        cstr="const unsigned char *"
+    )
     cdef bytes _read_string(self, unsigned int length)
 
     @cython.locals(

--- a/src/zeroconf/_protocol/incoming.pxd
+++ b/src/zeroconf/_protocol/incoming.pxd
@@ -81,7 +81,8 @@ cdef class DNSIncoming:
         link="unsigned int",
         link_data="unsigned int",
         link_py_int=object,
-        linked_labels=cython.list
+        linked_labels=cython.list,
+        cstr="const unsigned char *"
     )
     cdef unsigned int _decode_labels_at_offset(self, unsigned int off, cython.list labels, cython.set seen_pointers)
 

--- a/src/zeroconf/_protocol/incoming.py
+++ b/src/zeroconf/_protocol/incoming.py
@@ -430,7 +430,8 @@ class DNSIncoming:
 
             if length < 0x40:
                 label_idx = off + DNS_COMPRESSION_HEADER_LEN
-                labels.append(self.data[label_idx : label_idx + length].decode("utf-8", "replace"))
+                cstr = self.data
+                labels.append(cstr[label_idx : label_idx + length].decode("utf-8", "replace"))
                 off += DNS_COMPRESSION_HEADER_LEN + length
                 continue
 

--- a/src/zeroconf/_protocol/incoming.py
+++ b/src/zeroconf/_protocol/incoming.py
@@ -260,13 +260,15 @@ class DNSIncoming:
         """Reads a character string from the packet"""
         length = self.view[self.offset]
         self.offset += 1
-        info = self.data[self.offset : self.offset + length].decode("utf-8", "replace")
+        cstr = self.data
+        info = cstr[self.offset : self.offset + length].decode("utf-8", "replace")
         self.offset += length
         return info
 
     def _read_string(self, length: _int) -> bytes:
         """Reads a string of a given length from the packet"""
-        info = self.data[self.offset : self.offset + length]
+        cstr = self.data
+        info = cstr[self.offset : self.offset + length]
         self.offset += length
         return info
 


### PR DESCRIPTION
`__Pyx_PyBytes_AsString` -> `__Pyx_PyBytes_FromStringAndSize` seems to be significantly faster than `PySequence_GetSlice`
<img width="367" alt="Screenshot 2025-03-10 at 8 34 47 PM" src="https://github.com/user-attachments/assets/5f691695-c617-4a7b-924e-fffea870e76c" />

But we do need to worry about bounds checking if we do this
