### PR TITLE
chore: migrate TTL to only accept int

### DIFF
--- a/src/zeroconf/_cache.pxd
+++ b/src/zeroconf/_cache.pxd
@@ -83,5 +83,5 @@ cdef class DNSCache:
         self,
         DNSRecord record,
         double now,
-        cython.float ttl
+        unsigned int ttl
     )

--- a/src/zeroconf/_cache.py
+++ b/src/zeroconf/_cache.py
@@ -317,7 +317,7 @@ class DNSCache:
                     # Expire in 1s
                     self._async_set_created_ttl(record, now, 1)
 
-    def _async_set_created_ttl(self, record: DNSRecord, now: _float, ttl: _float) -> None:
+    def _async_set_created_ttl(self, record: DNSRecord, now: _float, ttl: _int) -> None:
         """Set the created time and ttl of a record."""
         # It would be better if we made a copy instead of mutating the record
         # in place, but records currently don't have a copy method.

--- a/src/zeroconf/_dns.pxd
+++ b/src/zeroconf/_dns.pxd
@@ -44,10 +44,10 @@ cdef class DNSQuestion(DNSEntry):
 
 cdef class DNSRecord(DNSEntry):
 
-    cdef public cython.float ttl
+    cdef public unsigned int ttl
     cdef public double created
 
-    cdef _fast_init_record(self, str name, cython.uint type_, cython.uint class_, cython.float ttl, double created)
+    cdef _fast_init_record(self, str name, cython.uint type_, cython.uint class_, unsigned int ttl, double created)
 
     cdef bint _suppressed_by_answer(self, DNSRecord answer)
 
@@ -66,7 +66,7 @@ cdef class DNSRecord(DNSEntry):
 
     cpdef bint is_recent(self, double now)
 
-    cdef _set_created_ttl(self, double now, cython.float ttl)
+    cdef _set_created_ttl(self, double now, unsigned int ttl)
 
 cdef class DNSAddress(DNSRecord):
 
@@ -74,7 +74,7 @@ cdef class DNSAddress(DNSRecord):
     cdef public bytes address
     cdef public object scope_id
 
-    cdef _fast_init(self, str name, cython.uint type_, cython.uint class_, cython.float ttl, bytes address, object scope_id, double created)
+    cdef _fast_init(self, str name, cython.uint type_, cython.uint class_, unsigned int ttl, bytes address, object scope_id, double created)
 
     cdef bint _eq(self, DNSAddress other)
 
@@ -87,7 +87,7 @@ cdef class DNSHinfo(DNSRecord):
     cdef public str cpu
     cdef public str os
 
-    cdef _fast_init(self, str name, cython.uint type_, cython.uint class_, cython.float ttl, str cpu, str os, double created)
+    cdef _fast_init(self, str name, cython.uint type_, cython.uint class_, unsigned int ttl, str cpu, str os, double created)
 
     cdef bint _eq(self, DNSHinfo other)
 
@@ -99,7 +99,7 @@ cdef class DNSPointer(DNSRecord):
     cdef public str alias
     cdef public str alias_key
 
-    cdef _fast_init(self, str name, cython.uint type_, cython.uint class_, cython.float ttl, str alias, double created)
+    cdef _fast_init(self, str name, cython.uint type_, cython.uint class_, unsigned int ttl, str alias, double created)
 
     cdef bint _eq(self, DNSPointer other)
 
@@ -110,7 +110,7 @@ cdef class DNSText(DNSRecord):
     cdef public cython.int _hash
     cdef public bytes text
 
-    cdef _fast_init(self, str name, cython.uint type_, cython.uint class_, cython.float ttl, bytes text, double created)
+    cdef _fast_init(self, str name, cython.uint type_, cython.uint class_, unsigned int ttl, bytes text, double created)
 
     cdef bint _eq(self, DNSText other)
 
@@ -125,7 +125,7 @@ cdef class DNSService(DNSRecord):
     cdef public str server
     cdef public str server_key
 
-    cdef _fast_init(self, str name, cython.uint type_, cython.uint class_, cython.float ttl, cython.uint priority, cython.uint weight, cython.uint port, str server, double created)
+    cdef _fast_init(self, str name, cython.uint type_, cython.uint class_, unsigned int ttl, cython.uint priority, cython.uint weight, cython.uint port, str server, double created)
 
     cdef bint _eq(self, DNSService other)
 
@@ -137,7 +137,7 @@ cdef class DNSNsec(DNSRecord):
     cdef public str next_name
     cdef public cython.list rdtypes
 
-    cdef _fast_init(self, str name, cython.uint type_, cython.uint class_, cython.float ttl, str next_name, cython.list rdtypes, double created)
+    cdef _fast_init(self, str name, cython.uint type_, cython.uint class_, unsigned int ttl, str next_name, cython.list rdtypes, double created)
 
     cdef bint _eq(self, DNSNsec other)
 

--- a/src/zeroconf/_dns.py
+++ b/src/zeroconf/_dns.py
@@ -166,18 +166,17 @@ class DNSRecord(DNSEntry):
 
     __slots__ = ("created", "ttl")
 
-    # TODO: Switch to just int ttl
     def __init__(
         self,
         name: str,
         type_: int,
         class_: int,
-        ttl: float | int,
+        ttl: _int,
         created: float | None = None,
     ) -> None:
         self._fast_init_record(name, type_, class_, ttl, created or current_time_millis())
 
-    def _fast_init_record(self, name: str, type_: _int, class_: _int, ttl: _float, created: _float) -> None:
+    def _fast_init_record(self, name: str, type_: _int, class_: _int, ttl: _int, created: _float) -> None:
         """Fast init for reuse."""
         self._fast_init_entry(name, type_, class_)
         self.ttl = ttl
@@ -227,7 +226,7 @@ class DNSRecord(DNSEntry):
         """Returns true if the record more than one quarter of its TTL remaining."""
         return self.created + (_RECENT_TIME_MS * self.ttl) > now
 
-    def _set_created_ttl(self, created: _float, ttl: float | int) -> None:
+    def _set_created_ttl(self, created: _float, ttl: _int) -> None:
         """Set the created and ttl of a record."""
         # It would be better if we made a copy instead of mutating the record
         # in place, but records currently don't have a copy method.
@@ -266,7 +265,7 @@ class DNSAddress(DNSRecord):
         name: str,
         type_: _int,
         class_: _int,
-        ttl: _float,
+        ttl: _int,
         address: bytes,
         scope_id: _int | None,
         created: _float,
@@ -327,7 +326,7 @@ class DNSHinfo(DNSRecord):
         self._fast_init(name, type_, class_, ttl, cpu, os, created or current_time_millis())
 
     def _fast_init(
-        self, name: str, type_: _int, class_: _int, ttl: _float, cpu: str, os: str, created: _float
+        self, name: str, type_: _int, class_: _int, ttl: _int, cpu: str, os: str, created: _float
     ) -> None:
         """Fast init for reuse."""
         self._fast_init_record(name, type_, class_, ttl, created)
@@ -374,7 +373,7 @@ class DNSPointer(DNSRecord):
         self._fast_init(name, type_, class_, ttl, alias, created or current_time_millis())
 
     def _fast_init(
-        self, name: str, type_: _int, class_: _int, ttl: _float, alias: str, created: _float
+        self, name: str, type_: _int, class_: _int, ttl: _int, alias: str, created: _float
     ) -> None:
         self._fast_init_record(name, type_, class_, ttl, created)
         self.alias = alias
@@ -429,7 +428,7 @@ class DNSText(DNSRecord):
         self._fast_init(name, type_, class_, ttl, text, created or current_time_millis())
 
     def _fast_init(
-        self, name: str, type_: _int, class_: _int, ttl: _float, text: bytes, created: _float
+        self, name: str, type_: _int, class_: _int, ttl: _int, text: bytes, created: _float
     ) -> None:
         self._fast_init_record(name, type_, class_, ttl, created)
         self.text = text
@@ -468,7 +467,7 @@ class DNSService(DNSRecord):
         name: str,
         type_: int,
         class_: int,
-        ttl: float | int,
+        ttl: int,
         priority: int,
         weight: int,
         port: int,
@@ -484,7 +483,7 @@ class DNSService(DNSRecord):
         name: str,
         type_: _int,
         class_: _int,
-        ttl: _float,
+        ttl: _int,
         priority: _int,
         weight: _int,
         port: _int,
@@ -539,7 +538,7 @@ class DNSNsec(DNSRecord):
         name: str,
         type_: int,
         class_: int,
-        ttl: int | float,
+        ttl: _int,
         next_name: str,
         rdtypes: list[int],
         created: float | None = None,
@@ -551,7 +550,7 @@ class DNSNsec(DNSRecord):
         name: str,
         type_: _int,
         class_: _int,
-        ttl: _float,
+        ttl: _int,
         next_name: str,
         rdtypes: list[_int],
         created: _float,

--- a/src/zeroconf/_handlers/record_manager.pxd
+++ b/src/zeroconf/_handlers/record_manager.pxd
@@ -8,7 +8,7 @@ from .._updates cimport RecordUpdateListener
 from .._utils.time cimport current_time_millis
 from .._record_update cimport RecordUpdate
 
-cdef cython.float _DNS_PTR_MIN_TTL
+cdef unsigned int _DNS_PTR_MIN_TTL
 cdef cython.uint _TYPE_PTR
 cdef object _ADDRESS_RECORD_TYPES
 cdef bint TYPE_CHECKING

--- a/src/zeroconf/_services/browser.py
+++ b/src/zeroconf/_services/browser.py
@@ -394,9 +394,8 @@ class QueryScheduler:
         refresh_time_millis: float_,
     ) -> None:
         """Schedule a query for a pointer."""
-        ttl = int(pointer.ttl) if isinstance(pointer.ttl, float) else pointer.ttl
         scheduled_ptr_query = _ScheduledPTRQuery(
-            pointer.alias, pointer.name, ttl, expire_time_millis, refresh_time_millis
+            pointer.alias, pointer.name, pointer.ttl, expire_time_millis, refresh_time_millis
         )
         self._schedule_ptr_query(scheduled_ptr_query)
 

--- a/src/zeroconf/const.py
+++ b/src/zeroconf/const.py
@@ -57,7 +57,7 @@ _DNS_OTHER_TTL = 4500  # 75 minutes for non-host records (PTR, TXT etc) as-per R
 # ServiceBrowsers generating excessive queries refresh queries.
 # Apple uses a 15s minimum TTL, however we do not have the same
 # level of rate limit and safe guards so we use 1/4 of the recommended value
-_DNS_PTR_MIN_TTL = _DNS_OTHER_TTL / 4
+_DNS_PTR_MIN_TTL = 1125
 
 _DNS_PACKET_HEADER_LEN = 12
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -196,7 +196,7 @@ class PacketGeneration(unittest.TestCase):
             "testname2.local.",
             const._TYPE_SRV,
             const._CLASS_IN | const._CLASS_UNIQUE,
-            const._DNS_HOST_TTL / 2,
+            int(const._DNS_HOST_TTL / 2),
             0,
             0,
             80,


### PR DESCRIPTION
TTLs are always in full seconds. We shouldn't see any floats here.  This was legacy backwards compat, however they should all be fixed now.

Cython 3.1 compat