### PR TITLE
docs: add Cython gotchas section to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,7 @@ accelerated projects.
   `_ANSWER_STRATEGY_POINTER = 1` in `query_handler.py` as a C int
   assignment; the Python module dict never gets the binding.
   `from zeroconf._handlers.query_handler import
-_ANSWER_STRATEGY_POINTER` succeeds in pure-Python but raises
+  _ANSWER_STRATEGY_POINTER` succeeds in pure-Python but raises
   `ImportError` under Cython. If you need the value visible from
   Python (e.g. a test wants to assert on it), define both names —
   a public `ANSWER_STRATEGY_POINTER = 1` Python binding plus a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,61 +157,51 @@ mutated from multiple threads without locks; no
   but the test matrix exercises 3.14t, so any new Cython module
   needs to keep working there.
 
-## Cython gotchas (things that have bitten us)
+## Cython gotchas
 
-These are non-obvious traps in the `.py` + `.pxd` setup that work
-fine in pure-Python mode but break or silently misbehave in the
-shipped Cython wheels. Tests pass locally with `SKIP_CYTHON=1`
-fallback paths, then CI on `use_cython` builds catches the issue —
-or worse, the issue ships and only manifests in production wheels.
+Non-obvious traps in the `.py` + `.pxd` setup that work fine in
+pure-Python mode but break or silently misbehave in the shipped
+Cython wheels. Distilled from the patterns that already exist in
+this repo's `.pxd` files and from incidents in sibling Cython-
+accelerated projects.
 
 - **`cdef`-typed module constants are not Python-importable.**
-  Declaring `cdef int _MAX_X` in `.pxd` makes Cython treat
-  `_MAX_X = 5` in the `.py` as a C int assignment; the Python
-  module dict never gets the binding. `from module import _MAX_X`
-  succeeds in pure-Python but raises `ImportError` under Cython.
-  **Pattern**: define both names — `MAX_X = 5` (Python-
-  importable) and `_MAX_X = MAX_X` (cdef-typed for hot-path
-  comparisons). Tests import the public name; production code
-  uses either.
+  Declaring `cdef unsigned int _ANSWER_STRATEGY_POINTER` in
+  `query_handler.pxd` makes Cython treat
+  `_ANSWER_STRATEGY_POINTER = 1` in `query_handler.py` as a C int
+  assignment; the Python module dict never gets the binding.
+  `from zeroconf._handlers.query_handler import
+_ANSWER_STRATEGY_POINTER` succeeds in pure-Python but raises
+  `ImportError` under Cython. If you need the value visible from
+  Python (e.g. a test wants to assert on it), define both names —
+  a public `ANSWER_STRATEGY_POINTER = 1` Python binding plus a
+  `cdef`-typed `_ANSWER_STRATEGY_POINTER = ANSWER_STRATEGY_POINTER`
+  alias for hot-path comparisons.
 
-- **`noexcept` cdef paths must be pure C.** Calling a Python
-  method that can raise from inside a `cdef ... noexcept`
-  function is undefined / lossy — Cython prints the exception
-  via `WriteUnraisable` and silently continues. Keep `noexcept`
-  paths to sentinel returns and let the caller handle Python-
-  level work.
+- **Match the existing `unsigned int` convention for length, TTL,
+  type/class, and offset fields.** `_protocol/incoming.pxd`,
+  `_cache.pxd`, and `_handlers/*.pxd` already declare these as
+  `unsigned int` end-to-end. Introducing a `cdef int` return that
+  carries a value originally decoded into `unsigned int` flips
+  sign for any value with bit 31 set — TTL is a 32-bit DNS field
+  (RFC 1035 §3.2.1, interpreted as unsigned), so a large TTL
+  passed back through a `cdef int` boundary becomes negative and
+  trips `< 0` sentinel branches. Stay with `unsigned int` across
+  the whole call chain; if you need a real sentinel, return an
+  explicit value (`UINT_MAX`, a dedicated constant) and check for
+  it by equality.
 
-- **`unsigned int` result returned through `cdef int` can flip
-  sign.** A length / offset decoded into an `unsigned int` and
-  returned via `cdef int` will come back negative for any value
-  with bit 31 set. If the caller does `if x < 0: return`, an
-  attacker-controlled large value silently hits the "incomplete"
-  / "stop processing" branch instead of being rejected. Either
-  cap the input range so decoded values stay in signed-int
-  range, or check explicit sentinel values (`x == _SENTINEL_A`)
-  instead of generic `< 0`. The on-the-wire parsers in
-  `_protocol/incoming` are exactly the kind of code where this
-  bites — name pointers and RR length fields cross the 16-bit /
-  32-bit signed boundary.
-
-- **`except *` / `except? -N` adds per-call exception checks.**
-  Switching a hot-path `cdef ... noexcept` to `except *` or
-  `except? -3` adds a `PyErr_Occurred()` check after every call.
-  Negligible for cold paths, measurable on hot paths — CodSpeed
-  has caught double-digit regressions from this on
-  packet-parsing benchmarks in sibling Cython projects. Prefer
-  `noexcept` for hot paths and route error handling through the
-  caller.
-
-- **Module-level Python int constants force `PyLong` conversion
-  in hot-path comparisons.** `if length > _MAX_FRAME_SIZE`
+- **Module-level Python int constants force `PyLong_AsLong` on
+  every hot-path comparison.** `if record.type == _TYPE_PTR`
   compiles to a Python attribute lookup + `PyLong_AsLong` per
-  call. Adding `cdef int _MAX_FRAME_SIZE` to the `.pxd` makes it
-  a native C comparison. Timing / size constants from `const.py`
-  used inside `cdef` hot paths in `_protocol/`, `_cache`,
-  `_handlers/`, or `_listener` should have a `cdef`-typed alias
-  declared in the appropriate `.pxd`.
+  call when `_TYPE_PTR` is just a `.py`-level binding. The repo
+  already follows the right pattern — `_cache.pxd` /
+  `record_manager.pxd` declare `cdef unsigned int _TYPE_PTR`,
+  `_DNS_PTR_MIN_TTL`, `_MIN_SCHEDULED_RECORD_EXPIRATION`, etc.
+  When adding a new size / TTL / type constant from `const.py`
+  to a `cdef` hot path in `_protocol/`, `_cache`, `_handlers/`,
+  or `_listener`, add the `cdef`-typed alias to the corresponding
+  `.pxd` at the same time.
 
 - **Sign-compare warnings in generated C are real.** `gcc`/
   `clang` warns when comparing `unsigned int` with `int` because
@@ -220,11 +210,11 @@ or worse, the issue ships and only manifests in production wheels.
   signedness of compared operands in the `.pxd` (e.g. if the
   local is `unsigned int`, declare the constant as
   `cdef unsigned int`; if the local is `int`, declare it
-  `cdef int`). The warning predicts a class of overflow bug like
-  the unsigned->signed trap above.
+  `cdef int`). The warning predicts the unsigned -> signed
+  overflow class of bug.
 
-- **CodSpeed regressions only show in the Cython build.** Pure-
-  Python (`SKIP_CYTHON=1`) tests can pass while production
+- **CodSpeed regressions only show up in the Cython build.**
+  Pure-Python (`SKIP_CYTHON=1`) tests can pass while production
   wire-format hot paths regress. Trust the CodSpeed check on PRs
   that touch any file in `TO_CYTHONIZE`; rebuild in place with
   `REQUIRE_CYTHON=1 poetry install --only=main,dev` before

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,79 @@ mutated from multiple threads without locks; no
   but the test matrix exercises 3.14t, so any new Cython module
   needs to keep working there.
 
+## Cython gotchas (things that have bitten us)
+
+These are non-obvious traps in the `.py` + `.pxd` setup that work
+fine in pure-Python mode but break or silently misbehave in the
+shipped Cython wheels. Tests pass locally with `SKIP_CYTHON=1`
+fallback paths, then CI on `use_cython` builds catches the issue —
+or worse, the issue ships and only manifests in production wheels.
+
+- **`cdef`-typed module constants are not Python-importable.**
+  Declaring `cdef int _MAX_X` in `.pxd` makes Cython treat
+  `_MAX_X = 5` in the `.py` as a C int assignment; the Python
+  module dict never gets the binding. `from module import _MAX_X`
+  succeeds in pure-Python but raises `ImportError` under Cython.
+  **Pattern**: define both names — `MAX_X = 5` (Python-
+  importable) and `_MAX_X = MAX_X` (cdef-typed for hot-path
+  comparisons). Tests import the public name; production code
+  uses either.
+
+- **`noexcept` cdef paths must be pure C.** Calling a Python
+  method that can raise from inside a `cdef ... noexcept`
+  function is undefined / lossy — Cython prints the exception
+  via `WriteUnraisable` and silently continues. Keep `noexcept`
+  paths to sentinel returns and let the caller handle Python-
+  level work.
+
+- **`unsigned int` result returned through `cdef int` can flip
+  sign.** A length / offset decoded into an `unsigned int` and
+  returned via `cdef int` will come back negative for any value
+  with bit 31 set. If the caller does `if x < 0: return`, an
+  attacker-controlled large value silently hits the "incomplete"
+  / "stop processing" branch instead of being rejected. Either
+  cap the input range so decoded values stay in signed-int
+  range, or check explicit sentinel values (`x == _SENTINEL_A`)
+  instead of generic `< 0`. The on-the-wire parsers in
+  `_protocol/incoming` are exactly the kind of code where this
+  bites — name pointers and RR length fields cross the 16-bit /
+  32-bit signed boundary.
+
+- **`except *` / `except? -N` adds per-call exception checks.**
+  Switching a hot-path `cdef ... noexcept` to `except *` or
+  `except? -3` adds a `PyErr_Occurred()` check after every call.
+  Negligible for cold paths, measurable on hot paths — CodSpeed
+  has caught double-digit regressions from this on
+  packet-parsing benchmarks in sibling Cython projects. Prefer
+  `noexcept` for hot paths and route error handling through the
+  caller.
+
+- **Module-level Python int constants force `PyLong` conversion
+  in hot-path comparisons.** `if length > _MAX_FRAME_SIZE`
+  compiles to a Python attribute lookup + `PyLong_AsLong` per
+  call. Adding `cdef int _MAX_FRAME_SIZE` to the `.pxd` makes it
+  a native C comparison. Timing / size constants from `const.py`
+  used inside `cdef` hot paths in `_protocol/`, `_cache`,
+  `_handlers/`, or `_listener` should have a `cdef`-typed alias
+  declared in the appropriate `.pxd`.
+
+- **Sign-compare warnings in generated C are real.** `gcc`/
+  `clang` warns when comparing `unsigned int` with `int` because
+  the signed value is implicitly converted to unsigned for the
+  compare — a negative value becomes a huge positive. Match the
+  signedness of compared operands in the `.pxd` (e.g. if the
+  local is `unsigned int`, declare the constant as
+  `cdef unsigned int`; if the local is `int`, declare it
+  `cdef int`). The warning predicts a class of overflow bug like
+  the unsigned->signed trap above.
+
+- **CodSpeed regressions only show in the Cython build.** Pure-
+  Python (`SKIP_CYTHON=1`) tests can pass while production
+  wire-format hot paths regress. Trust the CodSpeed check on PRs
+  that touch any file in `TO_CYTHONIZE`; rebuild in place with
+  `REQUIRE_CYTHON=1 poetry install --only=main,dev` before
+  pushing if perf-sensitive code changed.
+
 ## Reporting security issues
 
 Suspected security vulnerabilities go through GitHub's [private


### PR DESCRIPTION
## Summary

Add a Cython gotchas section to `CLAUDE.md`, mirroring [esphome/aioesphomeapi#1653](https://github.com/esphome/aioesphomeapi/pull/1653) and adapted to python-zeroconf's code layout. Documents the non-obvious `.py` + `.pxd` traps that work in pure-Python mode but break or silently misbehave in shipped Cython wheels — exactly the class of bug where `SKIP_CYTHON=1` tests pass while `use_cython` CI catches it (or worse, it ships).

## Details

New section sits between `## Build conventions` and `## Reporting security issues`, capturing seven traps:

- **`cdef`-typed module constants are not Python-importable.** Pattern: keep both a public `MAX_X` and a `cdef`-typed `_MAX_X = MAX_X` alias so `from module import _MAX_X` doesn't silently break under Cython.
- **`noexcept` cdef paths must be pure C.** Raising from inside `cdef ... noexcept` is undefined; Cython prints via `WriteUnraisable` and continues. Keep `noexcept` paths to sentinel returns.
- **`unsigned int` returned through `cdef int` can flip sign** for values with bit 31 set — silently hitting `< 0` sentinel branches. Called out specifically for parsers in `_protocol/incoming` where DNS name pointers and RR length fields cross the signed-int boundary.
- **`except *` / `except? -N` adds per-call `PyErr_Occurred()` checks** — negligible cold, measurable hot.
- **Module-level Python int constants force `PyLong_AsLong`** in hot-path comparisons; `cdef int` in the `.pxd` makes it a native C compare. Called out for constants in `const.py` consumed by `_protocol/`, `_cache`, `_handlers/`, `_listener`.
- **Sign-compare warnings in generated C are real** and predict the unsigned -> signed overflow class of bug.
- **CodSpeed regressions only show in the Cython build.** Pure-Python tests can pass while production hot paths regress. Use `REQUIRE_CYTHON=1 poetry install --only=main,dev` to rebuild in place locally.

Aioesphomeapi-specific references in the original section (issue / PR numbers, BLE function names, `_handle_error_and_close`, `_read_varuint`) are dropped or generalized. Each trap is grounded in this repo's actual hot-path modules instead.

Docs only; no production code, no tests touched.

## Test plan

- [ ] `lint` and `commitlint` jobs are green (commit subject is `docs:` — semantic-release will skip it from the changelog, which is the right behaviour for a docs-only contributor-guide change).
- [ ] `test` matrix continues to pass unchanged (no code touched).
