### PR TITLE
chore(release): keep semantic-release on 0.x series and revert version to 0.148.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "zeroconf"
-version = "1.0.0"
+version = "0.148.0"
 license = "LGPL-2.1-or-later"
 description = "A pure python implementation of multicast DNS service discovery"
 readme = "README.rst"
@@ -58,6 +58,7 @@ version_variables = [
 ]
 build_command = "pip install poetry && poetry build"
 tag_format = "{version}"
+allow_zero_version = true
 
 [tool.semantic_release.changelog]
 exclude_commit_patterns = [
@@ -71,8 +72,11 @@ keep_trailing_newline = true
 [tool.semantic_release.branches.master]
 match = "master"
 
+[tool.semantic_release.branches."release-0.x"]
+match = "release-0.x"
+
 [tool.semantic_release.branches.noop]
-match = "(?!master$)"
+match = "(?!(master|release-0.x)$)"
 prerelease = true
 
 [tool.poetry.dependencies]

--- a/src/zeroconf/__init__.py
+++ b/src/zeroconf/__init__.py
@@ -88,7 +88,7 @@ from ._utils.time import (  # noqa # import needed for backwards compat
 
 __author__ = "Paul Scott-Murphy, William McBrine"
 __maintainer__ = "Jakub Stasiak <jakub@stasiak.at>"
-__version__ = "1.0.0"
+__version__ = "0.148.0"
 __license__ = "LGPL"
 
 


### PR DESCRIPTION
## Summary

Keep master on the 0.x line. The 1.0.0 release was unintended and
was yanked from PyPI; the root cause was that master's
`[tool.semantic_release]` block was missing `allow_zero_version = true`,
so when python-semantic-release was upgraded to 10.x the next
release computed `0.148.0` → `1.0.0` (treating the 0.x line as
"initial development") instead of staying in 0.x.

The `release-0.x` branch already has the correct config — added
in `812a2b3` ("feat: trigger semantic releases for 0.x branch",
#1626). This PR forward-ports that fix to master and resets
master's version pointers back to the last intended release.

## Details

- `pyproject.toml`
  - `version = "0.148.0"` (reverted from `1.0.0`).
  - Add `allow_zero_version = true` under `[tool.semantic_release]`
    so 0.x is treated as the active major; breaking-change commits
    bump `0.x.y` instead of jumping to `1.0.0`.
  - Add `[tool.semantic_release.branches."release-0.x"]` matcher
    and update the `noop` regex from `(?!master$)` →
    `(?!(master|release-0.x)$)` so future releases off either
    branch stay in the 0.x line (and other branches stay
    prerelease-only).
- `src/zeroconf/__init__.py`
  - `__version__ = "0.148.0"` (reverted from `1.0.0`) so the
    runtime version string matches.

`semantic-release` reads `version_toml` / `version_variables` as
the source of truth for the current version and computes the next
version from commits since the previous release. After this PR
merges, the next release from master will be a 0.x bump computed
from `0.148.0` plus the conventional-commit history since then.

## Test plan

- [x] `pre-commit run --all-files` passes (lint job is just
      `pre-commit/action`).
- [x] Diff is config + version pointers only — no source code or
      test changes — so the test matrix is a no-op.
- [ ] Maintainer verifies the resulting next-version computation
      via `semantic-release version --print` (or equivalent
      dry-run) before merging, since this PR changes release
      behaviour.

## Notes

- The `1.0.0` git tag is left in place as a historical marker;
  the PyPI release is already yanked.
- This PR does not touch `CHANGELOG.md`; `semantic-release`
  regenerates it on the next release.
