### PR TITLE
test: pass timeout=0 explicitly in test_event_loop_blocked

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -753,11 +753,10 @@ def test_shutdown_while_register_in_process():
 
 
 @pytest.mark.asyncio
-@patch("zeroconf._core._STARTUP_TIMEOUT", 0)
 @patch("zeroconf._core.AsyncEngine._async_setup", new_callable=AsyncMock)
 async def test_event_loop_blocked(mock_start):
     """Test we raise NotRunningException when waiting for startup that times out."""
     aiozc = AsyncZeroconf(interfaces=["127.0.0.1"])
     with pytest.raises(NotRunningException):
-        await aiozc.zeroconf.async_wait_for_start()
+        await aiozc.zeroconf.async_wait_for_start(timeout=0)
     assert aiozc.zeroconf.started is False


### PR DESCRIPTION
## Summary

`test_event_loop_blocked` was taking 9.00s because the
`@patch("zeroconf._core._STARTUP_TIMEOUT", 0)` decorator never
took effect — `async_wait_for_start(self, timeout: float = _STARTUP_TIMEOUT)`
in `src/zeroconf/_core.py:239` captures the constant as a
default-arg at function-definition time, so patching the
module-level name afterwards does not change the default the
call resolves to.

The test was therefore using `timeout=9` (the real
`_STARTUP_TIMEOUT`) and waiting the full 9 seconds before raising
`NotRunningException`.

## Details

Pass `timeout=0` to the call directly and drop the no-op patch
decorator. The `@patch("zeroconf._core.AsyncEngine._async_setup", ...)`
decorator is kept — that one *does* work and is what prevents the
engine from actually starting, which is what the test is
exercising.

## Test plan

- [x] `poetry run pytest tests/test_core.py::test_event_loop_blocked`
      passes in 0.08s (was 9.00s).
- [x] Pre-commit (ruff, mypy, etc.) clean.
