### PR TITLE
ci: scope release concurrency group per ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,9 @@ jobs:
 
     runs-on: ubuntu-latest
     environment: release
-    concurrency: release
+    concurrency:
+      group: release-${{ github.head_ref || github.ref }}
+      cancel-in-progress: false
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
## Summary

Scope the `release` job's concurrency group per ref instead of a single shared `release` key. Mirrors [dbus-fast#677](https://github.com/Bluetooth-Devices/dbus-fast/pull/677).

## Details

The current `concurrency: release` on the release job is a global key across every branch and PR. As soon as a second PR's CI reaches the `release` job, the older run gets canceled with `Canceling since a higher priority waiting request for release exists`. Since PRs run the release job in dry-run mode (`no_operation_mode: true`), this loses a useful validation signal on the older PR for no gain.

With `release-${{ github.head_ref || github.ref }}`:

- Each PR / branch gets its own group, so dry-runs on different PRs run independently.
- On master the key resolves to `release-refs/heads/master`, so actual releases still serialize behind one another.
- `cancel-in-progress: false` keeps queued runs from killing each other. The workflow-level `concurrency` block already cancels stale runs per head_ref before they reach this job, so we don't need a second layer of cancellation here.

## Test plan

- [ ] Two simultaneous PRs reach the release job without canceling each other
- [ ] A push to master still serializes releases (group key is constant per ref)
- [ ] PR dry-run (`Test release` step) still runs as before
