### PR TITLE
chore: some Cython 3.1.0rc1 build failures

### DIFF
--- a/src/zeroconf/_listener.pxd
+++ b/src/zeroconf/_listener.pxd
@@ -50,7 +50,7 @@ cdef class AsyncListener:
 
     cpdef _respond_query(
         self,
-        object msg,
+        DNSIncoming msg,
         object addr,
         object port,
         object transport,


### PR DESCRIPTION
Fix the few build failures I've hit with Cython 3.1.0rc1. Unfortunately, I'm stuck at:

```
Error compiling Cython file:
------------------------------------------------------------
...
        version: IPVersion = IPVersion.All,
    ) -> list[DNSAddress]:
        """Return matching DNSAddress from ServiceInfo."""
        return self._dns_addresses(override_ttl, version)

    def _dns_addresses(
    ^
------------------------------------------------------------

src/zeroconf/_services/info.py:586:4: Signature not compatible with previous declaration

Error compiling Cython file:
------------------------------------------------------------
...
    cpdef addresses_by_version(self, object version)

    cpdef ip_addresses_by_version(self, object version)

    @cython.locals(cacheable=cython.bint)
    cdef cython.list _dns_addresses(self, object override_ttls, object version)
                                   ^
------------------------------------------------------------

src/zeroconf/_services/info.pxd:124:35: Previous declaration is here
```

and the like. I suspect it doesn't like `override_ttls` but can't figure out how to make it work.