### PR TITLE
test: drop pending multicast responses before TOCTOU assertion

### DIFF
--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -695,6 +695,16 @@ async def test_service_info_async_request(quick_timing: None) -> None:
     assert aiosinfos[1] is not None
     assert aiosinfos[1].addresses == [socket.inet_aton("10.0.1.5")]
 
+    # Drop pending multicast responses queued under the original
+    # `info` / `info2` registrations. Their snapshots predate the
+    # `async_update_service` swap, so if they flushed after
+    # `_clear_cache` below they would poison `aiosinfo.server`
+    # with `ash-1.local.` and the `_is_complete=False` loop would
+    # then keep asking for an A record nobody answers. The pending
+    # `loop.call_at` for each queue fires harmlessly on the empty
+    # deque.
+    aiozc.zeroconf.out_queue.queue.clear()
+    aiozc.zeroconf.out_delay_queue.queue.clear()
     aiosinfo = AsyncServiceInfo(type_, registration_name)
     _clear_cache(aiozc.zeroconf)
     # Generating the race condition is almost impossible


### PR DESCRIPTION
## Summary

`test_service_info_async_request` flakes on multiple CI runners (e.g. [macOS 3.12 skip_cython](https://github.com/python-zeroconf/python-zeroconf/actions/runs/25996065731/job/76410639256?pr=1698), [ubuntu 3.13 use_cython](https://github.com/python-zeroconf/python-zeroconf/actions/runs/25996691182/job/76412322785)) with:

```
AssertionError: assert [b'\n\x00\x01\x02'] == [b'\n\x00\x01\x03']
```

## Root cause

After tracing the captured packet log, the failure isn't a timeout / convergence problem — a **stale queued multicast response** ends up overwriting the correct one:

1. The earlier `async_get_service_info` / `gather` calls trigger queries that the local zeroconf answers via `out_queue` (or `out_delay_queue`). The queue snapshots the records (SRV → `ash-1.local.`, A → `10.0.1.2`) and aggregates the send by up to ~620ms / ~1320ms.
2. `async_update_service(new_info)` swaps the registry entry to `ash-2.local.` / `10.0.1.3` and broadcasts the new records.
3. With `quick_timing`, the broadcast finishes within ~30ms, so the stale queued response is still pending when the test reaches the assertion block.
4. The test calls `_clear_cache(...)` and `async_request(zc, 500)` with `_is_complete` patched to `False`.
5. The queued response flushes *after* the cache clear, re-caching `ash-1.local. → 10.0.1.2` and pointing `aiosinfo.server` at `ash-1.local.`.
6. The patched loop then keeps asking for an A record for `ash-1.local.`, which nothing in the registry answers, so the final state stays on `10.0.1.2` and the assertion fails.

Evidence from the failing ubuntu run (`MulticastOutgoingQueue` flushing stale records right after the ash-2 broadcasts):

```
... answers=[(record[srv,…,xxxyyy._test1-srvc-type._tcp.local.]=120/119,ash-1.local.:80, 0.0),
            (record[txt,…]…, 0.0)],
   additionals=[record[a,…,ash-1.local.]=120/119,10.0.1.2, …]
```

…followed by repeated `questions=[a[…,ash-1.local.], quada[…,ash-1.local.]]` queries from the AsyncServiceInfo loop.

## Fix

Drop the pending entries from both `out_queue` and `out_delay_queue` before clearing the cache. The already-scheduled `loop.call_at` for each queue fires on the empty deque and is a no-op (the `while len(self.queue)…` loop in `async_ready` doesn't iterate, and `if answers:` is False), so this is deterministic and adds no wall-clock delay.

A code-side fix for the underlying behaviour (invalidating queued responses when the registry changes) is left as a separate concern.

## Test plan

- [x] `SKIP_CYTHON=1 poetry run pytest --timeout=60 -q tests/test_asyncio.py::test_service_info_async_request` — 5 consecutive runs pass (~4.15s each).
- [x] `poetry run pytest --timeout=60 -q tests/test_asyncio.py::test_service_info_async_request` (with Cython extensions) — 3 consecutive runs pass.
- [x] `poetry run pre-commit run --files tests/test_asyncio.py` — clean.
