### PR TITLE
fix(core): release sockets when close runs before engine setup completes

### DIFF
--- a/src/zeroconf/_engine.py
+++ b/src/zeroconf/_engine.py
@@ -146,11 +146,17 @@ class AsyncEngine:
     async def _async_close(self) -> None:
         """Cancel and wait for the cleanup task to finish."""
         assert self._setup_task is not None
-        # ``gather(return_exceptions=True)`` lets a setup task that was
-        # cancelled by a prior ``_async_shutdown`` (close-before-start)
-        # finish without re-raising, while still propagating cancellation
-        # of the calling task.
-        await asyncio.gather(self._setup_task, return_exceptions=True)
+        # Setup may have been cancelled by a prior ``_async_shutdown``
+        # (close-before-start); swallow that case only. ``setup_task.cancelled()``
+        # is True precisely when the task itself was cancelled, so a
+        # ``CancelledError`` raised by an outer-task cancellation falls
+        # through to the caller, and any non-cancel setup exception is
+        # re-raised by ``await``.
+        try:
+            await self._setup_task
+        except asyncio.CancelledError:
+            if not self._setup_task.cancelled():
+                raise
         self._async_shutdown()
         await asyncio.sleep(0)  # flush out any call soons
         if self._cleanup_timer is not None:

--- a/src/zeroconf/_engine.py
+++ b/src/zeroconf/_engine.py
@@ -114,14 +114,9 @@ class AsyncEngine:
                 lambda: AsyncListener(self.zc),  # type: ignore[arg-type, return-value]
                 sock=s,
             )
-            # Register the wrapped transport before dropping the engine's
-            # handle on ``s`` so a concurrent ``_async_shutdown`` always
-            # sees the socket in exactly one place (transport-owned via
-            # ``self.readers``/``self.senders``, or still raw in
-            # ``_listen_socket``/``_respond_sockets``) — never in neither.
-            # The block between the two awaits is atomic under asyncio,
-            # so today this ordering is belt-and-braces; do not introduce
-            # an ``await`` between the append and the reference drop.
+            # Register the wrapped transport before releasing the engine's
+            # handle so a concurrent shutdown always sees ``s`` in exactly
+            # one place; do not add an ``await`` between these two steps.
             self.protocols.append(cast(AsyncListener, protocol))
             self.readers.append(make_wrapped_transport(cast(asyncio.DatagramTransport, transport)))
             if s in sender_sockets:
@@ -151,12 +146,9 @@ class AsyncEngine:
     async def _async_close(self) -> None:
         """Cancel and wait for the cleanup task to finish."""
         assert self._setup_task is not None
-        # Setup may have been cancelled by a prior ``_async_shutdown``
-        # (close-before-start); swallow that case only. ``setup_task.cancelled()``
-        # is True precisely when the task itself was cancelled, so a
-        # ``CancelledError`` raised by an outer-task cancellation falls
-        # through to the caller, and any non-cancel setup exception is
-        # re-raised by ``await``.
+        # Swallow CancelledError only if the setup task itself was
+        # cancelled (close-before-start); outer-task cancellation must
+        # propagate.
         try:
             await self._setup_task
         except asyncio.CancelledError:
@@ -168,28 +160,17 @@ class AsyncEngine:
             self._cleanup_timer.cancel()
 
     def _async_shutdown(self) -> None:
-        """Shutdown transports and sockets.
-
-        Safe to call repeatedly: ``close()`` may invoke this across the
-        sync, in-loop, and async close paths. The setup-task cancel,
-        transport closes, and raw-socket closes are all no-ops on the
-        second pass; keep it that way (don't add counters or one-shot
-        side effects without a guard). ``running_future`` is replaced on
-        every call by design, so a fresh future blocks readers that join
-        after a partial restart attempt.
-        """
+        """Shutdown transports and sockets; safe to call repeatedly."""
         assert self.running_future is not None
         assert self.loop is not None
         self.running_future = self.loop.create_future()
-        # Stop ``_async_create_endpoints`` from continuing to wrap sockets
-        # after shutdown has started — otherwise it would create transports
-        # that nobody closes, leaking FDs.
+        # Cancel pending setup so it can't wrap fresh transports after
+        # shutdown has started.
         if self._setup_task is not None and not self._setup_task.done():
             self._setup_task.cancel()
         for wrapped_transport in itertools.chain(self.senders, self.readers):
             wrapped_transport.transport.close()
-        # Anything still in these collections was never adopted by a
-        # transport; release the FDs so they don't leak.
+        # Anything still here was never adopted by a transport.
         if self._listen_socket is not None:
             self._listen_socket.close()
             self._listen_socket = None

--- a/src/zeroconf/_engine.py
+++ b/src/zeroconf/_engine.py
@@ -23,7 +23,6 @@ USA
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import itertools
 import socket
 import threading
@@ -147,18 +146,24 @@ class AsyncEngine:
     async def _async_close(self) -> None:
         """Cancel and wait for the cleanup task to finish."""
         assert self._setup_task is not None
-        # Setup may have been cancelled by a prior ``_async_shutdown`` (e.g.
-        # close-before-start); swallow the cancellation so close still runs
-        # to completion.
-        with contextlib.suppress(asyncio.CancelledError):
-            await self._setup_task
+        # ``gather(return_exceptions=True)`` lets a setup task that was
+        # cancelled by a prior ``_async_shutdown`` (close-before-start)
+        # finish without re-raising, while still propagating cancellation
+        # of the calling task.
+        await asyncio.gather(self._setup_task, return_exceptions=True)
         self._async_shutdown()
         await asyncio.sleep(0)  # flush out any call soons
         if self._cleanup_timer is not None:
             self._cleanup_timer.cancel()
 
     def _async_shutdown(self) -> None:
-        """Shutdown transports and sockets."""
+        """Shutdown transports and sockets.
+
+        Idempotent: ``close()`` may invoke this multiple times across the
+        sync, in-loop, and async close paths. Every operation here is a
+        no-op on the second pass — keep it that way (e.g. don't add
+        counters or one-shot side effects without a guard).
+        """
         assert self.running_future is not None
         assert self.loop is not None
         self.running_future = self.loop.create_future()

--- a/src/zeroconf/_engine.py
+++ b/src/zeroconf/_engine.py
@@ -114,17 +114,22 @@ class AsyncEngine:
                 lambda: AsyncListener(self.zc),  # type: ignore[arg-type, return-value]
                 sock=s,
             )
-            # The transport now owns ``s``; drop our reference so
-            # ``_async_shutdown`` only closes sockets that never reached a
-            # transport (e.g. when setup is cancelled mid-flight).
-            if s is self._listen_socket:
-                self._listen_socket = None
-            if s in self._respond_sockets:
-                self._respond_sockets.remove(s)
+            # Register the wrapped transport before dropping the engine's
+            # handle on ``s`` so a concurrent ``_async_shutdown`` always
+            # sees the socket in exactly one place (transport-owned via
+            # ``self.readers``/``self.senders``, or still raw in
+            # ``_listen_socket``/``_respond_sockets``) — never in neither.
+            # The block between the two awaits is atomic under asyncio,
+            # so today this ordering is belt-and-braces; do not introduce
+            # an ``await`` between the append and the reference drop.
             self.protocols.append(cast(AsyncListener, protocol))
             self.readers.append(make_wrapped_transport(cast(asyncio.DatagramTransport, transport)))
             if s in sender_sockets:
                 self.senders.append(make_wrapped_transport(cast(asyncio.DatagramTransport, transport)))
+            if s is self._listen_socket:
+                self._listen_socket = None
+            if s in self._respond_sockets:
+                self._respond_sockets.remove(s)
 
     def _async_cache_cleanup(self) -> None:
         """Periodic cache cleanup."""
@@ -165,10 +170,13 @@ class AsyncEngine:
     def _async_shutdown(self) -> None:
         """Shutdown transports and sockets.
 
-        Idempotent: ``close()`` may invoke this multiple times across the
-        sync, in-loop, and async close paths. Every operation here is a
-        no-op on the second pass — keep it that way (e.g. don't add
-        counters or one-shot side effects without a guard).
+        Safe to call repeatedly: ``close()`` may invoke this across the
+        sync, in-loop, and async close paths. The setup-task cancel,
+        transport closes, and raw-socket closes are all no-ops on the
+        second pass; keep it that way (don't add counters or one-shot
+        side effects without a guard). ``running_future`` is replaced on
+        every call by design, so a fresh future blocks readers that join
+        after a partial restart attempt.
         """
         assert self.running_future is not None
         assert self.loop is not None

--- a/src/zeroconf/_engine.py
+++ b/src/zeroconf/_engine.py
@@ -23,6 +23,7 @@ USA
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import itertools
 import socket
 import threading
@@ -114,6 +115,13 @@ class AsyncEngine:
                 lambda: AsyncListener(self.zc),  # type: ignore[arg-type, return-value]
                 sock=s,
             )
+            # The transport now owns ``s``; drop our reference so
+            # ``_async_shutdown`` only closes sockets that never reached a
+            # transport (e.g. when setup is cancelled mid-flight).
+            if s is self._listen_socket:
+                self._listen_socket = None
+            if s in self._respond_sockets:
+                self._respond_sockets.remove(s)
             self.protocols.append(cast(AsyncListener, protocol))
             self.readers.append(make_wrapped_transport(cast(asyncio.DatagramTransport, transport)))
             if s in sender_sockets:
@@ -139,19 +147,36 @@ class AsyncEngine:
     async def _async_close(self) -> None:
         """Cancel and wait for the cleanup task to finish."""
         assert self._setup_task is not None
-        await self._setup_task
+        # Setup may have been cancelled by a prior ``_async_shutdown`` (e.g.
+        # close-before-start); swallow the cancellation so close still runs
+        # to completion.
+        with contextlib.suppress(asyncio.CancelledError):
+            await self._setup_task
         self._async_shutdown()
         await asyncio.sleep(0)  # flush out any call soons
-        assert self._cleanup_timer is not None
-        self._cleanup_timer.cancel()
+        if self._cleanup_timer is not None:
+            self._cleanup_timer.cancel()
 
     def _async_shutdown(self) -> None:
         """Shutdown transports and sockets."""
         assert self.running_future is not None
         assert self.loop is not None
         self.running_future = self.loop.create_future()
+        # Stop ``_async_create_endpoints`` from continuing to wrap sockets
+        # after shutdown has started — otherwise it would create transports
+        # that nobody closes, leaking FDs.
+        if self._setup_task is not None and not self._setup_task.done():
+            self._setup_task.cancel()
         for wrapped_transport in itertools.chain(self.senders, self.readers):
             wrapped_transport.transport.close()
+        # Anything still in these collections was never adopted by a
+        # transport; release the FDs so they don't leak.
+        if self._listen_socket is not None:
+            self._listen_socket.close()
+            self._listen_socket = None
+        for s in self._respond_sockets:
+            s.close()
+        self._respond_sockets = []
 
     def close(self) -> None:
         """Close from sync context.

--- a/tests/services/test_browser.py
+++ b/tests/services/test_browser.py
@@ -1052,7 +1052,7 @@ def test_service_browser_listeners_no_update_service():
                 callbacks.append(("remove", type_, name))
 
         def update_service(self, zc, type_, name) -> None:  # type: ignore[no-untyped-def]
-            """No-op so the browser thread doesn't see ``NotImplementedError``."""
+            pass
 
     listener = MyServiceListener()
 

--- a/tests/services/test_browser.py
+++ b/tests/services/test_browser.py
@@ -1033,7 +1033,7 @@ def test_service_browser_listeners_update_service():
 
 
 def test_service_browser_listeners_no_update_service():
-    """Test that the ServiceBrowser ServiceListener that does not implement update_service."""
+    """A listener that ignores update events records only add/remove callbacks."""
 
     # instantiate a zeroconf instance
     zc = Zeroconf(interfaces=["127.0.0.1"])

--- a/tests/services/test_browser.py
+++ b/tests/services/test_browser.py
@@ -1051,6 +1051,9 @@ def test_service_browser_listeners_no_update_service():
             if name == registration_name:
                 callbacks.append(("remove", type_, name))
 
+        def update_service(self, zc, type_, name) -> None:  # type: ignore[no-untyped-def]
+            """No-op so the browser thread doesn't see ``NotImplementedError``."""
+
     listener = MyServiceListener()
 
     browser = r.ServiceBrowser(zc, type_, None, listener)

--- a/tests/services/test_info.py
+++ b/tests/services/test_info.py
@@ -1529,6 +1529,7 @@ async def test_bad_ip_addresses_ignored_in_cache():
     info = ServiceInfo(type_, registration_name)
     info.load_from_cache(aiozc.zeroconf)
     assert info.addresses_by_version(IPVersion.V4Only) == [b"\x7f\x00\x00\x01"]
+    await aiozc.async_close()
 
 
 @pytest.mark.asyncio
@@ -1804,6 +1805,7 @@ async def test_address_resolver():
     aiozc.zeroconf.async_send(outgoing)
     assert await resolve_task
     assert resolver.addresses == [b"\x7f\x00\x00\x01"]
+    await aiozc.async_close()
 
 
 @pytest.mark.asyncio
@@ -1828,6 +1830,7 @@ async def test_address_resolver_ipv4():
     aiozc.zeroconf.async_send(outgoing)
     assert await resolve_task
     assert resolver.addresses == [b"\x7f\x00\x00\x01"]
+    await aiozc.async_close()
 
 
 @pytest.mark.asyncio
@@ -1854,6 +1857,7 @@ async def test_address_resolver_ipv6():
     aiozc.zeroconf.async_send(outgoing)
     assert await resolve_task
     assert resolver.ip_addresses_by_version(IPVersion.All) == [ip_address("fe80::52e:c2f2:bc5f:e9c6")]
+    await aiozc.async_close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -500,6 +500,7 @@ async def test_async_service_registration_name_strict_check(quick_timing: None) 
 
     await aiozc.async_unregister_service(info)
     await aiozc.async_close()
+    zc.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -824,6 +824,9 @@ def test_shutdown_while_register_in_process(quick_timing: None) -> None:
 async def test_event_loop_blocked(mock_start):
     """Test we raise NotRunningException when waiting for startup that times out."""
     aiozc = AsyncZeroconf(interfaces=["127.0.0.1"])
-    with pytest.raises(NotRunningException):
-        await aiozc.zeroconf.async_wait_for_start(timeout=0)
-    assert aiozc.zeroconf.started is False
+    try:
+        with pytest.raises(NotRunningException):
+            await aiozc.zeroconf.async_wait_for_start(timeout=0)
+        assert aiozc.zeroconf.started is False
+    finally:
+        await aiozc.async_close()

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -75,38 +75,22 @@ async def test_reaper():
 
 @pytest.mark.asyncio
 async def test_setup_releases_socket_ownership() -> None:
-    """After endpoints are created, ``_listen_socket``/``_respond_sockets`` are empty.
-
-    Pins the invariant that ``_async_shutdown`` relies on: sockets adopted
-    by transports are removed from the engine's pending-socket collections,
-    so anything left there is unowned and safe to close directly.
-    """
+    """Engine releases its pending-socket refs once each socket has a transport."""
     aiozc = AsyncZeroconf(interfaces=["127.0.0.1"])
     try:
         await aiozc.zeroconf.async_wait_for_start()
         engine = aiozc.zeroconf.engine
         assert engine._listen_socket is None
         assert engine._respond_sockets == []
-        assert engine.readers  # all sockets reached a reader transport
-        assert engine.senders  # ...and a sender transport
+        assert engine.readers
+        assert engine.senders
     finally:
         await aiozc.async_close()
 
 
 @pytest.mark.asyncio
 async def test_async_close_propagates_outer_cancellation() -> None:
-    """Outer-task cancellation while awaiting setup must reach the caller.
-
-    Pins the ``self._setup_task.cancelled()`` gate in ``_async_close``:
-    only a CancelledError from a *setup-task* cancel is swallowed; a
-    CancelledError that did not come from a setup-task cancel has to
-    surface so outer callers (``run_coro_with_timeout``, ``asyncio.wait_for``)
-    see it.
-
-    A future whose exception was set to ``CancelledError`` re-raises on
-    ``await`` while still reporting ``cancelled() is False`` — the exact
-    shape of an outer-task cancel from the gate's point of view.
-    """
+    """Outer-task cancellation while awaiting setup propagates to the caller."""
     aiozc = AsyncZeroconf(interfaces=["127.0.0.1"])
     try:
         await aiozc.zeroconf.async_wait_for_start()

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -87,7 +87,40 @@ async def test_setup_releases_socket_ownership() -> None:
         engine = aiozc.zeroconf.engine
         assert engine._listen_socket is None
         assert engine._respond_sockets == []
-        assert engine.readers  # all sockets reached a transport
+        assert engine.readers  # all sockets reached a reader transport
+        assert engine.senders  # ...and a sender transport
+    finally:
+        await aiozc.async_close()
+
+
+@pytest.mark.asyncio
+async def test_async_close_propagates_outer_cancellation() -> None:
+    """Outer-task cancellation while awaiting setup must reach the caller.
+
+    Pins the ``self._setup_task.cancelled()`` gate in ``_async_close``:
+    only a CancelledError from a *setup-task* cancel is swallowed; a
+    CancelledError that did not come from a setup-task cancel has to
+    surface so outer callers (``run_coro_with_timeout``, ``asyncio.wait_for``)
+    see it.
+
+    A future whose exception was set to ``CancelledError`` re-raises on
+    ``await`` while still reporting ``cancelled() is False`` — the exact
+    shape of an outer-task cancel from the gate's point of view.
+    """
+    aiozc = AsyncZeroconf(interfaces=["127.0.0.1"])
+    try:
+        await aiozc.zeroconf.async_wait_for_start()
+        engine = aiozc.zeroconf.engine
+        loop = asyncio.get_running_loop()
+        original_task = engine._setup_task
+        fake_task = loop.create_future()
+        fake_task.set_exception(asyncio.CancelledError())
+        engine._setup_task = fake_task  # type: ignore[assignment]
+        try:
+            with pytest.raises(asyncio.CancelledError):
+                await engine._async_close()
+        finally:
+            engine._setup_task = original_task
     finally:
         await aiozc.async_close()
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -74,6 +74,25 @@ async def test_reaper():
 
 
 @pytest.mark.asyncio
+async def test_setup_releases_socket_ownership() -> None:
+    """After endpoints are created, ``_listen_socket``/``_respond_sockets`` are empty.
+
+    Pins the invariant that ``_async_shutdown`` relies on: sockets adopted
+    by transports are removed from the engine's pending-socket collections,
+    so anything left there is unowned and safe to close directly.
+    """
+    aiozc = AsyncZeroconf(interfaces=["127.0.0.1"])
+    try:
+        await aiozc.zeroconf.async_wait_for_start()
+        engine = aiozc.zeroconf.engine
+        assert engine._listen_socket is None
+        assert engine._respond_sockets == []
+        assert engine.readers  # all sockets reached a transport
+    finally:
+        await aiozc.async_close()
+
+
+@pytest.mark.asyncio
 async def test_reaper_aborts_when_done():
     """Ensure cache cleanup stops when zeroconf is done."""
     with patch.object(_engine, "_CACHE_CLEANUP_INTERVAL", 0.01):

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1799,6 +1799,8 @@ async def test_response_aggregation_timings_multiple(run_isolated, disable_dupli
         zc.record_manager.async_updates_from_response(incoming)
         assert info2.dns_pointer() in incoming.answers()
 
+    await aiozc.async_close()
+
 
 @pytest.mark.asyncio
 async def test_response_aggregation_random_delay():

--- a/tests/utils/test_asyncio.py
+++ b/tests/utils/test_asyncio.py
@@ -105,6 +105,7 @@ def test_shutdown_loop() -> None:
 
     assert loop.is_running() is False
     runcoro_thread.join()
+    loop.close()
 
 
 def test_cumulative_timeouts_less_than_close_plus_buffer():


### PR DESCRIPTION
## Summary

Closes #1133 (long-standing pytest warning noise).

The library change is the load-bearing one: when `Zeroconf` is constructed inside a running asyncio loop, `AsyncEngine._async_setup` runs as a scheduled task and `_async_create_endpoints` only wraps the raw sockets it received in `__init__` once the loop gives the task a turn. If something closed the instance before that turn — a sync `zc.close()` from the same loop, an error path that bails before the first `await`, or a test that just races — `_async_shutdown` had no transports to close, the raw sockets stayed in `_listen_socket` / `_respond_sockets`, and the FDs leaked until interpreter shutdown.

The rest of the diff is the test-side cleanup #1133 originally pointed at.

## Details

- `_async_create_endpoints` now drops its handle on each socket as the transport adopts it (`self._listen_socket = None`, `self._respond_sockets.remove(s)`), so by definition anything left in those collections is unowned.
- `_async_shutdown` cancels any still-pending setup task (so it can't race in afterward to wrap a socket we're about to free) and then closes whatever wasn't adopted.
- `_async_close` swallows `CancelledError` from the awaited setup task and no longer asserts on `_cleanup_timer` — that timer is only scheduled inside `_async_setup`, so a setup that was cancelled before its first sync line never sets it.
- Tests:
  - `tests/services/test_info.py` — four tests created an `AsyncZeroconf` and never called `async_close`; added it.
  - `tests/test_asyncio.py::test_async_service_registration_name_strict_check` — same, for a sync `Zeroconf`.
  - `tests/test_handlers.py::test_response_aggregation_timings_multiple` — same.
  - `tests/test_core.py::test_event_loop_blocked` — mocks `_async_setup`, so the engine sockets were never wrapped; `async_close` now closes them via the path above.
  - `tests/utils/test_asyncio.py::test_shutdown_loop` — added the missing `loop.close()`.
  - `tests/services/test_browser.py::test_service_browser_listeners_no_update_service` — gave the listener an empty `update_service` so the browser thread stops surfacing `NotImplementedError` (the test's intent — that no update callbacks are recorded — is preserved).

No protocol-affecting changes; nothing in `const.py` moved.

## Test plan

- [x] `poetry run pytest --timeout=60 tests` — 335 passed, 3 skipped, 0 warnings.
- [x] `poetry run pytest -W error::ResourceWarning -W error::pytest.PytestUnraisableExceptionWarning -W error::pytest.PytestUnhandledThreadExceptionWarning --timeout=60 tests` — same result; the strict filters that would have errored before now pass.
- [x] `poetry run pre-commit run --files <changed files>` — clean.
