### PR TITLE
ci: don't fail-fast the wheel matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,7 @@ jobs:
     name: Wheels for ${{ matrix.os }} (${{ matrix.musl == 'musllinux' && 'musllinux' || 'manylinux' }}) ${{ matrix.qemu }} ${{ matrix.pyver }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os:
           [


### PR DESCRIPTION
## Summary

Add `fail-fast: false` to the `build_wheels` job's matrix strategy so one arch's failure no longer cancels the other ~30 wheel builds.

## Motivation

[`run/25974564348`](https://github.com/python-zeroconf/python-zeroconf/actions/runs/25974564348) had a single failing entry — `Wheels for ubuntu-latest (musllinux) armv7l cp39` — and every other arch was cancelled mid-build. `upload_pypi` was skipped, so `0.149.0` landed on PyPI as sdist only. With `fail-fast: false`, the other arches would have completed and `upload_pypi` would have published whatever the matrix produced; a fix could then re-target just the broken arch.

`fail-fast: false` is already set on the `test` matrix at line 51 — this just brings `build_wheels` in line.

## Test plan

- [ ] Merge → next release's wheel matrix continues even if a single arch fails.
- [ ] Sanity-check that `upload_pypi` (which depends on `build_wheels`) still gates correctly. With `fail-fast: false`, a single-arch failure means `build_wheels` is `failure`, so `upload_pypi` would still be skipped — same gating behaviour, just better diagnostics on which arch broke.

## Note

This is a `ci:` change, so it's excluded from `semantic-release`'s changelog (`exclude_commit_patterns` in `pyproject.toml`) and won't bump the version on its own.
