### PR TITLE
chore: enable ruff SIM108, SIM102, SIM202 in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,12 +170,9 @@ select = [
     "FLY002", # too many to fix right now
     "PT018", # too many to fix right now
     "PLR0124", # too many to fix right now
-    "SIM202" , # too many to fix right now
     "PT012" , # too many to fix right now
     "TID252", # too many to fix right now
     "PLR0913", # skip this one
-    "SIM102" , # too many to fix right now
-    "SIM108", # too many to fix right now
     "T201", # too many to fix right now
     "PT004", # nice to have
 ]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -95,10 +95,7 @@ def time_changed_millis(millis: float | None = None) -> None:
     """Call all scheduled events for a time."""
     loop = asyncio.get_running_loop()
     loop_time = loop.time()
-    if millis is not None:
-        mock_seconds_into_future = millis / 1000
-    else:
-        mock_seconds_into_future = loop_time
+    mock_seconds_into_future = millis / 1000 if millis is not None else loop_time
 
     with mock.patch("time.monotonic", return_value=mock_seconds_into_future):
         for task in list(loop._scheduled):  # type: ignore[attr-defined]

--- a/tests/services/test_browser.py
+++ b/tests/services/test_browser.py
@@ -227,10 +227,7 @@ class TestServiceBrowser(unittest.TestCase):
             generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
             assert generated.is_response() is True
 
-            if service_state_change == r.ServiceStateChange.Removed:
-                ttl = 0
-            else:
-                ttl = 120
+            ttl = 0 if service_state_change == r.ServiceStateChange.Removed else 120
 
             generated.add_answer_at_time(
                 r.DNSText(
@@ -1575,9 +1572,8 @@ async def test_close_zeroconf_without_browser_before_start_up_queries():
     registration_name = f"xxxyyy.{type_}"
 
     def on_service_state_change(zeroconf, service_type, state_change, name):
-        if name == registration_name:
-            if state_change is ServiceStateChange.Added:
-                service_added.set()
+        if name == registration_name and state_change is ServiceStateChange.Added:
+            service_added.set()
 
     aiozc = AsyncZeroconf(interfaces=["127.0.0.1"])
     zeroconf_browser = aiozc.zeroconf
@@ -1644,9 +1640,8 @@ async def test_close_zeroconf_without_browser_after_start_up_queries():
     registration_name = f"xxxyyy.{type_}"
 
     def on_service_state_change(zeroconf, service_type, state_change, name):
-        if name == registration_name:
-            if state_change is ServiceStateChange.Added:
-                service_added.set()
+        if name == registration_name and state_change is ServiceStateChange.Added:
+            service_added.set()
 
     aiozc = AsyncZeroconf(interfaces=["127.0.0.1"])
     zeroconf_browser = aiozc.zeroconf

--- a/tests/test_dns.py
+++ b/tests/test_dns.py
@@ -76,7 +76,7 @@ class TestDunder(unittest.TestCase):
     def test_dns_question_repr(self):
         question = r.DNSQuestion("irrelevant", const._TYPE_SRV, const._CLASS_IN | const._CLASS_UNIQUE)
         repr(question)
-        assert not question != question
+        assert (question != question) is False
 
     def test_dns_service_repr(self):
         service = r.DNSService(
@@ -112,7 +112,7 @@ class TestDunder(unittest.TestCase):
             addresses=[socket.inet_aton("10.0.1.2")],
         )
 
-        assert not info != info
+        assert (info != info) is False
         repr(info)
 
     def test_service_info_text_properties_not_given(self):


### PR DESCRIPTION
Drops the per-test ignores for `SIM108` (use ternary), `SIM102` (combine nested `if`), and `SIM202` (use `==` instead of `not !=`); fixes the six existing violations they surfaced. The two `SIM202` sites in `test_dns.py` are testing `__ne__` directly, so they're rewritten as `(x != x) is False` to preserve intent without tripping the rule.
