### PR TITLE
test: cap helper get_service_info timeout in suppression test (~3.0s → ~1.85s)

### DIFF
--- a/tests/services/test_info.py
+++ b/tests/services/test_info.py
@@ -430,9 +430,9 @@ class TestServiceInfo(unittest.TestCase):
 
                 return r.DNSIncoming(generated.packets()[0])
 
-            def get_service_info_helper(zc, type, name):
+            def get_service_info_helper(zc, type, name, timeout):
                 nonlocal service_info
-                service_info = zc.get_service_info(type, name)
+                service_info = zc.get_service_info(type, name, timeout)
                 service_info_event.set()
 
             try:
@@ -453,9 +453,14 @@ class TestServiceInfo(unittest.TestCase):
                 for question in seed_history_questions:
                     zc.question_history.add_question_at_time(question, far_future, set())
 
+                # No answers ever come back (all queries are suppressed),
+                # so cap the helper at the worst-case sum of the three
+                # phase waits below plus margin instead of the 3000ms
+                # default. Phase 3 waits ~1.6s (the 999ms QM gap plus
+                # jitter and 500ms buffer); 1500ms covers it.
                 helper_thread = threading.Thread(
                     target=get_service_info_helper,
-                    args=(zc, service_type, service_name),
+                    args=(zc, service_type, service_name, 1500),
                 )
                 helper_thread.start()
                 wait_time = (const._LISTENER_TIME + info._AVOID_SYNC_DELAY_RANDOM_INTERVAL[1] + 500) / 1000


### PR DESCRIPTION
## Summary

Part of #1707. Tests-only change.

The helper thread in `test_get_info_suppressed_by_question_history` calls `zc.get_service_info` with the default 3000ms timeout. Every query in this test is suppressed by the seeded question history, so no answer ever arrives — the helper sits at the full timeout. The three phase waits in the main thread sum to ~2.06s, so capping the helper at 1500ms is safe and lets the test finish in the phase-wait budget instead of the helper-timeout budget.

No production change.

Wall time:
- Before: 3.01s
- After: 1.85s

## Test plan

- [x] Targeted test passes under Cython build (`REQUIRE_CYTHON=1`)
- [x] Full `tests/` suite passes (337 passed, 3 IPv6 skips)
- [x] Pre-commit hooks pass