### PR TITLE
ci: replace deprecated upload-to-gh-release with publish-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
         if: steps.release.outputs.released == 'true'
 
       - name: Publish package distributions to GitHub Releases
-        uses: python-semantic-release/upload-to-gh-release@0a92b5d7ebfc15a84f9801ebd1bf706343d43711 # main
+        uses: python-semantic-release/publish-action@310a9983a0ae878b29f3aac778d7c77c1db27378 # v10.5.3
         if: steps.release.outputs.released == 'true'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

The `python-semantic-release/upload-to-gh-release` action is
archived and now prints a deprecation notice on every release run:

> This action has been DEPRECATED. Please use the
> 'python-semantic-release/publish-action' instead.

Swap the deprecated step in the `release` job for
`python-semantic-release/publish-action`, pinned to v10.5.3 (the
same PSR release used by the surrounding `Test release` /
`Release` steps). The new action exposes the same `github_token`
input, so no other changes are needed.

## Test plan

- [ ] CI lint + commitlint pass on this PR.
- [ ] Verified upstream: `upload-to-gh-release` is archived, and
      `publish-action` v10.5.3's `action.yml` takes the same
      `github_token` input the old step took.
- [ ] Real-world validation happens on the next release run on
      `master`, where the GitHub Releases asset upload uses the
      new action.
