### PR TITLE
test: speed up slow loopback tests (closes #1700)

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -91,6 +91,23 @@ def _clear_cache(zc: Zeroconf) -> None:
     zc.question_history.clear()
 
 
+def _backdate_cache(zc: Zeroconf, ms: int = 1100) -> None:
+    """Backdate every cached record's `created` time by `ms` milliseconds.
+
+    rfc6762#section-10.2 keys off "received more than one second ago", so
+    backdating is equivalent to sleeping `ms` in real time without the
+    wall-clock wait.
+
+    Iterate `store.values()`, not the dict directly — when a record is
+    re-added with an equal hash, the key stays the original object while
+    the value is replaced with the latest; mutating the key would update
+    stale objects no one reads.
+    """
+    for store in zc.cache.cache.values():
+        for record in store.values():
+            record.created -= ms
+
+
 def time_changed_millis(millis: float | None = None) -> None:
     """Call all scheduled events for a time."""
     loop = asyncio.get_running_loop()

--- a/tests/services/test_browser.py
+++ b/tests/services/test_browser.py
@@ -556,7 +556,7 @@ def test_first_query_delay():
 
 
 @pytest.mark.asyncio
-async def test_asking_default_is_asking_qm_questions_after_the_first_qu():
+async def test_asking_default_is_asking_qm_questions_after_the_first_qu(quick_timing: None) -> None:
     """Verify the service browser's first questions are QU and refresh queries are QM."""
     service_added = asyncio.Event()
     service_removed = asyncio.Event()
@@ -658,7 +658,7 @@ async def test_asking_default_is_asking_qm_questions_after_the_first_qu():
 
 
 @pytest.mark.asyncio
-async def test_ttl_refresh_cancelled_rescue_query():
+async def test_ttl_refresh_cancelled_rescue_query(quick_timing: None) -> None:
     """Verify seeing a name again cancels the rescue query."""
     service_added = asyncio.Event()
     service_removed = asyncio.Event()
@@ -846,7 +846,7 @@ async def test_asking_qu_questions():
             await aiozc.async_close()
 
 
-def test_legacy_record_update_listener():
+def test_legacy_record_update_listener(quick_timing: None) -> None:
     """Test a RecordUpdateListener that does not implement update_records."""
 
     # instantiate a zeroconf instance
@@ -1499,10 +1499,15 @@ def test_service_browser_expire_callbacks():
     # Force the ttl to be 1 second
     now = current_time_millis()
     for cache_record in list(zc.cache.cache.values()):
-        for record in cache_record:
+        for record in cache_record.values():
             zc.cache._async_set_created_ttl(record, now, 1)
 
-    time.sleep(0.3)
+    # Wait for the add callback to fire from the original inject_response.
+    for _ in range(30):
+        time.sleep(0.01)
+        if len(callbacks) == 1:
+            break
+
     info.port = 400
     info._dns_service_cache = None  # we are mutating the record so clear the cache
 
@@ -1511,8 +1516,8 @@ def test_service_browser_expire_callbacks():
         mock_incoming_msg([info.dns_service()]),
     )
 
-    for _ in range(10):
-        time.sleep(0.05)
+    for _ in range(30):
+        time.sleep(0.01)
         if len(callbacks) == 2:
             break
 
@@ -1521,8 +1526,19 @@ def test_service_browser_expire_callbacks():
         ("update", type_, registration_name),
     ]
 
-    for _ in range(25):
-        time.sleep(0.05)
+    # Re-add every cached record with `created` in the past so the
+    # next reaper tick (0.01s) expires them and fires the remove
+    # callback, instead of waiting the full TTL in real time.
+    # Going through `_async_set_created_ttl` updates the expiration
+    # heap; mutating `record.created` directly would leave the heap
+    # entry pointing at the original `when` so the reaper never wakes.
+    past = current_time_millis() - 2000
+    for cache_record in list(zc.cache.cache.values()):
+        for record in list(cache_record.values()):
+            zc.cache._async_set_created_ttl(record, past, 1)
+
+    for _ in range(30):
+        time.sleep(0.01)
         if len(callbacks) == 3:
             break
 
@@ -1567,7 +1583,7 @@ def test_scheduled_ptr_query_dunder_methods():
 
 
 @pytest.mark.asyncio
-async def test_close_zeroconf_without_browser_before_start_up_queries():
+async def test_close_zeroconf_without_browser_before_start_up_queries(quick_timing: None) -> None:
     """Test that we stop sending startup queries if zeroconf is closed out from under the browser."""
     service_added = asyncio.Event()
     type_ = "_http._tcp.local."
@@ -1634,7 +1650,7 @@ async def test_close_zeroconf_without_browser_before_start_up_queries():
 
 
 @pytest.mark.asyncio
-async def test_close_zeroconf_without_browser_after_start_up_queries():
+async def test_close_zeroconf_without_browser_after_start_up_queries(quick_timing: None) -> None:
     """Test that we stop sending rescue queries if zeroconf is closed out from under the browser."""
     service_added = asyncio.Event()
 

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -708,16 +708,21 @@ async def test_service_info_async_request(quick_timing: None) -> None:
     aiosinfo = AsyncServiceInfo(type_, registration_name)
     _clear_cache(aiozc.zeroconf)
     # Generating the race condition is almost impossible
-    # without patching since its a TOCTOU race
+    # without patching since its a TOCTOU race. 1500ms covers
+    # the initial _LISTENER_TIME + random delay (200-320ms) and
+    # leaves plenty of margin for the loopback response to land
+    # before the loop times out.
     with patch("zeroconf.asyncio.AsyncServiceInfo._is_complete", False):
-        await aiosinfo.async_request(aiozc.zeroconf, 3000)
+        await aiosinfo.async_request(aiozc.zeroconf, 1500)
     assert aiosinfo is not None
     assert aiosinfo.addresses == [socket.inet_aton("10.0.1.3")]
 
     task = await aiozc.async_unregister_service(new_info)
     await task
 
-    aiosinfo = await aiozc.async_get_service_info(type_, registration_name)
+    # Cap timeout: the service is gone, so this is expected to return None;
+    # waiting the default 3000ms is pure overhead.
+    aiosinfo = await aiozc.async_get_service_info(type_, registration_name, timeout=200)
     assert aiosinfo is None
 
     await aiozc.async_close()
@@ -784,7 +789,7 @@ async def test_async_service_browser(quick_timing: None) -> None:
 
 
 @pytest.mark.asyncio
-async def test_async_context_manager() -> None:
+async def test_async_context_manager(quick_timing: None) -> None:
     """Test using an async context manager."""
     type_ = "_test10-sr-type._tcp.local."
     name = "xxxyyy"
@@ -984,7 +989,7 @@ async def test_service_browser_instantiation_generates_add_events_from_cache():
 
 
 @pytest.mark.asyncio
-async def test_integration():
+async def test_integration(quick_timing: None) -> None:
     service_added = asyncio.Event()
     service_removed = asyncio.Event()
     unexpected_ttl = asyncio.Event()
@@ -1176,9 +1181,11 @@ async def test_info_asking_default_is_asking_qm_questions_after_the_first_qu():
     # patch the zeroconf send
     with patch.object(zeroconf_info, "async_send", send):
         aiosinfo = AsyncServiceInfo(type_, registration_name)
-        # Patch _is_complete so we send multiple times
+        # Patch _is_complete so we send multiple times. 500ms covers
+        # the QU query at 0ms plus the QM query at ~_LISTENER_TIME +
+        # max random delay (~320ms).
         with patch("zeroconf.asyncio.AsyncServiceInfo._is_complete", False):
-            await aiosinfo.async_request(aiozc.zeroconf, 1200)
+            await aiosinfo.async_request(aiozc.zeroconf, 500)
         try:
             assert first_outgoing.questions[0].unicast is True  # type: ignore[union-attr]
             assert second_outgoing.questions[0].unicast is False  # type: ignore[attr-defined]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -24,7 +24,7 @@ from zeroconf._listener import AsyncListener, _WrappedTransport
 from zeroconf._protocol.incoming import DNSIncoming
 from zeroconf.asyncio import AsyncZeroconf
 
-from . import _clear_cache, _inject_response, _wait_for_start, has_working_ipv6
+from . import _backdate_cache, _clear_cache, _inject_response, _wait_for_start, has_working_ipv6
 
 log = logging.getLogger("zeroconf")
 original_logging_level = logging.NOTSET
@@ -301,7 +301,7 @@ class Framework(unittest.TestCase):
             # all old records with that name, rrtype, and rrclass that were received
             # more than one second ago are declared invalid,
             # and marked to expire from the cache in one second.
-            time.sleep(1.1)
+            _backdate_cache(zeroconf)
 
             # service updated. currently only text record can be updated
             service_text = b"path=/~humingchun/"
@@ -310,12 +310,12 @@ class Framework(unittest.TestCase):
             assert dns_text is not None
             assert cast(r.DNSText, dns_text).text == service_text  # service_text is b'path=/~humingchun/'
 
-            time.sleep(1.1)
+            _backdate_cache(zeroconf)
 
             # The split message only has a SRV and A record.
             # This should not evict TXT records from the cache
             _inject_response(zeroconf, mock_split_incoming_msg(r.ServiceStateChange.Updated))
-            time.sleep(1.1)
+            _backdate_cache(zeroconf)
             dns_text = zeroconf.cache.get_by_details(service_name, const._TYPE_TXT, const._CLASS_IN)
             assert dns_text is not None
             assert cast(r.DNSText, dns_text).text == service_text  # service_text is b'path=/~humingchun/'
@@ -426,7 +426,7 @@ def test_goodbye_all_services():
     zc.close()
 
 
-def test_register_service_with_custom_ttl():
+def test_register_service_with_custom_ttl(quick_timing: None) -> None:
     """Test a registering a service with a custom ttl."""
 
     # instantiate a zeroconf instance
@@ -453,7 +453,7 @@ def test_register_service_with_custom_ttl():
     zc.close()
 
 
-def test_logging_packets(caplog):
+def test_logging_packets(caplog: pytest.LogCaptureFixture, quick_timing: None) -> None:
     """Test packets are only logged with debug logging."""
 
     # instantiate a zeroconf instance

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -39,9 +39,17 @@ async def test_reaper():
         original_entries = list(itertools.chain(*(cache.entries_with_name(name) for name in cache.names())))
         record_with_10s_ttl = r.DNSAddress("a", const._TYPE_SOA, const._CLASS_IN, 10, b"a")
         record_with_1s_ttl = r.DNSAddress("a", const._TYPE_SOA, const._CLASS_IN, 1, b"b")
+        # Backdate the short-lived record so it expires at the next
+        # reaper tick instead of waiting the full TTL in real time.
+        record_with_1s_ttl.created -= 2000
         zeroconf.cache.async_add_records([record_with_10s_ttl, record_with_1s_ttl])
         question = r.DNSQuestion("_hap._tcp._local.", const._TYPE_PTR, const._CLASS_IN)
         now = r.current_time_millis()
+        # Add the question at `past` so the reaper's next tick will see
+        # `current_time - past > _DUPLICATE_QUESTION_INTERVAL` and prune it,
+        # while the initial `suppresses(now, ...)` check still sees the
+        # question as recent (since `now - past == 999`, not strictly `> 999`).
+        past = now - 999
         other_known_answers: set[r.DNSRecord] = {
             r.DNSPointer(
                 "_hap._tcp.local.",
@@ -51,10 +59,10 @@ async def test_reaper():
                 "known-to-other._hap._tcp.local.",
             )
         }
-        zeroconf.question_history.add_question_at_time(question, now, other_known_answers)
+        zeroconf.question_history.add_question_at_time(question, past, other_known_answers)
         assert zeroconf.question_history.suppresses(question, now, other_known_answers)
         entries_with_cache = list(itertools.chain(*(cache.entries_with_name(name) for name in cache.names())))
-        await asyncio.sleep(1.2)
+        await asyncio.sleep(0.1)
         entries = list(itertools.chain(*(cache.entries_with_name(name) for name in cache.names())))
         assert zeroconf.cache.get(record_with_1s_ttl) is None
         await aiozc.async_close()
@@ -77,6 +85,10 @@ async def test_reaper_aborts_when_done():
         assert zeroconf.cache.get(record_with_10s_ttl) is not None
         assert zeroconf.cache.get(record_with_1s_ttl) is not None
         await aiozc.async_close()
-        await asyncio.sleep(1.2)
+        # Backdate to immediate expiry so we don't have to wait the full
+        # TTL; the assertion is that the reaper has stopped, so a
+        # short sleep is enough to give it a chance to (incorrectly) run.
+        record_with_1s_ttl.created -= 2000
+        await asyncio.sleep(0.1)
         assert zeroconf.cache.get(record_with_10s_ttl) is not None
         assert zeroconf.cache.get(record_with_1s_ttl) is not None

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -215,15 +215,18 @@ class TestRegistrar(unittest.TestCase):
         out = r.DNSOutgoing(const._FLAGS_QR_QUERY)
         out.add_question(r.DNSQuestion(type_.upper(), const._TYPE_PTR, const._CLASS_IN))
         zc.send(out)
-        time.sleep(1)
         info = ServiceInfo(type_, registration_name)
-        info.load_from_cache(zc)
+        for _ in range(50):
+            time.sleep(0.02)
+            info.load_from_cache(zc)
+            if info.addresses:
+                break
         assert info.addresses == [socket.inet_pton(socket.AF_INET, "1.2.3.4")]
         assert info.properties == {b"version": b"1.0"}
         zc.close()
 
 
-def test_ptr_optimization():
+def test_ptr_optimization(quick_timing: None) -> None:
     # instantiate a zeroconf instance
     zc = Zeroconf(interfaces=["127.0.0.1"])
 
@@ -597,7 +600,7 @@ async def test_probe_answered_immediately_with_uppercase_name():
     zc.close()
 
 
-def test_qu_response():
+def test_qu_response(quick_timing: None) -> None:
     """Handle multicast incoming with the QU bit set."""
     # instantiate a zeroconf instance
     zc = Zeroconf(interfaces=["127.0.0.1"])
@@ -1351,8 +1354,12 @@ async def test_cache_flush_bit():
         else:
             assert entry.ttl == 1
 
-    # Wait for the ttl 1 records to expire
-    await asyncio.sleep(1.1)
+    # Backdate the ttl=1 records so they are already expired when
+    # load_from_cache runs — equivalent to sleeping 1.1s without the wait.
+    for store in zc.cache.cache.values():
+        for cached in store.values():
+            if cached.ttl == 1:
+                cached.created -= 1100
 
     loaded_info = r.ServiceInfo(type_, registration_name)
     loaded_info.load_from_cache(zc)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 import os
 import socket
-import time
 import unittest
 from threading import Event
 from typing import Any
@@ -113,8 +112,10 @@ class ListenerTest(unittest.TestCase):
             service_added.wait(1)
             assert service_added.is_set()
 
-            # short pause to allow multicast timers to expire
-            time.sleep(0.5)
+            # Drain pending multicast announces from the registrar instead
+            # of sleeping for them — same pattern as PR #1701.
+            zeroconf_registrar.out_queue.queue.clear()
+            zeroconf_registrar.out_delay_queue.queue.clear()
 
             zeroconf_browser.add_service_listener(type_, DuplicateListener())
             duplicate_service_added.wait(

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -29,7 +29,7 @@ def teardown_module():
         log.setLevel(original_logging_level)
 
 
-def test_legacy_record_update_listener():
+def test_legacy_record_update_listener(quick_timing: None) -> None:
     """Test a RecordUpdateListener that does not implement update_records."""
 
     # instantiate a zeroconf instance


### PR DESCRIPTION
## Summary

Closes #1700. Drops full-suite runtime from ~85s to ~46s by
removing real-time waits from tests that don't need them on a
loopback socket. Behaviour under test is unchanged — only the
test setup is shortened.

## Details

- **`quick_timing` fixture** applied to 13 register/announce-heavy
  tests (`test_register_service_with_custom_ttl`,
  `test_logging_packets`, `test_ptr_optimization`, `test_qu_response`,
  `test_async_context_manager`, `test_integration` in
  `test_asyncio.py`, `test_asking_default_is_asking_qm_questions_after_the_first_qu`,
  `test_ttl_refresh_cancelled_rescue_query`, both
  `test_legacy_record_update_listener`s,
  `test_close_zeroconf_without_browser_before_start_up_queries`,
  `test_close_zeroconf_without_browser_after_start_up_queries`).
  The fixture shrinks `_CHECK_TIME` / `_REGISTER_TIME` /
  `_UNREGISTER_TIME` from RFC 6762 §8.1/§8.3 production values
  (500ms / 225ms / 125ms) to 10ms each via `patch.object`, so
  nothing outside the `with` block is affected.

- **`_backdate_cache(zc, ms=1100)`** new helper in `tests/__init__.py`.
  Replaces real-time sleeps that exist only to satisfy RFC 6762 §10.2's
  "received more than one second ago" check (the cache flush logic in
  `DNSCache.async_mark_unique_records_older_than_1s_to_expire`):
  - `test_async_updates_from_response`: 3 × `time.sleep(1.1)` → 3 ×
    `_backdate_cache(zc)` (3.3s → 0.03s).
  - `test_cache_flush_bit`: `await asyncio.sleep(1.1)` → inline
    backdate of the TTL=1 records (1.1s → 0.0s).

  The helper iterates `store.values()` rather than the inner dict
  directly because `DNSCache._async_add` re-keys the dict with
  `store[record] = record`: when a new record with equal hash
  arrives, the **key** stays the original object but the **value**
  becomes the new record. Mutating the keys would update stale
  objects no one reads.

- **Reaper-driven tests** (`test_reaper`, `test_reaper_aborts_when_done`,
  `test_service_browser_expire_callbacks`) re-add records via
  `cache._async_set_created_ttl(record, past, 1)` so the cache's
  expire heap picks up the updated `when = created + ttl*1000`.
  Mutating `record.created` alone leaves the heap entry pointing
  at the original future expiration time and the reaper never wakes
  the record up. Combined with the `_CACHE_CLEANUP_INTERVAL=0.01s`
  patch these tests already had, the reaper now fires within ~10ms.

- **`test_service_info_async_request`** caps the post-unregister
  `async_get_service_info` to `timeout=200` (the service is gone,
  the default 3000ms is pure overhead) and tightens the
  `_is_complete=False` TOCTOU-race loop from 3000ms to 1500ms.
  1500ms covers the initial `_LISTENER_TIME + random_delay`
  (≈220-320ms) and leaves plenty of margin for the loopback
  response to land before the loop times out.

- **`test_info_asking_default_is_asking_qm_questions_after_the_first_qu`**
  drops its forced-loop timeout from 1200ms to 500ms — enough for
  the QU query at t=0 and the QM query at t≈`_LISTENER_TIME` +
  max random delay (320ms).

- **`test_register_and_lookup_type_by_uppercase_name`** replaces
  `time.sleep(1)` with a 50×20ms poll on the cache (same pattern
  as `test_sending_unicast` in `test_core.py`).

- **`test_integration_with_listener_class`** drains the registrar's
  `out_queue` / `out_delay_queue` instead of `time.sleep(0.5)` for
  "multicast timers to expire" — same pattern as #1701.

The remaining ~2-3s tests in the slowest-20 are intrinsic-timing:
`_DUPLICATE_QUESTION_INTERVAL`-bound queries
(`test_we_try_four_times_with_random_delay`,
`test_get_info_suppressed_by_question_history`,
`test_get_info_partial`), the multicast aggregation windows
(`test_response_aggregation_timings`, `…_multiple`), and the 1s
`asyncio.run_coroutine_threadsafe(...).result(1)` guard in
`test_shutdown_loop`. `_DUPLICATE_QUESTION_INTERVAL` is a cdef
constant in `_services/info.pxd` and `_history.pxd`, so it can't
be `patch.object`-ed in Cython mode.

## Test plan

- [x] Full suite passes: 335 passed, 3 skipped.
- [x] All changed tests stable across five back-to-back runs.
- [x] Pre-commit clean on the modified files (ruff, mypy, flake8,
      codespell, pyupgrade).
- [x] Before/after slowest-20 comparison shows the targeted tests
      now drop off the list (most go from ~1.9-3.3s down to
      0.03-0.4s).
