### PR TITLE
test: pass timeout=200 to ServiceInfo-request timeout tests

### DIFF
--- a/tests/services/test_info.py
+++ b/tests/services/test_info.py
@@ -1050,12 +1050,12 @@ def test_request_timeout():
     """Test that the timeout does not throw an exception and finishes close to the actual timeout."""
     zeroconf = r.Zeroconf(interfaces=["127.0.0.1"])
     start_time = r.current_time_millis()
-    assert zeroconf.get_service_info("_notfound.local.", "notthere._notfound.local.") is None
+    assert zeroconf.get_service_info("_notfound.local.", "notthere._notfound.local.", timeout=200) is None
     end_time = r.current_time_millis()
     zeroconf.close()
-    # 3000ms for the default timeout
+    # 200ms for the timeout passed above
     # 1000ms for loaded systems + schedule overhead
-    assert (end_time - start_time) < 3000 + 1000
+    assert (end_time - start_time) < 200 + 1000
 
 
 @pytest.mark.asyncio
@@ -1888,7 +1888,7 @@ async def test_unicast_flag_if_requested() -> None:
     # patch the zeroconf send
     with patch.object(aiozc.zeroconf, "async_send", async_send):
         await aiozc.async_get_service_info(
-            f"willnotbefound.{type_}", type_, question_type=r.DNSQuestionType.QU
+            f"willnotbefound.{type_}", type_, timeout=200, question_type=r.DNSQuestionType.QU
         )
 
     await aiozc.async_close()

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -1276,12 +1276,15 @@ async def test_async_request_timeout():
     aiozc = AsyncZeroconf(interfaces=["127.0.0.1"])
     await aiozc.zeroconf.async_wait_for_start()
     start_time = current_time_millis()
-    assert await aiozc.async_get_service_info("_notfound.local.", "notthere._notfound.local.") is None
+    assert (
+        await aiozc.async_get_service_info("_notfound.local.", "notthere._notfound.local.", timeout=200)
+        is None
+    )
     end_time = current_time_millis()
     await aiozc.async_close()
-    # 3000ms for the default timeout
+    # 200ms for the timeout passed above
     # 1000ms for loaded systems + schedule overhead
-    assert (end_time - start_time) < 3000 + 1000
+    assert (end_time - start_time) < 200 + 1000
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Three tests were each taking ~3 seconds because they relied on
the default 3000ms `ServiceInfo` request timeout to lapse:

- `test_request_timeout` (`tests/services/test_info.py`)
- `test_async_request_timeout` (`tests/test_asyncio.py`)
- `test_unicast_flag_if_requested` (`tests/services/test_info.py`)

Pass `timeout=200` explicitly so the request fails over in ~0.2s
instead of ~3s.

## Details

- The first two tests assert the elapsed time is close to the
  requested timeout — the property is "the timeout returns
  roughly when asked, plus slack for scheduler overhead." The
  assertion bound moves from `< 3000 + 1000` to `< 200 + 1000`
  so the property is preserved at the new (smaller) timeout.
- `test_unicast_flag_if_requested` only cares that every outgoing
  question has `question.unicast` set; the timeout value is
  irrelevant to what it pins.

Combined wall time across the three goes from ~9s to ~0.75s.

Two other 3.01s tests in the same family
(`test_we_try_four_times_with_random_delay`,
`test_get_info_suppressed_by_question_history`) are *not*
included here — they encode assumptions about retry counts /
question-history windows that are tied to the production timing
constants and need a separate fix.

## Test plan

- [x] `poetry run pytest tests/services/test_info.py::test_request_timeout tests/services/test_info.py::test_unicast_flag_if_requested tests/test_asyncio.py::test_async_request_timeout`
      passes in 0.75s combined (was ~9s).
- [x] Pre-commit (ruff, mypy, etc.) clean.
