### PR TITLE
ci: cache poetry venv keyed on lockfile and cython sources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,8 @@ jobs:
           - os: macos-latest
             python-version: "pypy-3.10"
     runs-on: ${{ matrix.os }}
+    env:
+      POETRY_VIRTUALENVS_IN_PROJECT: "true"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
       - name: Set up uv
@@ -89,13 +91,21 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: "poetry"
           allow-prereleases: true
+      - name: Cache poetry venv
+        id: cache-venv
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            .venv
+            src/zeroconf/**/*.so
+          key: venv-v1-${{ runner.os }}-${{ env.ImageOS }}-${{ env.ImageVersion }}-py${{ matrix.python-version }}-${{ matrix.extension }}-${{ hashFiles('poetry.lock', 'pyproject.toml', 'build_ext.py') }}-${{ hashFiles('src/zeroconf/**/*.py', 'src/zeroconf/**/*.pxd') }}
       - name: Install Dependencies no cython
-        if: ${{ matrix.extension == 'skip_cython' }}
+        if: ${{ matrix.extension == 'skip_cython' && steps.cache-venv.outputs.cache-hit != 'true' }}
         env:
           SKIP_CYTHON: 1
         run: poetry install --only=main,dev
       - name: Install Dependencies with cython
-        if: ${{ matrix.extension != 'skip_cython' }}
+        if: ${{ matrix.extension != 'skip_cython' && steps.cache-venv.outputs.cache-hit != 'true' }}
         env:
           REQUIRE_CYTHON: 1
         run: poetry install --only=main,dev
@@ -108,6 +118,8 @@ jobs:
 
   benchmark:
     runs-on: ubuntu-latest
+    env:
+      POETRY_VIRTUALENVS_IN_PROJECT: "true"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
       - name: Setup Python 3.13
@@ -120,7 +132,16 @@ jobs:
           enable-cache: true
       - name: Install poetry
         run: uv tool install poetry
+      - name: Cache poetry venv
+        id: cache-venv
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            .venv
+            src/zeroconf/**/*.so
+          key: venv-v1-${{ runner.os }}-${{ env.ImageOS }}-${{ env.ImageVersion }}-benchmark-py3.13-${{ hashFiles('poetry.lock', 'pyproject.toml', 'build_ext.py') }}-${{ hashFiles('src/zeroconf/**/*.py', 'src/zeroconf/**/*.pxd') }}
       - name: Install Dependencies
+        if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
           REQUIRE_CYTHON=1 poetry install --only=main,dev
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  POETRY_VIRTUALENVS_IN_PROJECT: "true"
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -75,8 +78,6 @@ jobs:
           - os: macos-latest
             python-version: "pypy-3.10"
     runs-on: ${{ matrix.os }}
-    env:
-      POETRY_VIRTUALENVS_IN_PROJECT: "true"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
       - name: Set up uv
@@ -98,7 +99,7 @@ jobs:
           path: |
             .venv
             src/zeroconf/**/*.so
-          key: venv-v1-${{ runner.os }}-${{ env.ImageOS }}-${{ env.ImageVersion }}-py${{ matrix.python-version }}-${{ matrix.extension }}-${{ hashFiles('poetry.lock', 'pyproject.toml', 'build_ext.py') }}-${{ hashFiles('src/zeroconf/**/*.py', 'src/zeroconf/**/*.pxd') }}
+          key: venv-v1-${{ runner.os }}-py${{ matrix.python-version }}-${{ matrix.extension }}-${{ hashFiles('poetry.lock', 'pyproject.toml', 'build_ext.py', 'src/zeroconf/**/*.py', 'src/zeroconf/**/*.pxd') }}
       - name: Install Dependencies no cython
         if: ${{ matrix.extension == 'skip_cython' && steps.cache-venv.outputs.cache-hit != 'true' }}
         env:
@@ -118,8 +119,6 @@ jobs:
 
   benchmark:
     runs-on: ubuntu-latest
-    env:
-      POETRY_VIRTUALENVS_IN_PROJECT: "true"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
       - name: Setup Python 3.13
@@ -139,7 +138,7 @@ jobs:
           path: |
             .venv
             src/zeroconf/**/*.so
-          key: venv-v1-${{ runner.os }}-${{ env.ImageOS }}-${{ env.ImageVersion }}-benchmark-py3.13-${{ hashFiles('poetry.lock', 'pyproject.toml', 'build_ext.py') }}-${{ hashFiles('src/zeroconf/**/*.py', 'src/zeroconf/**/*.pxd') }}
+          key: venv-v1-${{ runner.os }}-benchmark-py3.13-${{ hashFiles('poetry.lock', 'pyproject.toml', 'build_ext.py', 'src/zeroconf/**/*.py', 'src/zeroconf/**/*.pxd') }}
       - name: Install Dependencies
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |


### PR DESCRIPTION
## Summary

Cache the poetry-managed `.venv` plus built Cython artefacts (`src/zeroconf/**/*.so`) across the test matrix and benchmark jobs. Mirrors [dbus-fast#675](https://github.com/Bluetooth-Devices/dbus-fast/pull/675) and the follow-up cleanup in [dbus-fast#679](https://github.com/Bluetooth-Devices/dbus-fast/pull/679), adapted to this repo's matrix shape.

## Details

Cache key components:

- `runner.os` + `matrix.python-version` + `matrix.extension` (`skip_cython` / `use_cython`)
- `hashFiles('poetry.lock', 'pyproject.toml', 'build_ext.py', 'src/zeroconf/**/*.py', 'src/zeroconf/**/*.pxd')`

On a cache hit, the `Install Dependencies` step is skipped via `if: steps.cache-venv.outputs.cache-hit != 'true'`. Pure-Python and Cython-source changes both invalidate the cache, so we never run tests against stale `.so` files.

`POETRY_VIRTUALENVS_IN_PROJECT: "true"` is set at workflow-level `env:` so poetry creates `.venv` inside the repo (cacheable as a single path) and the env var lives in one place.

Why the cache key looks the way it does:

- The `extension` axis is in the key because `skip_cython` and `use_cython` produce different venvs (one has `.so` files, one doesn't).
- `.c` files are intentionally not cached. They're regenerated from `.py`/`.pxd` by Cython, and only needed when we rebuild — and on a hit we skip the rebuild.
- `pyproject.toml` and `build_ext.py` are in the hash so changes to `TO_CYTHONIZE`, extension flags, or runtime deps invalidate the cache.

The matrix here is ~30 cells (7 Python × 3 OS × 2 extension modes, minus exclusions) plus the benchmark job, so unchanged-deps PRs that only touch tests or docs should now skip ~30 poetry installs and ~13 Cython rebuilds.

## Test plan

- [ ] First run on this branch is a cold cache (expected); subsequent runs that don't touch `src/zeroconf/**/*.py` or `*.pxd` should hit the cache and skip install
- [ ] `actions/cache` step succeeds across Linux / macOS / Windows
- [ ] `use_cython` cells continue to exercise the Cython extension (CodSpeed signal is the canary)
- [ ] Free-threaded `3.14t` entry still passes
