### PR TITLE
docs: add SECURITY.md with private vulnerability reporting policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,17 @@ mutated from multiple threads without locks; no
   but the test matrix exercises 3.14t, so any new Cython module
   needs to keep working there.
 
+## Reporting security issues
+
+Suspected security vulnerabilities go through GitHub's [private
+vulnerability reporting][gh-report], not public issues or pull
+requests. The policy is spelled out in [SECURITY.md](SECURITY.md).
+If a user describes what sounds like a vulnerability in chat,
+point them at that route instead of opening a public issue, PR,
+or commit that names the bug class and the affected code path.
+
+[gh-report]: https://github.com/python-zeroconf/python-zeroconf/security/advisories/new
+
 ## Useful entry points
 
 | Path                             | What                                                                           |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,52 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report security vulnerabilities privately through GitHub's
+[private vulnerability reporting][gh-report] for this repository.
+That route sends the report directly to the maintainers and lets
+us coordinate a fix, a CVE, and a release before public
+disclosure.
+
+**Do not** open a regular GitHub issue, a pull request, or post
+to a public channel (mailing list, chat room, Stack Overflow,
+etc.) for a suspected vulnerability. If you are unsure whether
+something is a vulnerability, use the private report — we would
+rather see a false alarm than a public one.
+
+We aim to acknowledge new reports within a few business days.
+
+[gh-report]: https://github.com/python-zeroconf/python-zeroconf/security/advisories/new
+
+## Supported versions
+
+Security fixes are released against the latest `0.x` line on
+PyPI. Older releases are not maintained — please upgrade to the
+current release before reporting, and confirm the issue still
+reproduces there.
+
+## Scope
+
+`python-zeroconf` is an mDNS / DNS-SD library. By design it
+parses untrusted multicast traffic from the local network
+(RFC 6762, RFC 6763). In-scope issues include:
+
+- Memory-safety, parsing, or denial-of-service issues triggered
+  by crafted mDNS / DNS-SD packets reaching `DNSIncoming`, the
+  record cache, the service registry, or listener callbacks.
+- Logic bugs that cause the library to answer queries it should
+  not, leak information across interfaces, or hijack a service
+  name from another responder in a way the RFCs don't sanction.
+- Issues in the build / packaging pipeline (`build_ext.py`,
+  wheel contents, signed-release flow) that could lead to a
+  compromised wheel on PyPI.
+
+Out of scope:
+
+- Risks inherent to running an mDNS responder on an untrusted
+  network — mDNS is unauthenticated by design (RFC 6762 §21).
+  Reports of the form "a malicious LAN peer can send packets"
+  are expected behaviour unless they cross one of the lines
+  above.
+- Misconfiguration of a downstream application that uses the
+  library.


### PR DESCRIPTION
## Summary

Add a `SECURITY.md` that directs vulnerability reports through GitHub's [private vulnerability reporting](https://github.com/python-zeroconf/python-zeroconf/security/advisories/new), so reporters have a documented private channel and aren't tempted to open a public issue or PR. Cross-reference the policy from `CLAUDE.md` so future LLM-assisted contributions route reports the same way.

## Details

- **`SECURITY.md`** — top-level file (where GitHub's Security tab looks for it). Names the supported channel, supported versions (latest `0.x`), and an in-scope / out-of-scope list grounded in the project's actual attack surface: crafted mDNS / DNS-SD packets through `DNSIncoming`, cache, registry, listener callbacks; logic bugs that cross interface boundaries or hijack a name; build/packaging pipeline (`build_ext.py`, wheel contents, signed-release flow). Out of scope: things that are expected behaviour per RFC 6762 §21 (mDNS is unauthenticated by design).
- **`CLAUDE.md`** — new `## Reporting security issues` section between the build conventions and the entry-points table. Tells the LLM contributor not to open a public issue, PR, or commit naming the bug class and the affected code path when a user describes a suspected vulnerability; instead, point them at `SECURITY.md` / the private-reporting URL.

## Test plan

- [ ] `SECURITY.md` is discoverable via GitHub's Security tab after merge (`/security/policy` resolves).
- [ ] The "Report a vulnerability" button on the Security tab leads to `/security/advisories/new`.
- [ ] `lint` and `commitlint` jobs are green.
