### PR TITLE
fix(ci): drop cp39 from cibuildwheel matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,10 +211,6 @@ jobs:
           - os: ubuntu-latest
             qemu: armv7l
             musl: "musllinux"
-            pyver: cp39
-          - os: ubuntu-latest
-            qemu: armv7l
-            musl: "musllinux"
             pyver: cp310
           - os: ubuntu-latest
             qemu: armv7l
@@ -238,10 +234,6 @@ jobs:
             pyver: cp314t
           # qemu is slow, make a single
           # runner per Python version
-          - os: ubuntu-latest
-            qemu: armv7l
-            musl: ""
-            pyver: cp39
           - os: ubuntu-latest
             qemu: armv7l
             musl: ""


### PR DESCRIPTION
## Summary

After [#1688](https://github.com/python-zeroconf/python-zeroconf/pull/1688) bumped `requires-python` to `>=3.10`, two `cp39` matrix entries were left behind in the cibuildwheel matrix. cibuildwheel refused them with `No build identifiers selected`, the failure cancelled every other arch in the wheel job (no `fail-fast: false` on this matrix), and `0.149.0` reached PyPI as **sdist + one stray cp314 wheel only** — `upload_pypi` was skipped because `build_wheels` didn't complete.

## Details

Failing job: [`Wheels for ubuntu-latest (musllinux) armv7l cp39`](https://github.com/python-zeroconf/python-zeroconf/actions/runs/25974564348/job/76352840921)

```
##[error]cibuildwheel: No build identifiers selected:
BuildSelector(build_config='cp39*',
              skip_config='cp36-* cp37-* pp36-* pp37-* pp38-* cp38-*',
              requires_python=<SpecifierSet('>=3.10')>,
              enable=frozenset())
##[error]Process completed with exit code 3.
```

This PR removes the two stale entries:

- `ubuntu-latest qemu=armv7l musl=musllinux pyver=cp39`
- `ubuntu-latest qemu=armv7l musl=""        pyver=cp39`

The `fix:` prefix lets PSR cut `0.149.1`, so the wheel matrix runs once more and `upload_pypi` publishes a full cross-arch wheel set to replace the sdist-only `0.149.0`.

## Test plan

- [ ] Merge → confirm PSR releases `0.149.1`.
- [ ] Confirm every `Wheels for …` job completes successfully (no more cancelled arches).
- [ ] Confirm `0.149.1` on PyPI has the full wheel set (manylinux + musllinux x86_64 / aarch64 / armv7l / riscv64, macOS, Windows).

## Follow-up worth considering

Add `strategy.fail-fast: false` to the `build_wheels` matrix so a single arch failure no longer cancels the other ~30 jobs. Happy to do that in a separate PR if you want.
