### PR TITLE
ci: use uv to install poetry in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,8 +69,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
       - name: Install poetry
-        run: pipx install poetry
+        run: uv tool install poetry
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
         with:
@@ -102,7 +106,12 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
         with:
           python-version: 3.13
-      - uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+      - name: Install poetry
+        run: uv tool install poetry
       - name: Install Dependencies
         run: |
           REQUIRE_CYTHON=1 poetry install --only=main,dev


### PR DESCRIPTION
## Summary

Mirror of [esphome/aioesphomeapi#1650](https://github.com/esphome/aioesphomeapi/pull/1650) for `python-zeroconf`. Speeds up CI by replacing the slow `pipx install poetry` / `snok/install-poetry` provisioning with `astral-sh/setup-uv` + `uv tool install poetry`. No production code is touched.

## Details

- **`test` job** — adds `astral-sh/setup-uv@v8.1.0` (SHA-pinned, `enable-cache: true`) before installing poetry, then runs `uv tool install poetry` in place of `pipx install poetry`. `setup-python`'s `cache: "poetry"` is preserved — it caches the per-job project venv keyed off `poetry.lock`, which is independent of how poetry itself reaches `PATH`.
- **`benchmark` job** — same swap: the `snok/install-poetry@v1.4.1` action is replaced with `setup-uv` + `uv tool install poetry`.

Win is per-job, so it compounds across the test matrix (CPython 3.9–3.14, 3.14t, PyPy 3.9/3.10 × Linux/macOS/Windows × `skip_cython`/`use_cython`). Steady-state behaviour is unchanged; the speed-up shows up on every job's poetry-install step and on cache misses for wheel downloads via uv's cache.

## Test plan

- [ ] CI `test` matrix is green across all rows (the workflow change is exercised by every job on this PR).
- [ ] CI `benchmark` job runs to completion and CodSpeed posts a delta.
- [ ] `lint` and `commitlint` jobs are green.
