### PR TITLE
fix: bound _seen_logs and stop retaining exc_info

### DIFF
--- a/src/zeroconf/_logger.py
+++ b/src/zeroconf/_logger.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 import logging
 import sys
-from typing import Any, ClassVar, cast
+from typing import Any, ClassVar
 
 log = logging.getLogger(__name__.split(".", maxsplit=1)[0])
 log.addHandler(logging.NullHandler())
@@ -39,50 +39,42 @@ def set_logger_level_if_unset() -> None:
 set_logger_level_if_unset()
 
 
+_MAX_SEEN_LOGS = 256
+
+
 class QuietLogger:
-    _seen_logs: ClassVar[dict[str, int | tuple]] = {}
+    _seen_logs: ClassVar[set[str]] = set()
+
+    @classmethod
+    def _mark_seen(cls, key: str) -> bool:
+        """Record ``key`` and return True if it was newly added."""
+        if key in cls._seen_logs:
+            return False
+        # Keys can carry caller-supplied fields (peer addresses, packet
+        # offsets); clear when full so a malicious peer can't grow the
+        # set without bound.
+        if len(cls._seen_logs) >= _MAX_SEEN_LOGS:
+            cls._seen_logs.clear()
+        cls._seen_logs.add(key)
+        return True
 
     @classmethod
     def log_exception_warning(cls, *logger_data: Any) -> None:
-        exc_info = sys.exc_info()
-        exc_str = str(exc_info[1])
-        if exc_str not in cls._seen_logs:
-            # log at warning level the first time this is seen
-            cls._seen_logs[exc_str] = exc_info
-            logger = log.warning
-        else:
-            logger = log.debug
+        first_time = cls._mark_seen(str(sys.exc_info()[1]))
+        logger = log.warning if first_time else log.debug
         logger(*(logger_data or ["Exception occurred"]), exc_info=True)
 
     @classmethod
     def log_exception_debug(cls, *logger_data: Any) -> None:
-        log_exc_info = False
-        exc_info = sys.exc_info()
-        exc_str = str(exc_info[1])
-        if exc_str not in cls._seen_logs:
-            # log the trace only on the first time
-            cls._seen_logs[exc_str] = exc_info
-            log_exc_info = True
-        log.debug(*(logger_data or ["Exception occurred"]), exc_info=log_exc_info)
+        first_time = cls._mark_seen(str(sys.exc_info()[1]))
+        log.debug(*(logger_data or ["Exception occurred"]), exc_info=first_time)
 
     @classmethod
     def log_warning_once(cls, *args: Any) -> None:
-        msg_str = args[0]
-        if msg_str not in cls._seen_logs:
-            cls._seen_logs[msg_str] = 0
-            logger = log.warning
-        else:
-            logger = log.debug
-        cls._seen_logs[msg_str] = cast(int, cls._seen_logs[msg_str]) + 1
+        logger = log.warning if cls._mark_seen(args[0]) else log.debug
         logger(*args)
 
     @classmethod
     def log_exception_once(cls, exc: Exception, *args: Any) -> None:
-        msg_str = args[0]
-        if msg_str not in cls._seen_logs:
-            cls._seen_logs[msg_str] = 0
-            logger = log.warning
-        else:
-            logger = log.debug
-        cls._seen_logs[msg_str] = cast(int, cls._seen_logs[msg_str]) + 1
+        logger = log.warning if cls._mark_seen(args[0]) else log.debug
         logger(*args, exc_info=exc)

--- a/src/zeroconf/_logger.py
+++ b/src/zeroconf/_logger.py
@@ -50,11 +50,27 @@ def _mark_seen(seen: dict[str, None], key: str) -> bool:
     addresses, packet offsets) cannot grow it without bound. Evicts
     the oldest entry per overflow (dict preserves insertion order on
     Python 3.7+), so ``_MAX_SEEN_LOGS`` is a recency window.
+
+    The dict is shared across all ``Zeroconf`` instances in the
+    process; on the free-threaded build (3.14t) and under multi-
+    instance sync use, callers can race. Individual dict operations
+    (``in``, ``__setitem__``, ``pop``, ``len``) are atomic in CPython
+    3.13+ FT and don't crash, but the compound ``iter`` → ``next``
+    used to find the FIFO victim can raise ``RuntimeError`` if
+    another thread mutates the dict between the two ops. Catch and
+    skip — the other thread is already shrinking the set, so missing
+    one eviction here just lets the cap drift up by one entry per
+    racing thread until contention clears.
     """
     if key in seen:
         return False
     if len(seen) >= _MAX_SEEN_LOGS:
-        del seen[next(iter(seen))]
+        try:
+            oldest = next(iter(seen), None)
+        except RuntimeError:
+            oldest = None
+        if oldest is not None:
+            seen.pop(oldest, None)
     seen[key] = None
     return True
 

--- a/src/zeroconf/_logger.py
+++ b/src/zeroconf/_logger.py
@@ -48,7 +48,7 @@ def _mark_seen(seen: dict[str, None], key: str) -> bool:
 
     Bounds the dict so callers passing attacker-influenced keys (peer
     addresses, packet offsets) cannot grow it without bound. Evicts
-    the oldest entry per overflow (dict preserves insertion order on
+    the oldest entries on overflow (dict preserves insertion order on
     Python 3.7+), so ``_MAX_SEEN_LOGS`` is a recency window.
 
     The dict is shared across all ``Zeroconf`` instances in the
@@ -57,20 +57,20 @@ def _mark_seen(seen: dict[str, None], key: str) -> bool:
     (``in``, ``__setitem__``, ``pop``, ``len``) are atomic in CPython
     3.13+ FT and don't crash, but the compound ``iter`` → ``next``
     used to find the FIFO victim can raise ``RuntimeError`` if
-    another thread mutates the dict between the two ops. Catch and
-    skip — the other thread is already shrinking the set, so missing
-    one eviction here just lets the cap drift up by one entry per
-    racing thread until contention clears.
+    another thread mutates the dict between the two ops. The
+    eviction loop drains until ``len(seen) < _MAX_SEEN_LOGS`` so that
+    any drift accumulated by prior concurrent inserts is corrected by
+    the next caller, and bails on ``RuntimeError`` (another thread is
+    already shrinking the set) so we don't spin.
     """
     if key in seen:
         return False
-    if len(seen) >= _MAX_SEEN_LOGS:
+    while len(seen) >= _MAX_SEEN_LOGS:
         try:
-            oldest = next(iter(seen), None)
-        except RuntimeError:
-            oldest = None
-        if oldest is not None:
-            seen.pop(oldest, None)
+            oldest = next(iter(seen))
+        except (RuntimeError, StopIteration):
+            break
+        seen.pop(oldest, None)
     seen[key] = None
     return True
 

--- a/src/zeroconf/_logger.py
+++ b/src/zeroconf/_logger.py
@@ -39,7 +39,7 @@ def set_logger_level_if_unset() -> None:
 set_logger_level_if_unset()
 
 
-_MAX_SEEN_LOGS = 256
+_MAX_SEEN_LOGS = 512
 _seen_logs: set[str] = set()
 
 
@@ -47,12 +47,14 @@ def _mark_seen(seen: set[str], key: str) -> bool:
     """Record ``key`` in ``seen`` and return True if it was newly added.
 
     Bounds the set so callers passing attacker-influenced keys (peer
-    addresses, packet offsets) cannot grow it without bound.
+    addresses, packet offsets) cannot grow it without bound. Evicts
+    one arbitrary entry per overflow so warning-level re-emissions
+    stay smooth rather than arriving in bursts.
     """
     if key in seen:
         return False
     if len(seen) >= _MAX_SEEN_LOGS:
-        seen.clear()
+        seen.pop()
     seen.add(key)
     return True
 

--- a/src/zeroconf/_logger.py
+++ b/src/zeroconf/_logger.py
@@ -40,22 +40,22 @@ set_logger_level_if_unset()
 
 
 _MAX_SEEN_LOGS = 512
-_seen_logs: set[str] = set()
+_seen_logs: dict[str, None] = {}
 
 
-def _mark_seen(seen: set[str], key: str) -> bool:
+def _mark_seen(seen: dict[str, None], key: str) -> bool:
     """Record ``key`` in ``seen`` and return True if it was newly added.
 
-    Bounds the set so callers passing attacker-influenced keys (peer
+    Bounds the dict so callers passing attacker-influenced keys (peer
     addresses, packet offsets) cannot grow it without bound. Evicts
-    one arbitrary entry per overflow so warning-level re-emissions
-    stay smooth rather than arriving in bursts.
+    the oldest entry per overflow (dict preserves insertion order on
+    Python 3.7+), so ``_MAX_SEEN_LOGS`` is a recency window.
     """
     if key in seen:
         return False
     if len(seen) >= _MAX_SEEN_LOGS:
-        seen.pop()
-    seen.add(key)
+        del seen[next(iter(seen))]
+    seen[key] = None
     return True
 
 

--- a/src/zeroconf/_logger.py
+++ b/src/zeroconf/_logger.py
@@ -43,6 +43,23 @@ _MAX_SEEN_LOGS = 512
 _seen_logs: dict[str, None] = {}
 
 
+def _evict_oldest(seen: dict[str, None]) -> bool:
+    """Pop the oldest entry from ``seen``; return False if it raced.
+
+    Individual dict ops (``pop`` with a default, ``next``) are atomic
+    on the free-threaded build, but the compound ``iter`` → ``next``
+    used to pick the FIFO victim can raise ``RuntimeError`` if
+    another thread mutates the dict between the two ops. The caller
+    breaks its drain loop on False so concurrent mutation can't make
+    it spin.
+    """
+    try:
+        seen.pop(next(iter(seen)), None)
+    except (RuntimeError, StopIteration):
+        return False
+    return True
+
+
 def _mark_seen(seen: dict[str, None], key: str) -> bool:
     """Record ``key`` in ``seen`` and return True if it was newly added.
 
@@ -53,26 +70,22 @@ def _mark_seen(seen: dict[str, None], key: str) -> bool:
 
     The dict is shared across all ``Zeroconf`` instances in the
     process; on the free-threaded build (3.14t) and under multi-
-    instance sync use, callers can race. Individual dict operations
-    (``in``, ``__setitem__``, ``pop``, ``len``) are atomic in CPython
-    3.13+ FT and don't crash, but the compound ``iter`` → ``next``
-    used to find the FIFO victim can raise ``RuntimeError`` if
-    another thread mutates the dict between the two ops. The
-    eviction loop drains until ``len(seen) < _MAX_SEEN_LOGS`` so that
-    any drift accumulated by prior concurrent inserts is corrected by
-    the next caller, and bails on ``RuntimeError`` (another thread is
-    already shrinking the set) so we don't spin.
+    instance sync use, callers can race the ``len < cap`` check and
+    both insert, leaving the dict transiently above the cap. The
+    drain loop runs on every call (steady-state-at-cap hits are a
+    single ``len`` + compare past the membership check because the
+    helper short-circuits) so a contention burst is corrected by the
+    next caller regardless of whether it's a hit or a miss.
     """
-    if key in seen:
-        return False
-    while len(seen) >= _MAX_SEEN_LOGS:
-        try:
-            oldest = next(iter(seen))
-        except (RuntimeError, StopIteration):
-            break
-        seen.pop(oldest, None)
-    seen[key] = None
-    return True
+    inserting = key not in seen
+    # Hit (``inserting`` is False): drain only if drifted above cap.
+    # Miss (``inserting`` is True): drain to ``cap - 1`` to make room
+    # for the new key. Bool subtracts as 0/1 to pick the right limit.
+    while len(seen) > _MAX_SEEN_LOGS - inserting and _evict_oldest(seen):
+        pass
+    if inserting:
+        seen[key] = None
+    return inserting
 
 
 class QuietLogger:

--- a/src/zeroconf/_logger.py
+++ b/src/zeroconf/_logger.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 import logging
 import sys
-from typing import Any, ClassVar
+from typing import Any
 
 log = logging.getLogger(__name__.split(".", maxsplit=1)[0])
 log.addHandler(logging.NullHandler())
@@ -40,41 +40,41 @@ set_logger_level_if_unset()
 
 
 _MAX_SEEN_LOGS = 256
+_seen_logs: set[str] = set()
+
+
+def _mark_seen(seen: set[str], key: str) -> bool:
+    """Record ``key`` in ``seen`` and return True if it was newly added.
+
+    Bounds the set so callers passing attacker-influenced keys (peer
+    addresses, packet offsets) cannot grow it without bound.
+    """
+    if key in seen:
+        return False
+    if len(seen) >= _MAX_SEEN_LOGS:
+        seen.clear()
+    seen.add(key)
+    return True
 
 
 class QuietLogger:
-    _seen_logs: ClassVar[set[str]] = set()
-
-    @classmethod
-    def _mark_seen(cls, key: str) -> bool:
-        """Record ``key`` and return True if it was newly added."""
-        if key in cls._seen_logs:
-            return False
-        # Keys can carry caller-supplied fields (peer addresses, packet
-        # offsets); clear when full so a malicious peer can't grow the
-        # set without bound.
-        if len(cls._seen_logs) >= _MAX_SEEN_LOGS:
-            cls._seen_logs.clear()
-        cls._seen_logs.add(key)
-        return True
-
     @classmethod
     def log_exception_warning(cls, *logger_data: Any) -> None:
-        first_time = cls._mark_seen(str(sys.exc_info()[1]))
+        first_time = _mark_seen(_seen_logs, str(sys.exc_info()[1]))
         logger = log.warning if first_time else log.debug
         logger(*(logger_data or ["Exception occurred"]), exc_info=True)
 
     @classmethod
     def log_exception_debug(cls, *logger_data: Any) -> None:
-        first_time = cls._mark_seen(str(sys.exc_info()[1]))
+        first_time = _mark_seen(_seen_logs, str(sys.exc_info()[1]))
         log.debug(*(logger_data or ["Exception occurred"]), exc_info=first_time)
 
     @classmethod
     def log_warning_once(cls, *args: Any) -> None:
-        logger = log.warning if cls._mark_seen(args[0]) else log.debug
+        logger = log.warning if _mark_seen(_seen_logs, args[0]) else log.debug
         logger(*args)
 
     @classmethod
     def log_exception_once(cls, exc: Exception, *args: Any) -> None:
-        logger = log.warning if cls._mark_seen(args[0]) else log.debug
+        logger = log.warning if _mark_seen(_seen_logs, args[0]) else log.debug
         logger(*args, exc_info=exc)

--- a/src/zeroconf/_protocol/incoming.py
+++ b/src/zeroconf/_protocol/incoming.py
@@ -63,7 +63,7 @@ MAX_NAME_LENGTH = 253
 DECODE_EXCEPTIONS = (IndexError, struct.error, IncomingDecodeError)
 
 
-_seen_logs: set[str] = set()
+_seen_logs: dict[str, None] = {}
 _str = str
 _int = int
 

--- a/src/zeroconf/_protocol/incoming.py
+++ b/src/zeroconf/_protocol/incoming.py
@@ -37,7 +37,7 @@ from .._dns import (
     DNSText,
 )
 from .._exceptions import IncomingDecodeError
-from .._logger import log
+from .._logger import _mark_seen, log
 from .._utils.time import current_time_millis
 from ..const import (
     _FLAGS_QR_MASK,
@@ -63,7 +63,6 @@ MAX_NAME_LENGTH = 253
 DECODE_EXCEPTIONS = (IndexError, struct.error, IncomingDecodeError)
 
 
-_MAX_SEEN_LOGS = 256
 _seen_logs: set[str] = set()
 _str = str
 _int = int
@@ -183,16 +182,7 @@ class DNSIncoming:
 
     @classmethod
     def _log_exception_debug(cls, *logger_data: Any) -> None:
-        log_exc_info = False
-        exc_str = str(sys.exc_info()[1])
-        if exc_str not in _seen_logs:
-            # The dedup key embeds attacker-controlled fields (peer IP/port,
-            # byte offsets); clear when full so a malicious peer can't grow
-            # the set without bound.
-            if len(_seen_logs) >= _MAX_SEEN_LOGS:
-                _seen_logs.clear()
-            _seen_logs.add(exc_str)
-            log_exc_info = True
+        log_exc_info = _mark_seen(_seen_logs, str(sys.exc_info()[1]))
         log.debug(*(logger_data or ["Exception occurred"]), exc_info=log_exc_info)
 
     def answers(self) -> list[DNSRecord]:

--- a/src/zeroconf/_protocol/incoming.py
+++ b/src/zeroconf/_protocol/incoming.py
@@ -63,7 +63,8 @@ MAX_NAME_LENGTH = 253
 DECODE_EXCEPTIONS = (IndexError, struct.error, IncomingDecodeError)
 
 
-_seen_logs: dict[str, int | tuple] = {}
+_MAX_SEEN_LOGS = 256
+_seen_logs: set[str] = set()
 _str = str
 _int = int
 
@@ -183,11 +184,14 @@ class DNSIncoming:
     @classmethod
     def _log_exception_debug(cls, *logger_data: Any) -> None:
         log_exc_info = False
-        exc_info = sys.exc_info()
-        exc_str = str(exc_info[1])
+        exc_str = str(sys.exc_info()[1])
         if exc_str not in _seen_logs:
-            # log the trace only on the first time
-            _seen_logs[exc_str] = exc_info
+            # The dedup key embeds attacker-controlled fields (peer IP/port,
+            # byte offsets); clear when full so a malicious peer can't grow
+            # the set without bound.
+            if len(_seen_logs) >= _MAX_SEEN_LOGS:
+                _seen_logs.clear()
+            _seen_logs.add(exc_str)
             log_exc_info = True
         log.debug(*(logger_data or ["Exception occurred"]), exc_info=log_exc_info)
 

--- a/tests/benchmarks/test_mark_seen.py
+++ b/tests/benchmarks/test_mark_seen.py
@@ -1,0 +1,39 @@
+"""Benchmark for _logger._mark_seen."""
+
+from __future__ import annotations
+
+from pytest_codspeed import BenchmarkFixture
+
+from zeroconf._logger import _MAX_SEEN_LOGS, _mark_seen
+
+
+def test_mark_seen_hit(benchmark: BenchmarkFixture) -> None:
+    """Benchmark the cache-hit path (same key repeated)."""
+    seen: dict[str, None] = {"warm": None}
+
+    @benchmark
+    def _hit() -> None:
+        for _ in range(1000):
+            _mark_seen(seen, "warm")
+
+
+def test_mark_seen_fill(benchmark: BenchmarkFixture) -> None:
+    """Benchmark filling from empty up to the cap (no evictions)."""
+    keys = [f"key-{i}" for i in range(_MAX_SEEN_LOGS)]
+
+    @benchmark
+    def _fill() -> None:
+        seen: dict[str, None] = {}
+        for k in keys:
+            _mark_seen(seen, k)
+
+
+def test_mark_seen_churn(benchmark: BenchmarkFixture) -> None:
+    """Benchmark sustained eviction (every call past the cap drops oldest)."""
+    keys = [f"churn-{i}" for i in range(_MAX_SEEN_LOGS * 4)]
+
+    @benchmark
+    def _churn() -> None:
+        seen: dict[str, None] = {}
+        for k in keys:
+            _mark_seen(seen, k)

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -85,13 +85,18 @@ def test_llog_exception_debug():
     assert mock_log_debug.mock_calls == [call("the exception", exc_info=False)]
 
 
-def test_seen_logs_is_bounded():
-    """Distinct keys must not grow ``_seen_logs`` without bound."""
+def test_seen_logs_is_bounded() -> None:
+    """``_seen_logs`` stays at the cap and evicts oldest-first (FIFO)."""
     _logger._seen_logs.clear()
+    overflow = 5
     with patch("zeroconf._logger.log.warning"), patch("zeroconf._logger.log.debug"):
-        for i in range(_MAX_SEEN_LOGS + 5):
+        for i in range(_MAX_SEEN_LOGS + overflow):
             QuietLogger.log_warning_once(f"warning-{i}")
-    assert len(_logger._seen_logs) <= _MAX_SEEN_LOGS
+    assert len(_logger._seen_logs) == _MAX_SEEN_LOGS
+    for i in range(overflow):
+        assert f"warning-{i}" not in _logger._seen_logs
+    for i in range(_MAX_SEEN_LOGS, _MAX_SEEN_LOGS + overflow):
+        assert f"warning-{i}" in _logger._seen_logs
 
 
 def test_log_exception_once():

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -126,6 +126,27 @@ def test_mark_seen_drains_drift_above_cap() -> None:
         assert f"k-{i}" not in seen
 
 
+def test_mark_seen_drains_drift_on_hit_path() -> None:
+    """``_mark_seen`` drains drift even when ``key`` is already cached.
+
+    A hit-heavy workload after a contention burst (e.g. the same
+    exception text deduplicated repeatedly) must still correct the
+    overshoot — otherwise the dict can sit permanently above the cap
+    until a miss happens to come along.
+    """
+    seen: dict[str, None] = {}
+    drift = 10
+    for i in range(_MAX_SEEN_LOGS + drift):
+        seen[f"k-{i}"] = None
+    # Hit on a non-oldest key — survives the drift drain.
+    hit_key = f"k-{_MAX_SEEN_LOGS}"
+    assert _mark_seen(seen, hit_key) is False
+    assert len(seen) == _MAX_SEEN_LOGS
+    assert hit_key in seen
+    for i in range(drift):
+        assert f"k-{i}" not in seen
+
+
 def test_seen_logs_is_bounded() -> None:
     """``_seen_logs`` stays at the cap and evicts oldest-first (FIFO)."""
     _logger._seen_logs.clear()

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -105,6 +105,27 @@ def test_mark_seen_absorbs_runtime_error_during_eviction() -> None:
     assert "new-key" in seen
 
 
+def test_mark_seen_drains_drift_above_cap() -> None:
+    """``_mark_seen`` drains a drifted-over-cap dict back to the cap.
+
+    Concurrent inserts on the free-threaded build can leave the dict
+    transiently above ``_MAX_SEEN_LOGS`` (e.g. two threads both passed
+    the ``len < cap`` check and both inserted). The next non-racing
+    call must drain the accumulated overshoot, not just evict one
+    entry — otherwise the cap silently inflates with thread count.
+    """
+    seen: dict[str, None] = {}
+    drift = 10
+    for i in range(_MAX_SEEN_LOGS + drift):
+        seen[f"k-{i}"] = None
+    assert len(seen) == _MAX_SEEN_LOGS + drift
+    assert _mark_seen(seen, "new-key") is True
+    assert len(seen) == _MAX_SEEN_LOGS
+    assert "new-key" in seen
+    for i in range(drift + 1):
+        assert f"k-{i}" not in seen
+
+
 def test_seen_logs_is_bounded() -> None:
     """``_seen_logs`` stays at the cap and evicts oldest-first (FIFO)."""
     _logger._seen_logs.clear()

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -6,7 +6,7 @@ import logging
 from unittest.mock import call, patch
 
 from zeroconf import _logger
-from zeroconf._logger import _MAX_SEEN_LOGS, QuietLogger, set_logger_level_if_unset
+from zeroconf._logger import _MAX_SEEN_LOGS, QuietLogger, _mark_seen, set_logger_level_if_unset
 
 
 def test_loading_logger():
@@ -83,6 +83,26 @@ def test_llog_exception_debug():
         quiet_logger.log_exception_debug("the exception")
 
     assert mock_log_debug.mock_calls == [call("the exception", exc_info=False)]
+
+
+def test_mark_seen_absorbs_runtime_error_during_eviction() -> None:
+    """Concurrent mutation can make ``iter(seen)`` raise ``RuntimeError``.
+
+    Free-threaded (3.14t) and multi-instance sync callers share
+    ``_seen_logs``; if another thread mutates it between ``iter()``
+    and ``next()`` the iterator raises ``RuntimeError``.
+    ``_mark_seen`` must absorb that and still insert the new key.
+    """
+
+    class RacyDict(dict[str, None]):
+        def __iter__(self):  # type: ignore[override]
+            raise RuntimeError("dictionary changed size during iteration")
+
+    seen: dict[str, None] = RacyDict()
+    for i in range(_MAX_SEEN_LOGS):
+        seen[f"k-{i}"] = None
+    assert _mark_seen(seen, "new-key") is True
+    assert "new-key" in seen
 
 
 def test_seen_logs_is_bounded() -> None:

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from unittest.mock import call, patch
 
+from zeroconf import _logger
 from zeroconf._logger import _MAX_SEEN_LOGS, QuietLogger, set_logger_level_if_unset
 
 
@@ -25,7 +26,7 @@ def test_loading_logger():
 
 def test_log_warning_once():
     """Test we only log with warning level once."""
-    QuietLogger._seen_logs = set()
+    _logger._seen_logs.clear()
     quiet_logger = QuietLogger()
     with (
         patch("zeroconf._logger.log.warning") as mock_log_warning,
@@ -48,7 +49,7 @@ def test_log_warning_once():
 
 def test_log_exception_warning():
     """Test we only log with warning level once."""
-    QuietLogger._seen_logs = set()
+    _logger._seen_logs.clear()
     quiet_logger = QuietLogger()
     with (
         patch("zeroconf._logger.log.warning") as mock_log_warning,
@@ -71,7 +72,7 @@ def test_log_exception_warning():
 
 def test_llog_exception_debug():
     """Test we only log with a trace once."""
-    QuietLogger._seen_logs = set()
+    _logger._seen_logs.clear()
     quiet_logger = QuietLogger()
     with patch("zeroconf._logger.log.debug") as mock_log_debug:
         quiet_logger.log_exception_debug("the exception")
@@ -86,16 +87,16 @@ def test_llog_exception_debug():
 
 def test_seen_logs_is_bounded():
     """Distinct keys must not grow ``_seen_logs`` without bound."""
-    QuietLogger._seen_logs = set()
+    _logger._seen_logs.clear()
     with patch("zeroconf._logger.log.warning"), patch("zeroconf._logger.log.debug"):
         for i in range(_MAX_SEEN_LOGS + 5):
             QuietLogger.log_warning_once(f"warning-{i}")
-    assert len(QuietLogger._seen_logs) <= _MAX_SEEN_LOGS
+    assert len(_logger._seen_logs) <= _MAX_SEEN_LOGS
 
 
 def test_log_exception_once():
     """Test we only log with warning level once."""
-    QuietLogger._seen_logs = set()
+    _logger._seen_logs.clear()
     quiet_logger = QuietLogger()
     exc = Exception()
     with (

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from unittest.mock import call, patch
 
-from zeroconf._logger import QuietLogger, set_logger_level_if_unset
+from zeroconf._logger import _MAX_SEEN_LOGS, QuietLogger, set_logger_level_if_unset
 
 
 def test_loading_logger():
@@ -25,7 +25,7 @@ def test_loading_logger():
 
 def test_log_warning_once():
     """Test we only log with warning level once."""
-    QuietLogger._seen_logs = {}
+    QuietLogger._seen_logs = set()
     quiet_logger = QuietLogger()
     with (
         patch("zeroconf._logger.log.warning") as mock_log_warning,
@@ -48,7 +48,7 @@ def test_log_warning_once():
 
 def test_log_exception_warning():
     """Test we only log with warning level once."""
-    QuietLogger._seen_logs = {}
+    QuietLogger._seen_logs = set()
     quiet_logger = QuietLogger()
     with (
         patch("zeroconf._logger.log.warning") as mock_log_warning,
@@ -71,7 +71,7 @@ def test_log_exception_warning():
 
 def test_llog_exception_debug():
     """Test we only log with a trace once."""
-    QuietLogger._seen_logs = {}
+    QuietLogger._seen_logs = set()
     quiet_logger = QuietLogger()
     with patch("zeroconf._logger.log.debug") as mock_log_debug:
         quiet_logger.log_exception_debug("the exception")
@@ -84,9 +84,18 @@ def test_llog_exception_debug():
     assert mock_log_debug.mock_calls == [call("the exception", exc_info=False)]
 
 
+def test_seen_logs_is_bounded():
+    """Distinct keys must not grow ``_seen_logs`` without bound."""
+    QuietLogger._seen_logs = set()
+    with patch("zeroconf._logger.log.warning"), patch("zeroconf._logger.log.debug"):
+        for i in range(_MAX_SEEN_LOGS + 5):
+            QuietLogger.log_warning_once(f"warning-{i}")
+    assert len(QuietLogger._seen_logs) <= _MAX_SEEN_LOGS
+
+
 def test_log_exception_once():
     """Test we only log with warning level once."""
-    QuietLogger._seen_logs = {}
+    QuietLogger._seen_logs = set()
     quiet_logger = QuietLogger()
     exc = Exception()
     with (

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -14,6 +14,7 @@ import pytest
 
 import zeroconf as r
 from zeroconf import DNSHinfo, DNSIncoming, DNSText, const, current_time_millis
+from zeroconf._protocol import incoming as _incoming_module
 
 from . import has_working_ipv6
 
@@ -960,6 +961,19 @@ def test_dns_compression_generic_failure(caplog):
     parsed = r.DNSIncoming(packet, ("1.2.3.4", 5353))
     assert len(parsed.answers()) == 1
     assert "Received invalid packet from ('1.2.3.4', 5353)" in caplog.text
+
+
+def test_seen_logs_is_bounded():
+    """Corrupt packets from varying peers must not grow _seen_logs without bound."""
+    packet = (
+        b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x06domain\x05local\x00\x00\x01"
+        b"\x80\x01\x00\x00\x00\x01\x00\x04\xc0\xa8\xd0\x05-\x0c\x00\x01\x80\x01\x00\x00"
+        b"\x00\x01\x00\x04\xc0\xa8\xd0\x06"
+    )
+    _incoming_module._seen_logs.clear()
+    for port in range(_incoming_module._MAX_SEEN_LOGS + 5):
+        r.DNSIncoming(packet, ("1.2.3.4", port))
+    assert len(_incoming_module._seen_logs) <= _incoming_module._MAX_SEEN_LOGS
 
 
 def test_label_length_attack():

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -965,16 +965,25 @@ def test_dns_compression_generic_failure(caplog):
 
 
 def test_seen_logs_is_bounded():
-    """Corrupt packets from varying peers must not grow _seen_logs without bound."""
+    """Corrupt packets from varying peers fill ``_seen_logs`` exactly to the cap."""
     packet = (
         b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x06domain\x05local\x00\x00\x01"
         b"\x80\x01\x00\x00\x00\x01\x00\x04\xc0\xa8\xd0\x05-\x0c\x00\x01\x80\x01\x00\x00"
         b"\x00\x01\x00\x04\xc0\xa8\xd0\x06"
     )
+    overflow = 5
     _incoming_module._seen_logs.clear()
-    for port in range(_MAX_SEEN_LOGS + 5):
+    for port in range(_MAX_SEEN_LOGS + overflow):
         r.DNSIncoming(packet, ("1.2.3.4", port))
-    assert len(_incoming_module._seen_logs) <= _MAX_SEEN_LOGS
+    # Bound is hit exactly — confirms the parser exception path actually
+    # entered the dict with a per-port-unique key; a future change that
+    # dropped self.source from the exception text would collapse to a
+    # single dedup key and fail this assertion.
+    assert len(_incoming_module._seen_logs) == _MAX_SEEN_LOGS
+    # FIFO eviction: the earliest port's exception string is gone, the
+    # latest port's is still present.
+    assert not any("'1.2.3.4', 0)" in k for k in _incoming_module._seen_logs)
+    assert any(f"'1.2.3.4', {_MAX_SEEN_LOGS + overflow - 1})" in k for k in _incoming_module._seen_logs)
 
 
 def test_label_length_attack():

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -973,17 +973,27 @@ def test_seen_logs_is_bounded():
     )
     overflow = 5
     _incoming_module._seen_logs.clear()
+    # Snapshot the actual key the parser inserted per port. This is whatever
+    # ``str(exc_info()[1])`` produces today — the test stays agnostic to the
+    # exception text format so a future normalization of the message (see
+    # the discussion on #1714) doesn't break the assertions, while still
+    # pinning that the parser exception path actually entered the dict.
+    keys_per_port: list[str] = []
     for port in range(_MAX_SEEN_LOGS + overflow):
         r.DNSIncoming(packet, ("1.2.3.4", port))
-    # Bound is hit exactly — confirms the parser exception path actually
-    # entered the dict with a per-port-unique key; a future change that
-    # dropped self.source from the exception text would collapse to a
-    # single dedup key and fail this assertion.
+        keys_per_port.append(next(reversed(_incoming_module._seen_logs)))
+    # Bound is hit exactly.
     assert len(_incoming_module._seen_logs) == _MAX_SEEN_LOGS
-    # FIFO eviction: the earliest port's exception string is gone, the
-    # latest port's is still present.
-    assert not any("'1.2.3.4', 0)" in k for k in _incoming_module._seen_logs)
-    assert any(f"'1.2.3.4', {_MAX_SEEN_LOGS + overflow - 1})" in k for k in _incoming_module._seen_logs)
+    # Each port produced a distinct dedup key — a regression that dropped
+    # the per-packet-varying component (e.g. self.source) from the exception
+    # text would collapse all 517 calls to one key and fail this.
+    assert len(set(keys_per_port)) == _MAX_SEEN_LOGS + overflow
+    # FIFO eviction by key identity (no substring matching on the message
+    # format): the earliest ports' keys are gone, the latest ports' remain.
+    for port in range(overflow):
+        assert keys_per_port[port] not in _incoming_module._seen_logs
+    for port in range(_MAX_SEEN_LOGS, _MAX_SEEN_LOGS + overflow):
+        assert keys_per_port[port] in _incoming_module._seen_logs
 
 
 def test_label_length_attack():

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -14,6 +14,7 @@ import pytest
 
 import zeroconf as r
 from zeroconf import DNSHinfo, DNSIncoming, DNSText, const, current_time_millis
+from zeroconf._logger import _MAX_SEEN_LOGS
 from zeroconf._protocol import incoming as _incoming_module
 
 from . import has_working_ipv6
@@ -971,9 +972,9 @@ def test_seen_logs_is_bounded():
         b"\x00\x01\x00\x04\xc0\xa8\xd0\x06"
     )
     _incoming_module._seen_logs.clear()
-    for port in range(_incoming_module._MAX_SEEN_LOGS + 5):
+    for port in range(_MAX_SEEN_LOGS + 5):
         r.DNSIncoming(packet, ("1.2.3.4", port))
-    assert len(_incoming_module._seen_logs) <= _incoming_module._MAX_SEEN_LOGS
+    assert len(_incoming_module._seen_logs) <= _MAX_SEEN_LOGS
 
 
 def test_label_length_attack():


### PR DESCRIPTION
## Summary

Closes #1714. Bounds the `_seen_logs` exception-dedup state in
`_protocol/incoming.py` and `_logger.py`, and stops retaining
`sys.exc_info()` triples in it. A LAN-local peer sending malformed
mDNS packets could otherwise grow either dict without bound — each
unique exception string retained a traceback whose frame locals
pinned `self.data` (the raw inbound packet, up to 8966 bytes).

## Details

- The dedup key in `_log_exception_debug` is `str(sys.exc_info()[1])`,
  and the seven `IncomingDecodeError` messages raised from `_read_name`
  / `_decode_labels_at_offset` (RFC 6762 §18 name-decoding error paths)
  all embed `self.source` — which carries the peer's ephemeral source
  port, varying per packet — plus byte `offset` and pointer `link`.
  Each attacker-influenced combination produced a fresh key, so the
  unbounded growth was driven by `port × offset × link`, not by the
  small set of error classes.
- The stored value (the `exc_info` triple) has been dead state since
  4218d75 (Nov 2018), where `logger('Exception occurred:',
  exc_info=exc_info)` was rewritten to `exc_info=True` during a mypy
  cleanup. From that point on the dict has functioned as a
  `set`-with-junk-values: the value was never read. Behaviour is
  unchanged — `exc_info=True` tells the stdlib logger to call
  `sys.exc_info()` itself at the call site; the stored copy never
  contributed.
- `QuietLogger.log_warning_once` / `log_exception_once` used the same
  dict to store an integer counter that was likewise never read.
  Collapsed all four QuietLogger methods plus the parser-side
  `_log_exception_debug` onto a single `_mark_seen(seen, key) -> bool`
  helper that lives in `_logger.py`. Two separate dedup pools are
  preserved — `_logger._seen_logs` (QuietLogger paths) and
  `_protocol.incoming._seen_logs` (parser path) — so a parser flood
  cannot evict listener/core-side dedup state.
- Storage is `dict[str, None]` (insertion-ordered on Python 3.7+) and
  the helper drains oldest-first in a single loop whose target depends
  on whether we're about to insert:

  ```python
  inserting = key not in seen
  while len(seen) > _MAX_SEEN_LOGS - inserting and _evict_oldest(seen):
      pass
  if inserting:
      seen[key] = None
  return inserting
  ```

  Hits drain only when `len > cap` (drift correction); misses drain
  to `cap - 1` so the insert lands at exactly `cap`. `_MAX_SEEN_LOGS`
  (= 512) is therefore a recency window — under a sustained malformed-
  packet flood the oldest deduped key drops one at a time, no burst
  re-emission of warning-level logs. Worst-case footprint per pool
  ≈ 40 KB of short exception strings, vs. previously unbounded with
  ~9 KB per retained traceback.
- **Free-threaded (3.14t) safety.** The dedup dicts are module-level
  globals shared across all `Zeroconf` instances in the process; on
  the FT build callers can race without the GIL serialising opcodes.
  Individual dict ops (`in`, `__setitem__`, `pop`, `len`) are atomic
  in CPython 3.13+ FT and don't crash, but the compound
  `iter` → `next` used to pick the FIFO victim can raise
  `RuntimeError` if another thread mutates the dict between the two
  ops. `_evict_oldest` therefore wraps the pop in
  `try: seen.pop(next(iter(seen)), None) except (RuntimeError,
  StopIteration): return False` and the outer `while` short-circuits
  on False, so concurrent mutation can't make the loop spin.

  The drain runs on *every* call, including cache hits, so a hit-
  heavy workload following a contention burst still corrects the
  overshoot — without this, an `if`-style check on the miss path
  alone would leave the dict permanently above the cap whenever
  subsequent calls happened to be all hits. Under sustained inserts
  multiple threads can both pass the `len < cap` check and both
  insert, leaving the dict transiently above the cap; the next call
  drains the drift back to the cap, so the bound holds at steady
  state regardless of thread count.
- CWE-400 (Uncontrolled Resource Consumption). LAN-local attack
  surface only.

## Test plan

- [x] `poetry run pytest tests/test_logger.py tests/test_protocol.py
      --timeout=60 -v` — passes, including five regressions:
  - `test_seen_logs_is_bounded` (logger-side) — pins exact-cap +
    FIFO eviction so a swap to a non-ordered container fails it
  - `test_seen_logs_is_bounded` (protocol-side) — snapshots the
    actual dedup key the parser inserted per port via
    `next(reversed(_seen_logs))` and asserts FIFO eviction by key
    identity (not by substring matching on the exception text), so
    a future normalization of the `IncomingDecodeError` message
    format doesn't false-positive a regression. Also pins
    `len(set(keys_per_port)) == _MAX_SEEN_LOGS + overflow`, so a
    regression that dropped `self.source` from the exception text
    (collapsing all 517 calls to one dedup key) still fails the
    test rather than silently passing
  - `test_mark_seen_absorbs_runtime_error_during_eviction` —
    `RacyDict` whose `__iter__` raises `RuntimeError` proves the
    helper still inserts the new key when concurrent mutation
    breaks the iterator
  - `test_mark_seen_drains_drift_above_cap` — seeds the dict to
    `cap + 10` (simulating accumulated FT drift) and asserts the
    next *miss* drains all the way back to the cap, so a
    regression to single-eviction (one `pop` per call) would fail
  - `test_mark_seen_drains_drift_on_hit_path` — same seeded drift,
    but the call is a *hit*; pins that the drift drains anyway, so
    a regression that early-returned on hits without correcting
    overshoot would leave the dict at `cap + drift` and fail
- [x] `poetry run pytest --timeout=60` — 346 passed, 3 skipped
      (full suite, `REQUIRE_CYTHON=1`)
- [x] `poetry run pre-commit run --files src/zeroconf/_protocol/incoming.py
      src/zeroconf/_logger.py tests/test_logger.py tests/test_protocol.py
      tests/benchmarks/test_mark_seen.py` — all hooks pass
- [x] `REQUIRE_CYTHON=1 poetry install --only=main,dev` — Cython
      rebuild picks up the new dict-backed `_seen_logs` shape in
      `incoming.py`
- [x] CodSpeed bench at `tests/benchmarks/test_mark_seen.py` covers
      hit / fill / churn so future regressions show up on the PR
      CodSpeed delta
- [x] Ad-hoc FT-contention smoke: 16 threads × 1000 inserts on a
      shared dict end at exactly the cap on the GIL build; the FT
      drain behaviour is exercised by `test_mark_seen_drains_drift_above_cap`
      / `test_mark_seen_drains_drift_on_hit_path` and by the CI
      matrix's 3.14t entry
- [x] Hot-path microbench (best-of-10 over 200k iters,
      `REQUIRE_CYTHON=1`): cache-hit at exactly cap = 52 ns/call.
      The downstream `log.debug` / `log.warning` invocation dwarfs
      that, so the dedup wrapper is not the bottleneck.
- [ ] (optional) draft a GitHub Security Advisory so a CVE can be
      assigned alongside the patched release
