### PR TITLE
fix(ci): drop x86_64 mac wheels and clean up obsolete CIBW_SKIP entries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,9 +315,9 @@ jobs:
         uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
         # to supply options, put them in 'env', like:
         env:
-          CIBW_SKIP: cp36-* cp37-* cp38-* cp39-* pp36-* pp37-* pp38-* pp39-* ${{ matrix.musl == 'musllinux' && '*manylinux*' || '*musllinux*' }}
+          CIBW_SKIP: cp38-* cp39-* pp38-* pp39-* ${{ matrix.musl == 'musllinux' && '*manylinux*' || '*musllinux*' }}
           CIBW_BEFORE_ALL_LINUX: apt install -y gcc || yum install -y gcc || apk add gcc
-          CIBW_ARCHS_MACOS: "x86_64 arm64"
+          CIBW_ARCHS_MACOS: arm64
           REQUIRE_CYTHON: 1
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4


### PR DESCRIPTION
## Summary

Two fixes for the `0.149.2` wheel publish failure ([run 25976603151](https://github.com/python-zeroconf/python-zeroconf/actions/runs/25976603151)):

1. **Drop x86_64 mac wheels.** `CIBW_ARCHS_MACOS="x86_64 arm64"` failed delocate with an arch-mismatched wheel because cibuildwheel created the x86_64 build's virtualenv on the host arm64 (log shows `CPython3.10.11.final.0-64-arm64`), so the C extension compiled for arm64 inside a venv tagged x86_64. Cross-compiling x86_64 from Apple Silicon is brittle enough that the simpler answer is to drop x86_64 mac wheels — Apple Silicon has been the default since late 2020 and Intel-Mac users can still install via sdist.
2. **Drop obsolete `CIBW_SKIP` entries.** cibuildwheel 3.x dropped Python < 3.8 support and emits `Invalid skip selector: 'cp36-*'` / `'cp37-*'` / `'pp36-*'` / `'pp37-*'` warnings on every run. Removed.

## Details

`CIBW_ARCHS_MACOS=arm64` only affects mac runs; the env var is a no-op on Linux/Windows.

Reduced skip list keeps the still-useful entries: `cp38-*`, `cp39-*`, `pp38-*`, `pp39-*` (matches `requires-python = ">=3.10"`).

## Test plan

- [ ] Merge → PSR cuts `0.149.3`.
- [ ] Confirm `Wheels for macos-latest (manylinux)` job succeeds and produces only `*-macosx_*_arm64.whl`.
- [ ] Confirm `upload_pypi` runs and `0.149.3` lands on PyPI with the full Linux/Windows/mac-arm64 wheel set.
- [ ] Confirm no more `Invalid skip selector` warnings in cibuildwheel logs.

## Follow-up

Universal2 wheels (`CIBW_ARCHS_MACOS="universal2"`) are a possible re-add later if Intel-Mac coverage matters; they build natively on arm64 without the cross-compile issues. Out of scope for this PR.
