### PR TITLE
fix: address non-working socket configuration

### DIFF
--- a/src/zeroconf/_utils/net.py
+++ b/src/zeroconf/_utils/net.py
@@ -168,8 +168,17 @@ def normalize_interface_choice(
     result: list[str | tuple[tuple[str, int, int], int]] = []
     if choice is InterfaceChoice.Default:
         if ip_version != IPVersion.V4Only:
-            # IPv6 multicast uses interface 0 to mean the default
-            result.append((("", 0, 0), 0))
+            # IPv6 multicast uses interface 0 to mean the default. However,
+            # the default interface can't be used for outgoing IPv6 multicast
+            # requests. In a way, interface choice default isn't really working
+            # with IPv6. Inform the user accordingly.
+            message = (
+                "IPv6 multicast requests can't be sent using default interface. "
+                "Use V4Only, InterfaceChoice.All or an explicit list of interfaces."
+            )
+            log.error(message)
+            warnings.warn(message, DeprecationWarning, stacklevel=2)
+            result.append((("::", 0, 0), 0))
         if ip_version != IPVersion.V6Only:
             result.append("0.0.0.0")
     elif choice is InterfaceChoice.All:
@@ -220,28 +229,33 @@ def set_so_reuseport_if_available(s: socket.socket) -> None:
             raise
 
 
-def set_mdns_port_socket_options_for_ip_version(
+def set_respond_socket_multicast_options(
     s: socket.socket,
-    bind_addr: tuple[str] | tuple[str, int, int],
     ip_version: IPVersion,
 ) -> None:
-    """Set ttl/hops and loop for mdns port."""
-    if ip_version != IPVersion.V6Only:
-        ttl = struct.pack(b"B", 255)
-        loop = struct.pack(b"B", 1)
+    """Set ttl/hops and loop for mDNS respond socket."""
+    if ip_version == IPVersion.V4Only:
         # OpenBSD needs the ttl and loop values for the IP_MULTICAST_TTL and
         # IP_MULTICAST_LOOP socket options as an unsigned char.
-        try:
-            s.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, ttl)
-            s.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_LOOP, loop)
-        except OSError as e:
-            if bind_addr[0] != "" or get_errno(e) != errno.EINVAL:  # Fails to set on MacOS
-                raise
-
-    if ip_version != IPVersion.V4Only:
+        ttl = struct.pack(b"B", 255)
+        loop = struct.pack(b"B", 1)
+        s.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, ttl)
+        s.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_LOOP, loop)
+    elif ip_version == IPVersion.V6Only:
         # However, char doesn't work here (at least on Linux)
         s.setsockopt(_IPPROTO_IPV6, socket.IPV6_MULTICAST_HOPS, 255)
         s.setsockopt(_IPPROTO_IPV6, socket.IPV6_MULTICAST_LOOP, True)
+    else:
+        # A shared sender socket is not really possible, especially with link-local
+        # multicast addresses (ff02::/16), the kernel needs to know which interface
+        # to use for routing.
+        #
+        # It seems that macOS even refuses to take IPv4 socket options if this is an
+        # AF_INET6 socket.
+        #
+        # In theory we could reconfigure the socket on each send, but that is not
+        # really practical for Python Zerconf.
+        raise RuntimeError("Dual-stack responder socket not supported")
 
 
 def new_socket(
@@ -265,9 +279,6 @@ def new_socket(
 
     s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     set_so_reuseport_if_available(s)
-
-    if port == _MDNS_PORT:
-        set_mdns_port_socket_options_for_ip_version(s, bind_addr, ip_version)
 
     if apple_p2p:
         # SO_RECV_ANYIF = 0x1104
@@ -424,6 +435,7 @@ def new_respond_socket(
             socket.IP_MULTICAST_IF,
             socket.inet_aton(cast(str, interface)),
         )
+    set_respond_socket_multicast_options(respond_socket, IPVersion.V6Only if is_v6 else IPVersion.V4Only)
     return respond_socket
 
 
@@ -440,11 +452,13 @@ def create_sockets(
 
     normalized_interfaces = normalize_interface_choice(interfaces, ip_version)
 
-    # If we are using InterfaceChoice.Default we can use
+    # If we are using InterfaceChoice.Default with only IPv4 or only IPv6, we can use
     # a single socket to listen and respond.
-    if not unicast and interfaces is InterfaceChoice.Default:
+    if not unicast and interfaces is InterfaceChoice.Default and ip_version != IPVersion.All:
         for interface in normalized_interfaces:
             add_multicast_member(cast(socket.socket, listen_socket), interface)
+        # Sent responder socket options to the dual-use listen socket
+        set_respond_socket_multicast_options(cast(socket.socket, listen_socket), ip_version)
         return listen_socket, [cast(socket.socket, listen_socket)]
 
     respond_sockets = []

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -11,6 +11,7 @@ import threading
 import time
 import unittest
 import unittest.mock
+import warnings
 from typing import cast
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -87,16 +88,26 @@ class Framework(unittest.TestCase):
     def test_launch_and_close_v4_v6(self):
         rv = r.Zeroconf(interfaces=r.InterfaceChoice.All, ip_version=r.IPVersion.All)
         rv.close()
-        rv = r.Zeroconf(interfaces=r.InterfaceChoice.Default, ip_version=r.IPVersion.All)
-        rv.close()
+        with warnings.catch_warnings(record=True) as warned:
+            rv = r.Zeroconf(interfaces=r.InterfaceChoice.Default, ip_version=r.IPVersion.All)
+            rv.close()
+            first_warning = warned[0]
+            assert "IPv6 multicast requests can't be sent using default interface" in str(
+                first_warning.message
+            )
 
     @unittest.skipIf(not has_working_ipv6(), "Requires IPv6")
     @unittest.skipIf(os.environ.get("SKIP_IPV6"), "IPv6 tests disabled")
     def test_launch_and_close_v6_only(self):
         rv = r.Zeroconf(interfaces=r.InterfaceChoice.All, ip_version=r.IPVersion.V6Only)
         rv.close()
-        rv = r.Zeroconf(interfaces=r.InterfaceChoice.Default, ip_version=r.IPVersion.V6Only)
-        rv.close()
+        with warnings.catch_warnings(record=True) as warned:
+            rv = r.Zeroconf(interfaces=r.InterfaceChoice.Default, ip_version=r.IPVersion.V6Only)
+            rv.close()
+            first_warning = warned[0]
+            assert "IPv6 multicast requests can't be sent using default interface" in str(
+                first_warning.message
+            )
 
     @unittest.skipIf(sys.platform == "darwin", reason="apple_p2p failure path not testable on mac")
     def test_launch_and_close_apple_p2p_not_mac(self):


### PR DESCRIPTION
For IPv6, a shared listener/responder socket is not really possible when sending to link-local IPv6 multicast addresses (ff02::/16): The kernel needs to know which interface to use for routing.

On IPv4, this is historically a bit different, the kernel just uses what it deems the primary/best route interface based on the routing table. But for IPv6, a message is rejected by Linux with OSError no 99 "Cannot assign requested address" and OSError no 65 "No route to host" on macOS.

Removing the InterfaceChoice.Default config when IPv6 is enabled would be a major breaking change. Instead, inform the user with an error log message and a DeprecationWarning that this is not a working configuration.

As a further cleanup, move the socket options for sending multicast packets out of the common socket creation code. For listen only sockets those settings are not needed.

Also don't use a shared listener/responder sockets for dual-stack mode. Using a shared socket for IPv4 and IPv6 is especially problematic on macOS, where the kernel does not support this and even rejects socket options for IPv4 multicast in this case.

With a separate IPv4 socket, this actually fixes the IPv4 multicast query sending when using the default interface. The sending will only fail on the IPv6 socket, so IPv4 requests will make it through.

With that, the macOS error addressed in #392 is not a problem anymore. Actually, we would like to get an exception in case we get into this combination, so remove the explicit exception handling.

Fixes: #1562

chore: use new_respond_socket for all responder sockets

This unifies the socket creation for all interface specific responder sockets to use the new_respond_socket function. If the responder socket isn't used for multicast, it won't get bound to the interface explicitly. This mostly deduplicates code and makes it easier to maintain.