### PR TITLE
test: fix race in test_register_and_lookup_type_by_uppercase_name

### DIFF
--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -219,7 +219,11 @@ class TestRegistrar(unittest.TestCase):
         for _ in range(50):
             time.sleep(0.02)
             info.load_from_cache(zc)
-            if info.addresses:
+            # Wait for both A and TXT records — they arrive as separate
+            # cache updates and the listener may schedule the assertions
+            # between the two. Breaking on just `info.addresses` makes
+            # the test flaky under PyPy / skip_cython.
+            if info.addresses and info.properties:
                 break
         assert info.addresses == [socket.inet_pton(socket.AF_INET, "1.2.3.4")]
         assert info.properties == {b"version": b"1.0"}


### PR DESCRIPTION
## Summary

`test_register_and_lookup_type_by_uppercase_name` has a long-standing race that surfaced on the PR #1710 CI run for the pypy-3.10 / ubuntu / skip_cython matrix entry. The cache-poll loop:

```python
for _ in range(50):
    time.sleep(0.02)
    info.load_from_cache(zc)
    if info.addresses:
        break
assert info.addresses == [socket.inet_pton(socket.AF_INET, "1.2.3.4")]
assert info.properties == {b"version": b"1.0"}
```

breaks on the A record landing, but the next assertion checks the TXT record, which arrives via a separate cache update. Under PyPy / skip_cython the listener occasionally schedules the assertions between the two updates, leaving `info.properties == {}`.

Fix: require both before exiting the loop.

```python
if info.addresses and info.properties:
    break
```

The race predates and is not specific to PR #1710 — same flakiness class hit a recent master run on a different test (`test_service_browser_expire_callbacks`).

## Test plan

- [x] Targeted test passes locally
- [x] Pre-commit hooks pass