### PR TITLE
perf(build): parallelize cython extension compilation

### DIFF
--- a/build_ext.py
+++ b/build_ext.py
@@ -46,6 +46,8 @@ EXTENSIONS = [
 
 class BuildExt(build_ext):
     def build_extensions(self) -> None:
+        if self.parallel is None:  # type: ignore[has-type]
+            self.parallel = os.cpu_count() or 1
         try:
             super().build_extensions()
         except Exception:


### PR DESCRIPTION
## Summary

Default `BuildExt.parallel` to `os.cpu_count()` so per-module `gcc` compilation runs in parallel instead of serially. Targets the wheel-build pipeline, where the QEMU-emulated jobs (riscv64 + armv7l) are the long pole.

## Details

Profiling [`Wheels for ubuntu-latest (manylinux) riscv64 cp313`](https://github.com/python-zeroconf/python-zeroconf/actions/runs/25971016471/job/76343800255) (20m20s total):

- Cython codegen under QEMU: ~3 min
- 18 sequential `gcc -O3` compiles under QEMU: ~16 min (each 12–98s)
- 26 such jobs in the matrix (13× riscv64, 13× armv7l) at 13–24 min apiece

`build_ext.py:48` never set `self.parallel`, so distutils' `build_extensions` ran each compile one at a time, leaving 3 of the 4 runner cores idle the entire time.

Local sanity check on macOS arm64: full Cython wheel went from serial to ~270% CPU, 10s wall / 23s user — confirming `ThreadPoolExecutor` is dispatching parallel `gcc` invocations. `SKIP_CYTHON=1` path still builds.

Expected CI impact: 4-core ubuntu-latest runners should cut the QEMU compile phase to ~4–5 min, taking those 26 wheel jobs from ~20 min to ~8 min each. Native runners benefit too, smaller win since they're already fast.

The `# type: ignore[has-type]` is because `distutils.command.build_ext` ships no type stubs and mypy can't see that `self.parallel` is initialized to `None` by the base class.

## Test plan

- [x] `REQUIRE_CYTHON=1 pip wheel --no-deps -w wh .` — wheel builds, CPU saturation visible
- [x] `SKIP_CYTHON=1 pip wheel --no-deps -w wh .` — pure-Python fallback still works
- [x] pre-commit (ruff, mypy, flake8, codespell, cython-lint) passes
- [ ] CI green across the matrix; eyeball a riscv64 wheel job to confirm parallel `gcc` invocations and reduced wall time
