### PR TITLE
fix: missing wheel builds for Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
           [
             ubuntu-24.04-arm,
             ubuntu-latest,
-            windows-2019,
+            windows-latest,
             macos-13,
             macos-latest,
           ]


### PR DESCRIPTION
windows-2019 is no longer available on GitHub, we need to build wheels with windows-latest