### PR TITLE
fix(ci): drop retired macos-13 runner and skip cp39/pp39 in wheel matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,7 +315,7 @@ jobs:
         uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
         # to supply options, put them in 'env', like:
         env:
-          CIBW_SKIP: cp36-* cp37-* pp36-* pp37-* pp38-* cp38-* ${{ matrix.musl == 'musllinux' && '*manylinux*' || '*musllinux*' }}
+          CIBW_SKIP: cp36-* cp37-* cp38-* cp39-* pp36-* pp37-* pp38-* pp39-* ${{ matrix.musl == 'musllinux' && '*manylinux*' || '*musllinux*' }}
           CIBW_BEFORE_ALL_LINUX: apt install -y gcc || yum install -y gcc || apk add gcc
           CIBW_ARCHS_MACOS: "x86_64 arm64"
           REQUIRE_CYTHON: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,6 @@ jobs:
             ubuntu-24.04-arm,
             ubuntu-latest,
             windows-latest,
-            macos-13,
             macos-latest,
           ]
         qemu: [""]
@@ -318,6 +317,7 @@ jobs:
         env:
           CIBW_SKIP: cp36-* cp37-* pp36-* pp37-* pp38-* cp38-* ${{ matrix.musl == 'musllinux' && '*manylinux*' || '*musllinux*' }}
           CIBW_BEFORE_ALL_LINUX: apt install -y gcc || yum install -y gcc || apk add gcc
+          CIBW_ARCHS_MACOS: "x86_64 arm64"
           REQUIRE_CYTHON: 1
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4


### PR DESCRIPTION
## Summary

Two CI follow-ups from the Python-3.9-drop wheel-publish hiccup:

1. **Drop `macos-13` from the wheel matrix.** GitHub fully retired the `macos-13` runner image on 2025-12-04 ([actions/runner-images#13046](https://github.com/actions/runner-images/issues/13046)), so the matrix entry sits `queued` until the ~6h timeout — exactly what blocked `upload_pypi` for `0.149.1` ([run 25975208751](https://github.com/python-zeroconf/python-zeroconf/actions/runs/25975208751)). Replaced with `CIBW_ARCHS_MACOS="x86_64 arm64"` on `macos-latest` (arm64), so cibuildwheel cross-builds both architectures from one runner and Intel-Mac users keep getting x86_64 wheels.
2. **Skip `cp39-*` and `pp39-*` in `CIBW_SKIP`.** `pyproject.toml` is `requires-python = ">=3.10"` since #1688, so any matrix entry that targets 3.9 would hit "No build identifiers selected" — the same hard error that crashed the cp39 armv7l job in `0.149.0`. Belt-and-suspenders alongside #1691 which removed the explicit cp39 matrix rows.

## Details

- `CIBW_ARCHS_MACOS="x86_64 arm64"` only affects macOS runs; it's a no-op on the Linux/Windows entries.
- cibuildwheel ≥ 2.10 can build x86_64 wheels on an arm64 macOS runner; we're on `pypa/cibuildwheel@v3.4.1` so this works out of the box.
- The skip list got sorted into ascending order while editing.

## Test plan

- [ ] Merge → PSR cuts `0.149.2`.
- [ ] Confirm only 4 OS rows in the wheel matrix (no `macos-13`), and that `macos-latest` produces both `*-macosx_x86_64.whl` and `*-macosx_arm64.whl`.
- [ ] Confirm `upload_pypi` runs and `0.149.2` lands on PyPI with the full wheel set.

## Follow-up

Once #1692 (`ci: don't fail-fast the wheel matrix`) lands, future single-arch breakage won't take down the rest of the matrix.
