### PR TITLE
test: drop ZeroconfServiceTypes.find() timeouts from 500ms to 200ms on loopback

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -42,6 +42,13 @@ _MONOTONIC_RESOLUTION = time.get_clock_info("monotonic").resolution
 # or two queries.
 QUICK_REQUEST_TIMEOUT_MS = 50
 
+# Timeout for ZeroconfServiceTypes.find() / AsyncZeroconfServiceTypes.async_find()
+# in loopback integration tests. `find()` is just `time.sleep(timeout)` —
+# it doesn't short-circuit on the first matching response — so the
+# timeout becomes a lower bound on the test runtime. On loopback the
+# registrar's response lands within a few ms; 200ms is ~50x headroom.
+LOOPBACK_FIND_TIMEOUT = 0.2
+
 
 class QuestionHistoryWithoutSuppression(QuestionHistory):
     def suppresses(self, question: DNSQuestion, now: float, known_answers: set[DNSRecord]) -> bool:

--- a/tests/services/test_types.py
+++ b/tests/services/test_types.py
@@ -11,7 +11,7 @@ import unittest
 import zeroconf as r
 from zeroconf import ServiceInfo, Zeroconf, ZeroconfServiceTypes
 
-from .. import _clear_cache, has_working_ipv6
+from .. import LOOPBACK_FIND_TIMEOUT, _clear_cache, has_working_ipv6
 
 log = logging.getLogger("zeroconf")
 original_logging_level = logging.NOTSET
@@ -47,10 +47,10 @@ def test_integration_with_listener(disable_duplicate_packet_suppression):
     )
     zeroconf_registrar.registry.async_add(info)
     try:
-        service_types = ZeroconfServiceTypes.find(interfaces=["127.0.0.1"], timeout=0.2)
+        service_types = ZeroconfServiceTypes.find(interfaces=["127.0.0.1"], timeout=LOOPBACK_FIND_TIMEOUT)
         assert type_ in service_types
         _clear_cache(zeroconf_registrar)
-        service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=0.2)
+        service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=LOOPBACK_FIND_TIMEOUT)
         assert type_ in service_types
 
     finally:
@@ -79,10 +79,10 @@ def test_integration_with_listener_v6_records(disable_duplicate_packet_suppressi
     )
     zeroconf_registrar.registry.async_add(info)
     try:
-        service_types = ZeroconfServiceTypes.find(interfaces=["127.0.0.1"], timeout=0.2)
+        service_types = ZeroconfServiceTypes.find(interfaces=["127.0.0.1"], timeout=LOOPBACK_FIND_TIMEOUT)
         assert type_ in service_types
         _clear_cache(zeroconf_registrar)
-        service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=0.2)
+        service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=LOOPBACK_FIND_TIMEOUT)
         assert type_ in service_types
 
     finally:
@@ -115,10 +115,12 @@ def test_integration_with_listener_ipv6(disable_duplicate_packet_suppression):
     )
     zeroconf_registrar.registry.async_add(info)
     try:
-        service_types = ZeroconfServiceTypes.find(ip_version=r.IPVersion.V6Only, timeout=0.2)
+        service_types = ZeroconfServiceTypes.find(
+            ip_version=r.IPVersion.V6Only, timeout=LOOPBACK_FIND_TIMEOUT
+        )
         assert type_ in service_types
         _clear_cache(zeroconf_registrar)
-        service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=0.2)
+        service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=LOOPBACK_FIND_TIMEOUT)
         assert type_ in service_types
 
     finally:
@@ -147,10 +149,10 @@ def test_integration_with_subtype_and_listener(disable_duplicate_packet_suppress
     )
     zeroconf_registrar.registry.async_add(info)
     try:
-        service_types = ZeroconfServiceTypes.find(interfaces=["127.0.0.1"], timeout=0.2)
+        service_types = ZeroconfServiceTypes.find(interfaces=["127.0.0.1"], timeout=LOOPBACK_FIND_TIMEOUT)
         assert discovery_type in service_types
         _clear_cache(zeroconf_registrar)
-        service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=0.2)
+        service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=LOOPBACK_FIND_TIMEOUT)
         assert discovery_type in service_types
 
     finally:

--- a/tests/services/test_types.py
+++ b/tests/services/test_types.py
@@ -47,10 +47,10 @@ def test_integration_with_listener(disable_duplicate_packet_suppression):
     )
     zeroconf_registrar.registry.async_add(info)
     try:
-        service_types = ZeroconfServiceTypes.find(interfaces=["127.0.0.1"], timeout=0.5)
+        service_types = ZeroconfServiceTypes.find(interfaces=["127.0.0.1"], timeout=0.2)
         assert type_ in service_types
         _clear_cache(zeroconf_registrar)
-        service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=0.5)
+        service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=0.2)
         assert type_ in service_types
 
     finally:
@@ -79,10 +79,10 @@ def test_integration_with_listener_v6_records(disable_duplicate_packet_suppressi
     )
     zeroconf_registrar.registry.async_add(info)
     try:
-        service_types = ZeroconfServiceTypes.find(interfaces=["127.0.0.1"], timeout=0.5)
+        service_types = ZeroconfServiceTypes.find(interfaces=["127.0.0.1"], timeout=0.2)
         assert type_ in service_types
         _clear_cache(zeroconf_registrar)
-        service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=0.5)
+        service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=0.2)
         assert type_ in service_types
 
     finally:
@@ -115,10 +115,10 @@ def test_integration_with_listener_ipv6(disable_duplicate_packet_suppression):
     )
     zeroconf_registrar.registry.async_add(info)
     try:
-        service_types = ZeroconfServiceTypes.find(ip_version=r.IPVersion.V6Only, timeout=0.5)
+        service_types = ZeroconfServiceTypes.find(ip_version=r.IPVersion.V6Only, timeout=0.2)
         assert type_ in service_types
         _clear_cache(zeroconf_registrar)
-        service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=0.5)
+        service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=0.2)
         assert type_ in service_types
 
     finally:
@@ -147,10 +147,10 @@ def test_integration_with_subtype_and_listener(disable_duplicate_packet_suppress
     )
     zeroconf_registrar.registry.async_add(info)
     try:
-        service_types = ZeroconfServiceTypes.find(interfaces=["127.0.0.1"], timeout=0.5)
+        service_types = ZeroconfServiceTypes.find(interfaces=["127.0.0.1"], timeout=0.2)
         assert discovery_type in service_types
         _clear_cache(zeroconf_registrar)
-        service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=0.5)
+        service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=0.2)
         assert discovery_type in service_types
 
     finally:

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -43,6 +43,7 @@ from zeroconf.asyncio import (
 from zeroconf.const import _LISTENER_TIME
 
 from . import (
+    LOOPBACK_FIND_TIMEOUT,
     QUICK_REQUEST_TIMEOUT_MS,
     QuestionHistoryWithoutSuppression,
     _clear_cache,
@@ -925,10 +926,14 @@ async def test_async_zeroconf_service_types(quick_timing: None) -> None:
     await asyncio.sleep(0.05)
     _clear_cache(zeroconf_registrar.zeroconf)
     try:
-        service_types = await AsyncZeroconfServiceTypes.async_find(interfaces=["127.0.0.1"], timeout=0.2)
+        service_types = await AsyncZeroconfServiceTypes.async_find(
+            interfaces=["127.0.0.1"], timeout=LOOPBACK_FIND_TIMEOUT
+        )
         assert type_ in service_types
         _clear_cache(zeroconf_registrar.zeroconf)
-        service_types = await AsyncZeroconfServiceTypes.async_find(aiozc=zeroconf_registrar, timeout=0.2)
+        service_types = await AsyncZeroconfServiceTypes.async_find(
+            aiozc=zeroconf_registrar, timeout=LOOPBACK_FIND_TIMEOUT
+        )
         assert type_ in service_types
 
     finally:

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -919,14 +919,16 @@ async def test_async_zeroconf_service_types(quick_timing: None) -> None:
     )
     task = await zeroconf_registrar.async_register_service(info)
     await task
-    # Ensure we do not clear the cache until after the last broadcast is processed
-    await asyncio.sleep(0.2)
+    # Wait for the last announce broadcast before clearing. With
+    # `quick_timing` the broadcasts use _REGISTER_TIME=10ms apart so
+    # 50ms is plenty.
+    await asyncio.sleep(0.05)
     _clear_cache(zeroconf_registrar.zeroconf)
     try:
-        service_types = await AsyncZeroconfServiceTypes.async_find(interfaces=["127.0.0.1"], timeout=0.5)
+        service_types = await AsyncZeroconfServiceTypes.async_find(interfaces=["127.0.0.1"], timeout=0.2)
         assert type_ in service_types
         _clear_cache(zeroconf_registrar.zeroconf)
-        service_types = await AsyncZeroconfServiceTypes.async_find(aiozc=zeroconf_registrar, timeout=0.5)
+        service_types = await AsyncZeroconfServiceTypes.async_find(aiozc=zeroconf_registrar, timeout=0.2)
         assert type_ in service_types
 
     finally:


### PR DESCRIPTION
## Summary

Part of #1707 (slow tests sweep). Bucket C of a 3-PR series (follows #1708, #1709).

`ZeroconfServiceTypes.find()` is implemented as a bare `time.sleep(timeout)` — it doesn't short-circuit on the first matching response — so the timeout argument becomes a lower bound on test runtime. The integration-with-listener tests each call `find()` twice and pay 1.0s of pure sleep on top of ~200ms of registration setup. On loopback the registrar's response lands within a few ms, so 200ms is ~50× headroom.

`test_async_zeroconf_service_types` also slept 200ms after `async_register_service` to let the final announce broadcast land. That test already has the `quick_timing` fixture (which patches `_REGISTER_TIME=10ms`), so 50ms is plenty.

Speedups:

| test | before | after |
| --- | --- | --- |
| `test_integration_with_listener` | 1.28s | 0.67s |
| `test_integration_with_subtype_and_listener` | 1.27s | 0.66s |
| `test_integration_with_listener_v6_records` | 1.27s | 0.67s |
| `test_integration_with_listener_ipv6` (same pattern, not in #1707) | — | 0.67s |
| `test_async_zeroconf_service_types` | 1.54s | 0.77s |

Stable across 3 sequential runs. No production change.

The cleaner long-term fix is making `find()` event-driven (return as soon as expected types arrive) — left for a follow-up since that's an API-shape change.

## Test plan

- [x] Targeted tests pass three times in a row
- [x] Full `tests/` suite passes (337 passed, 3 IPv6 skips)
- [x] Pre-commit hooks pass