### PR TITLE
fix: bound DNSCache record count to prevent unbounded LAN-driven growth

### DIFF
--- a/src/zeroconf/_cache.pxd
+++ b/src/zeroconf/_cache.pxd
@@ -67,7 +67,7 @@ cdef class DNSCache:
     )
     cdef bint _async_add(self, DNSRecord record)
 
-    @cython.locals(record=DNSRecord, when_record=tuple)
+    @cython.locals(record=DNSRecord, when_record=tuple, expire_heap_len="unsigned int")
     cdef void _async_evict_oldest(self)
 
     @cython.locals(service_record=DNSService)

--- a/src/zeroconf/_cache.pxd
+++ b/src/zeroconf/_cache.pxd
@@ -19,6 +19,7 @@ cdef object _UNIQUE_RECORD_TYPES
 cdef unsigned int _TYPE_PTR
 cdef cython.uint _ONE_SECOND
 cdef unsigned int _MIN_SCHEDULED_RECORD_EXPIRATION
+cdef unsigned int _MAX_CACHE_RECORDS
 
 
 @cython.locals(record_cache=dict)
@@ -31,6 +32,7 @@ cdef class DNSCache:
     cdef public cython.dict service_cache
     cdef public list _expire_heap
     cdef public dict _expirations
+    cdef public unsigned int _total_records
 
     cpdef bint async_add_records(self, object entries)
 
@@ -60,9 +62,13 @@ cdef class DNSCache:
         service_store=cython.dict,
         service_record=DNSService,
         when=object,
-        new=bint
+        new=bint,
+        is_new=bint
     )
     cdef bint _async_add(self, DNSRecord record)
+
+    @cython.locals(record=DNSRecord, when_record=tuple)
+    cdef void _async_evict_oldest(self)
 
     @cython.locals(service_record=DNSService)
     cdef void _async_remove(self, DNSRecord record)

--- a/src/zeroconf/_cache.pxd
+++ b/src/zeroconf/_cache.pxd
@@ -67,8 +67,11 @@ cdef class DNSCache:
     )
     cdef bint _async_add(self, DNSRecord record)
 
-    @cython.locals(record=DNSRecord, when_record=tuple, expire_heap_len="unsigned int")
+    @cython.locals(record=DNSRecord, when_record=tuple)
     cdef void _async_evict_oldest(self)
+
+    @cython.locals(expire_heap_len="unsigned int")
+    cdef void _maybe_rebuild_heap(self)
 
     @cython.locals(service_record=DNSService)
     cdef void _async_remove(self, DNSRecord record)

--- a/src/zeroconf/_cache.py
+++ b/src/zeroconf/_cache.py
@@ -90,15 +90,20 @@ class DNSCache:
         # replaces any existing records that are __eq__ to each other which
         # removes the risk that accessing the cache from the wrong
         # direction would return the old incorrect entry.
-        if (store := self.cache.get(record.key)) is None:
-            store = self.cache[record.key] = {}
-        is_new = record not in store
+        store = self.cache.get(record.key)
+        is_new = store is None or record not in store
         # Bound total cache size; evict closest-to-expiration entry to
         # make room before inserting a new record. Prevents a LAN-local
         # flood of unique-name records from growing the cache without
         # bound (RFC 6762 §10 advisory caching, defense-in-depth).
         if is_new and self._total_records >= _MAX_CACHE_RECORDS:
             self._async_evict_oldest()
+            # The victim may have been the last record under
+            # ``record.key``, in which case ``_remove_key`` deleted
+            # the bucket. Re-fetch before creating below.
+            store = self.cache.get(record.key)
+        if store is None:
+            store = self.cache[record.key] = {}
         new = is_new and not isinstance(record, DNSNsec)
         if is_new:
             self._total_records += 1
@@ -120,10 +125,23 @@ class DNSCache:
         """Drop the closest-to-expiration record to make room for a new one.
 
         Skips stale heap entries (records re-added with a different TTL),
-        which mirrors the staleness check in ``async_expire``.
+        which mirrors the staleness check in ``async_expire``. If the
+        heap is mostly stale (long stale prefix from sustained TTL
+        re-adds), rebuild it once up front so the pop loop below
+        doesn't do O(stale_prefix * log n) work on a single add. Same
+        heuristic / threshold as ``async_expire``.
 
         This function must be run in from event loop.
         """
+        expire_heap_len = len(self._expire_heap)
+        if (
+            expire_heap_len > _MIN_SCHEDULED_RECORD_EXPIRATION
+            and expire_heap_len > len(self._expirations) * 2
+        ):
+            self._expire_heap = [
+                entry for entry in self._expire_heap if self._expirations.get(entry[1]) == entry[0]
+            ]
+            heapify(self._expire_heap)
         while self._expire_heap:
             when_record = heappop(self._expire_heap)
             record = when_record[1]

--- a/src/zeroconf/_cache.py
+++ b/src/zeroconf/_cache.py
@@ -110,9 +110,14 @@ class DNSCache:
         store[record] = record
         when = record.created + (record.ttl * 1000)
         if self._expirations.get(record) != when:
-            # Avoid adding duplicates to the heap
             heappush(self._expire_heap, (when, record))
             self._expirations[record] = when
+            # Re-adds of an existing record with a new TTL push a fresh
+            # entry but leave the prior tuple behind as stale, so a peer
+            # that just replays cached records can grow ``_expire_heap``
+            # without ever tripping the cap. Rebuild when stale entries
+            # dominate.
+            self._maybe_rebuild_heap()
 
         if isinstance(record, DNSService):
             service_record = record
@@ -122,16 +127,28 @@ class DNSCache:
         return new
 
     def _async_evict_oldest(self) -> None:
-        """Drop the closest-to-expiration record to make room for a new one.
+        """Drop the closest-to-expiration record to make room for a new one."""
+        while self._expire_heap:
+            when_record = heappop(self._expire_heap)
+            record = when_record[1]
+            if self._expirations.get(record) != when_record[0]:
+                continue
+            self._async_remove(record)
+            return
 
-        Skips stale heap entries (records re-added with a different TTL),
-        which mirrors the staleness check in ``async_expire``. If the
-        heap is mostly stale (long stale prefix from sustained TTL
-        re-adds), rebuild it once up front so the pop loop below
-        doesn't do O(stale_prefix * log n) work on a single add. Same
-        heuristic / threshold as ``async_expire``.
+    def _maybe_rebuild_heap(self) -> None:
+        """Rebuild ``_expire_heap`` if stale entries dominate.
 
-        This function must be run in from event loop.
+        Re-adds of an existing record with a new TTL append a fresh
+        ``(when, record)`` and leave the prior tuple behind as stale;
+        eviction's stale-skip loop and ``async_expire`` already absorb
+        these, but unchecked accumulation lets a peer that just replays
+        cached records grow the heap arbitrarily between cleanups.
+        Same threshold as the long-standing rebuild in ``async_expire``:
+        only fire when stale entries outweigh live ones (heap > 2 x
+        expirations), and only above a minimum floor so a small cache
+        isn't rebuilt for nothing. Amortized cost is O(1) per push;
+        the O(N) rebuild fires at most once per N stale pushes.
         """
         expire_heap_len = len(self._expire_heap)
         if (
@@ -142,13 +159,6 @@ class DNSCache:
                 entry for entry in self._expire_heap if self._expirations.get(entry[1]) == entry[0]
             ]
             heapify(self._expire_heap)
-        while self._expire_heap:
-            when_record = heappop(self._expire_heap)
-            record = when_record[1]
-            if self._expirations.get(record) != when_record[0]:
-                continue
-            self._async_remove(record)
-            return
 
     def async_add_records(self, entries: Iterable[DNSRecord]) -> bool:
         """Add multiple records.
@@ -190,43 +200,23 @@ class DNSCache:
 
         :param now: The current time in milliseconds.
         """
-        if not (expire_heap_len := len(self._expire_heap)):
+        if not self._expire_heap:
             return []
 
         expired: list[DNSRecord] = []
-        # Find any expired records and add them to the to-delete list
         while self._expire_heap:
             when_record = self._expire_heap[0]
             when = when_record[0]
             if when > now:
                 break
             heappop(self._expire_heap)
-            # Check if the record hasn't been re-added to the heap
-            # with a different expiration time as it will be removed
-            # later when it reaches the top of the heap and its
-            # expiration time is met.
+            # Skip entries left behind by a TTL re-add; the live tuple is
+            # later in the heap and will be removed when it reaches the top.
             record = when_record[1]
             if self._expirations.get(record) == when:
                 expired.append(record)
 
-        # If the expiration heap grows larger than the number expirations
-        # times two, we clean it up to avoid keeping expired entries in
-        # the heap and consuming memory. We guard this with a minimum
-        # threshold to avoid cleaning up the heap too often when there are
-        # only a few scheduled expirations.
-        if (
-            expire_heap_len > _MIN_SCHEDULED_RECORD_EXPIRATION
-            and expire_heap_len > len(self._expirations) * 2
-        ):
-            # Remove any expired entries from the expiration heap
-            # that do not match the expiration time in the expirations
-            # as it means the record has been re-added to the heap
-            # with a different expiration time.
-            self._expire_heap = [
-                entry for entry in self._expire_heap if self._expirations.get(entry[1]) == entry[0]
-            ]
-            heapify(self._expire_heap)
-
+        self._maybe_rebuild_heap()
         self.async_remove_records(expired)
         return expired
 

--- a/src/zeroconf/_cache.py
+++ b/src/zeroconf/_cache.py
@@ -37,7 +37,7 @@ from ._dns import (
     DNSText,
 )
 from ._utils.time import current_time_millis
-from .const import _ONE_SECOND, _TYPE_PTR
+from .const import _MAX_CACHE_RECORDS, _ONE_SECOND, _TYPE_PTR
 
 _UNIQUE_RECORD_TYPES = (DNSAddress, DNSHinfo, DNSPointer, DNSText, DNSService)
 _UniqueRecordsType = DNSAddress | DNSHinfo | DNSPointer | DNSText | DNSService
@@ -72,6 +72,7 @@ class DNSCache:
         self._expire_heap: list[tuple[float, DNSRecord]] = []
         self._expirations: dict[DNSRecord, float] = {}
         self.service_cache: _DNSRecordCacheType = {}
+        self._total_records: int = 0
 
     # Functions prefixed with async_ are NOT threadsafe and must
     # be run in the event loop.
@@ -91,7 +92,16 @@ class DNSCache:
         # direction would return the old incorrect entry.
         if (store := self.cache.get(record.key)) is None:
             store = self.cache[record.key] = {}
-        new = record not in store and not isinstance(record, DNSNsec)
+        is_new = record not in store
+        # Bound total cache size; evict closest-to-expiration entry to
+        # make room before inserting a new record. Prevents a LAN-local
+        # flood of unique-name records from growing the cache without
+        # bound (RFC 6762 §10 advisory caching, defense-in-depth).
+        if is_new and self._total_records >= _MAX_CACHE_RECORDS:
+            self._async_evict_oldest()
+        new = is_new and not isinstance(record, DNSNsec)
+        if is_new:
+            self._total_records += 1
         store[record] = record
         when = record.created + (record.ttl * 1000)
         if self._expirations.get(record) != when:
@@ -105,6 +115,22 @@ class DNSCache:
                 service_store = self.service_cache[service_record.server_key] = {}
             service_store[service_record] = service_record
         return new
+
+    def _async_evict_oldest(self) -> None:
+        """Drop the closest-to-expiration record to make room for a new one.
+
+        Skips stale heap entries (records re-added with a different TTL),
+        which mirrors the staleness check in ``async_expire``.
+
+        This function must be run in from event loop.
+        """
+        while self._expire_heap:
+            when_record = heappop(self._expire_heap)
+            record = when_record[1]
+            if self._expirations.get(record) != when_record[0]:
+                continue
+            self._async_remove(record)
+            return
 
     def async_add_records(self, entries: Iterable[DNSRecord]) -> bool:
         """Add multiple records.
@@ -129,6 +155,7 @@ class DNSCache:
             _remove_key(self.service_cache, service_record.server_key, service_record)
         _remove_key(self.cache, record.key, record)
         self._expirations.pop(record, None)
+        self._total_records -= 1
 
     def async_remove_records(self, entries: Iterable[DNSRecord]) -> None:
         """Remove multiple records.

--- a/src/zeroconf/_cache.py
+++ b/src/zeroconf/_cache.py
@@ -135,9 +135,6 @@ class DNSCache:
                 continue
             self._async_remove(record)
             return
-        # Heap-empty fall-through is unreachable by the cache invariant
-        # (every counted record has a heap entry); accounting drift would
-        # surface in tests via test_cache_total_records_invariant_under_mixed_ops.
 
     def _maybe_rebuild_heap(self) -> None:
         """Rebuild ``_expire_heap`` when stale entries dominate live ones."""

--- a/src/zeroconf/_cache.py
+++ b/src/zeroconf/_cache.py
@@ -135,21 +135,12 @@ class DNSCache:
                 continue
             self._async_remove(record)
             return
+        # Heap-empty fall-through is unreachable by the cache invariant
+        # (every counted record has a heap entry); accounting drift would
+        # surface in tests via test_cache_total_records_invariant_under_mixed_ops.
 
     def _maybe_rebuild_heap(self) -> None:
-        """Rebuild ``_expire_heap`` if stale entries dominate.
-
-        Re-adds of an existing record with a new TTL append a fresh
-        ``(when, record)`` and leave the prior tuple behind as stale;
-        eviction's stale-skip loop and ``async_expire`` already absorb
-        these, but unchecked accumulation lets a peer that just replays
-        cached records grow the heap arbitrarily between cleanups.
-        Same threshold as the long-standing rebuild in ``async_expire``:
-        only fire when stale entries outweigh live ones (heap > 2 x
-        expirations), and only above a minimum floor so a small cache
-        isn't rebuilt for nothing. Amortized cost is O(1) per push;
-        the O(N) rebuild fires at most once per N stale pushes.
-        """
+        """Rebuild ``_expire_heap`` when stale entries dominate live ones."""
         expire_heap_len = len(self._expire_heap)
         if (
             expire_heap_len > _MIN_SCHEDULED_RECORD_EXPIRATION

--- a/src/zeroconf/const.py
+++ b/src/zeroconf/const.py
@@ -59,6 +59,12 @@ _DNS_OTHER_TTL = 4500  # 75 minutes for non-host records (PTR, TXT etc) as-per R
 # level of rate limit and safe guards so we use 1/4 of the recommended value
 _DNS_PTR_MIN_TTL = 1125
 
+# Upper bound on the number of records the DNSCache will hold before it
+# starts evicting the closest-to-expiration entry to make room for new
+# arrivals. Bounds the memory a malicious LAN peer can force the cache
+# to retain by multicasting many unique-name records.
+_MAX_CACHE_RECORDS = 10000
+
 _DNS_PACKET_HEADER_LEN = 12
 
 _MAX_MSG_TYPICAL = 1460  # unused

--- a/tests/benchmarks/test_cache_bound.py
+++ b/tests/benchmarks/test_cache_bound.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from itertools import count
+
 from pytest_codspeed import BenchmarkFixture
 
 from zeroconf import DNSAddress, DNSCache, current_time_millis
 from zeroconf.const import _CLASS_IN, _MAX_CACHE_RECORDS, _TYPE_A
 
 
-def _make_records(count: int, now: float, prefix: str = "bench") -> list[DNSAddress]:
+def _make_records(count_: int, now: float, prefix: str = "bench") -> list[DNSAddress]:
     return [
         DNSAddress(
             f"{prefix}-{i}.local.",
@@ -18,8 +21,21 @@ def _make_records(count: int, now: float, prefix: str = "bench") -> list[DNSAddr
             bytes(((i >> 24) & 0xFF, (i >> 16) & 0xFF, (i >> 8) & 0xFF, i & 0xFF)),
             created=now + i,
         )
-        for i in range(count)
+        for i in range(count_)
     ]
+
+
+def _unbounded_records(now: float, prefix: str = "evict") -> Iterator[DNSAddress]:
+    """Unbounded generator of unique-name DNSAddress records."""
+    for i in count():
+        yield DNSAddress(
+            f"{prefix}-{i}.local.",
+            _TYPE_A,
+            _CLASS_IN,
+            120,
+            bytes(((i >> 24) & 0xFF, (i >> 16) & 0xFF, (i >> 8) & 0xFF, i & 0xFF)),
+            created=now + i,
+        )
 
 
 def test_cache_add_below_cap(benchmark: BenchmarkFixture) -> None:
@@ -38,15 +54,14 @@ def test_cache_add_at_cap_evicts(benchmark: BenchmarkFixture) -> None:
 
     Pre-fills the cache to ``_MAX_CACHE_RECORDS`` outside the timed body so
     only the eviction-path adds are measured. Each benchmark iteration
-    consumes one fresh unique record from a pre-built pool, keeping the
-    cache permanently at the cap and the work per iteration to a single
-    ``_async_add`` + ``_async_evict_oldest`` cycle.
+    pulls one fresh unique record from an unbounded generator, keeping the
+    cache permanently at the cap. The generator avoids the iteration-count
+    cap that a pre-built pool would impose for very fast operations.
     """
     now = current_time_millis()
     cache = DNSCache()
     cache.async_add_records(_make_records(_MAX_CACHE_RECORDS, now, prefix="fill"))
-    # Large pool so the iterator outlives any reasonable codspeed run count.
-    pool = iter(_make_records(100_000, now + _MAX_CACHE_RECORDS, prefix="evict"))
+    pool = _unbounded_records(now + _MAX_CACHE_RECORDS)
 
     @benchmark
     def _evict_one() -> None:

--- a/tests/benchmarks/test_cache_bound.py
+++ b/tests/benchmarks/test_cache_bound.py
@@ -8,14 +8,14 @@ from zeroconf import DNSAddress, DNSCache, current_time_millis
 from zeroconf.const import _CLASS_IN, _MAX_CACHE_RECORDS, _TYPE_A
 
 
-def _make_records(count: int, now: float) -> list[DNSAddress]:
+def _make_records(count: int, now: float, prefix: str = "bench") -> list[DNSAddress]:
     return [
         DNSAddress(
-            f"bench-{i}.local.",
+            f"{prefix}-{i}.local.",
             _TYPE_A,
             _CLASS_IN,
             120,
-            bytes((i & 0xFF, (i >> 8) & 0xFF, 0, 1)),
+            bytes(((i >> 24) & 0xFF, (i >> 16) & 0xFF, (i >> 8) & 0xFF, i & 0xFF)),
             created=now + i,
         )
         for i in range(count)
@@ -34,11 +34,20 @@ def test_cache_add_below_cap(benchmark: BenchmarkFixture) -> None:
 
 
 def test_cache_add_at_cap_evicts(benchmark: BenchmarkFixture) -> None:
-    """Steady-state add at the cap: every new record forces one eviction."""
+    """Steady-state add at the cap: every measured insert forces one eviction.
+
+    Pre-fills the cache to ``_MAX_CACHE_RECORDS`` outside the timed body so
+    only the eviction-path adds are measured. Each benchmark iteration
+    consumes one fresh unique record from a pre-built pool, keeping the
+    cache permanently at the cap and the work per iteration to a single
+    ``_async_add`` + ``_async_evict_oldest`` cycle.
+    """
     now = current_time_millis()
-    overflow_records = _make_records(_MAX_CACHE_RECORDS + 1000, now)
+    cache = DNSCache()
+    cache.async_add_records(_make_records(_MAX_CACHE_RECORDS, now, prefix="fill"))
+    # Large pool so the iterator outlives any reasonable codspeed run count.
+    pool = iter(_make_records(100_000, now + _MAX_CACHE_RECORDS, prefix="evict"))
 
     @benchmark
-    def _flood() -> None:
-        cache = DNSCache()
-        cache.async_add_records(overflow_records)
+    def _evict_one() -> None:
+        cache.async_add_records([next(pool)])

--- a/tests/benchmarks/test_cache_bound.py
+++ b/tests/benchmarks/test_cache_bound.py
@@ -1,0 +1,44 @@
+"""Benchmark for the DNSCache record-count bound + overflow eviction."""
+
+from __future__ import annotations
+
+from pytest_codspeed import BenchmarkFixture
+
+from zeroconf import DNSAddress, DNSCache, current_time_millis
+from zeroconf.const import _CLASS_IN, _MAX_CACHE_RECORDS, _TYPE_A
+
+
+def _make_records(count: int, now: float) -> list[DNSAddress]:
+    return [
+        DNSAddress(
+            f"bench-{i}.local.",
+            _TYPE_A,
+            _CLASS_IN,
+            120,
+            bytes((i & 0xFF, (i >> 8) & 0xFF, 0, 1)),
+            created=now + i,
+        )
+        for i in range(count)
+    ]
+
+
+def test_cache_add_below_cap(benchmark: BenchmarkFixture) -> None:
+    """Adding records while the cache is well below the cap (no eviction)."""
+    now = current_time_millis()
+    records = _make_records(1000, now)
+
+    @benchmark
+    def _add() -> None:
+        cache = DNSCache()
+        cache.async_add_records(records)
+
+
+def test_cache_add_at_cap_evicts(benchmark: BenchmarkFixture) -> None:
+    """Steady-state add at the cap: every new record forces one eviction."""
+    now = current_time_millis()
+    overflow_records = _make_records(_MAX_CACHE_RECORDS + 1000, now)
+
+    @benchmark
+    def _flood() -> None:
+        cache = DNSCache()
+        cache.async_add_records(overflow_records)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -525,11 +525,15 @@ def test_cache_eviction_empty_heap_returns_without_evicting() -> None:
     # By the cache invariant every record in ``_total_records`` has a heap
     # entry, so eviction should never see an empty heap. Force the broken
     # state directly to pin the defensive behaviour: ``_async_evict_oldest``
-    # returns without raising and the subsequent insert still lands.
+    # returns without raising and the subsequent insert still lands. Since
+    # eviction can't free space, the counter is allowed to drift past the
+    # cap by exactly one — pinned so a future change to the recovery
+    # semantics (e.g., refusing the add or clamping) fails this test.
     cache._total_records = const._MAX_CACHE_RECORDS
     cache._expire_heap = []
     cache.async_add_records([_addr("post-empty.local.", 0)])
     assert "post-empty.local." in cache.cache
+    assert cache._total_records == const._MAX_CACHE_RECORDS + 1
 
 
 def test_cache_eviction_skips_stale_heap_entries() -> None:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -583,6 +583,26 @@ def test_cache_eviction_victim_shares_key_with_new_record() -> None:
     assert total == cache._total_records
 
 
+def test_cache_dnsnsec_flood_is_bounded() -> None:
+    """DNSNsec records honour ``_MAX_CACHE_RECORDS`` (no bypass via the ``new`` flag)."""
+    cache = r.DNSCache()
+    overflow = 100
+    cache.async_add_records(
+        r.DNSNsec(
+            f"nsec-{i}.local.",
+            const._TYPE_NSEC,
+            const._CLASS_IN,
+            120,
+            f"nsec-{i}.local.",
+            [const._TYPE_A],
+        )
+        for i in range(const._MAX_CACHE_RECORDS + overflow)
+    )
+    assert cache._total_records == const._MAX_CACHE_RECORDS
+    total = sum(len(store) for store in cache.cache.values())
+    assert total == const._MAX_CACHE_RECORDS
+
+
 def test_cache_re_add_flood_does_not_grow_heap_unbounded() -> None:
     """Replaying cached records with shifting TTLs cannot grow ``_expire_heap`` unbounded."""
     cache = r.DNSCache()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -514,6 +514,59 @@ def test_cache_size_is_bounded() -> None:
         assert f"flood-{i}.local." in cache.cache
 
 
+def test_cache_eviction_skips_stale_heap_entries() -> None:
+    """Eviction must skip stale ``_expire_heap`` entries left by TTL re-adds."""
+    cache = r.DNSCache()
+    now = r.current_time_millis()
+    # Fill to one shy of the cap so a single add triggers exactly one eviction
+    cache.async_add_records(
+        r.DNSAddress(
+            f"stale-{i}.local.",
+            const._TYPE_A,
+            const._CLASS_IN,
+            120,
+            bytes((i & 0xFF, (i >> 8) & 0xFF, 0, 1)),
+            created=now + i,
+        )
+        for i in range(const._MAX_CACHE_RECORDS)
+    )
+    assert cache._total_records == const._MAX_CACHE_RECORDS
+
+    # Re-add the closest-to-expiration record with a longer TTL. The original
+    # (when, record) tuple stays at the head of _expire_heap as a stale entry;
+    # _expirations[record] now points to the new (later) expiration. Eviction
+    # must pop and skip that stale tuple before settling on a real victim.
+    victim_name = "stale-0.local."
+    refreshed = r.DNSAddress(
+        victim_name,
+        const._TYPE_A,
+        const._CLASS_IN,
+        7200,
+        bytes((0, 0, 0, 1)),
+        created=now + 0,
+    )
+    cache.async_add_records([refreshed])
+    assert cache._total_records == const._MAX_CACHE_RECORDS
+
+    # Force one eviction. The next-oldest legitimate record must go; the
+    # refreshed record stays alive.
+    cache.async_add_records(
+        [
+            r.DNSAddress(
+                "trigger.local.",
+                const._TYPE_A,
+                const._CLASS_IN,
+                120,
+                b"\xff\xff\xff\xff",
+                created=now + const._MAX_CACHE_RECORDS,
+            )
+        ]
+    )
+    assert cache._total_records == const._MAX_CACHE_RECORDS
+    assert victim_name in cache.cache
+    assert "stale-1.local." not in cache.cache
+
+
 def test_cache_eviction_decrements_total_records() -> None:
     """Natural removal (goodbyes, expirations) must keep ``_total_records`` in sync."""
     cache = r.DNSCache()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -567,6 +567,128 @@ def test_cache_eviction_skips_stale_heap_entries() -> None:
     assert "stale-1.local." not in cache.cache
 
 
+def test_cache_eviction_victim_shares_key_with_new_record() -> None:
+    """Eviction must not orphan the new record when it collides on ``record.key``.
+
+    If the closest-to-expiration record is the *last* one stored under
+    ``record.key`` and the incoming record uses the same key,
+    ``_remove_key`` deletes ``self.cache[record.key]`` during eviction.
+    A previous capture of ``store = self.cache.get(record.key)`` would
+    then write the new record into an orphaned dict not reachable via
+    the cache. Pin that the new record is reachable.
+    """
+    cache = r.DNSCache()
+    now = r.current_time_millis()
+    # Fill the cache to one shy of the cap with unique-name records, each
+    # with a later created time than the shared-key victim below.
+    cache.async_add_records(
+        r.DNSAddress(
+            f"filler-{i}.local.",
+            const._TYPE_A,
+            const._CLASS_IN,
+            120,
+            bytes((i & 0xFF, (i >> 8) & 0xFF, 0, 1)),
+            created=now + 1000 + i,
+        )
+        for i in range(const._MAX_CACHE_RECORDS - 1)
+    )
+
+    # Insert a record at "shared.local." with the earliest expiration —
+    # this is the one closest_to_expiration eviction will pick.
+    shared_key = "shared.local."
+    old_shared = r.DNSAddress(
+        shared_key,
+        const._TYPE_A,
+        const._CLASS_IN,
+        120,
+        b"\x01\x02\x03\x04",
+        created=now,
+    )
+    cache.async_add_records([old_shared])
+    assert cache._total_records == const._MAX_CACHE_RECORDS
+    assert shared_key in cache.cache
+
+    # Add a new record with the SAME key. Eviction will remove old_shared,
+    # which empties cache[shared_key], so _remove_key deletes that bucket.
+    # If _async_add captured the store before eviction it will now be
+    # writing into an orphaned dict.
+    new_shared = r.DNSAddress(
+        shared_key,
+        const._TYPE_A,
+        const._CLASS_IN,
+        120,
+        b"\x05\x06\x07\x08",
+        created=now + 999,
+    )
+    cache.async_add_records([new_shared])
+
+    # The new record must be reachable via the cache.
+    assert shared_key in cache.cache, "new record orphaned: cache bucket missing"
+    assert new_shared in cache.cache[shared_key]
+    assert cache.async_get_unique(new_shared) == new_shared
+    # And the counter accounting must still match observable state.
+    total = sum(len(store) for store in cache.cache.values())
+    assert total == cache._total_records
+
+
+def test_cache_eviction_rebuilds_heap_when_mostly_stale() -> None:
+    """Eviction rebuilds ``_expire_heap`` up front when stale entries dominate.
+
+    Without the rebuild, a single ``_async_add`` at cap could pop a long
+    stale prefix one entry at a time — O(stale_prefix * log n). The
+    rebuild is the same heuristic ``async_expire`` already uses: when
+    ``len(heap) > 2 * len(expirations)``, the heap is reconstructed
+    from only the valid entries in one O(n) pass before the pop loop.
+    """
+    cache = r.DNSCache()
+    now = r.current_time_millis()
+    base_kwargs = {"type_": const._TYPE_A, "class_": const._CLASS_IN}
+
+    cache.async_add_records(
+        r.DNSAddress(
+            f"r-{i}.local.",
+            ttl=120,
+            address=bytes((i & 0xFF, (i >> 8) & 0xFF, 0, 1)),
+            created=now + i,
+            **base_kwargs,
+        )
+        for i in range(const._MAX_CACHE_RECORDS)
+    )
+    # Two re-adds with distinct TTLs leave two stale entries per record
+    # in ``_expire_heap`` while ``_expirations`` stays at MAX. Heap reaches
+    # ~3x MAX, which trips the ``len(heap) > 2 * len(expirations)``
+    # threshold on the next eviction.
+    for ttl in (7200, 14400):
+        cache.async_add_records(
+            r.DNSAddress(
+                f"r-{i}.local.",
+                ttl=ttl,
+                address=bytes((i & 0xFF, (i >> 8) & 0xFF, 0, 1)),
+                created=now + i,
+                **base_kwargs,
+            )
+            for i in range(const._MAX_CACHE_RECORDS)
+        )
+    assert len(cache._expire_heap) > 2 * len(cache._expirations)
+
+    # One more insert pushes us over the cap; eviction fires and must
+    # rebuild before scanning.
+    cache.async_add_records(
+        [
+            r.DNSAddress(
+                "trigger.local.",
+                ttl=120,
+                address=b"\xff\xff\xff\xff",
+                created=now + const._MAX_CACHE_RECORDS,
+                **base_kwargs,
+            )
+        ]
+    )
+    # Rebuild dropped the stale entries; heap and expirations now match.
+    assert len(cache._expire_heap) == len(cache._expirations) == const._MAX_CACHE_RECORDS
+    assert cache._total_records == const._MAX_CACHE_RECORDS
+
+
 def test_cache_eviction_decrements_total_records() -> None:
     """Natural removal (goodbyes, expirations) must keep ``_total_records`` in sync."""
     cache = r.DNSCache()
@@ -592,3 +714,95 @@ def test_cache_eviction_decrements_total_records() -> None:
     cache.async_expire(now + (200 * 1000))
     assert cache._total_records == 0
     assert not cache.cache
+
+
+def test_cache_total_records_invariant_under_mixed_ops() -> None:
+    """``_total_records`` must equal ``sum(len(store) for store in cache.values())``.
+
+    Walks the counter through every code path that touches it — new inserts,
+    re-adds of an existing record (no increment), DNSService (extra
+    service_cache write), DNSNsec (stored but not counted as "new" by the
+    flag), shared-key inserts that empty their bucket on removal, full-cap
+    eviction, async_expire, manual async_remove_records — and asserts the
+    invariant after every step. Any future change that misses an increment
+    or doubles a decrement will trip this immediately; ``_total_records`` is
+    ``cdef unsigned int`` in the Cython build, so silent underflow would
+    otherwise propagate as a permanent eviction-on-every-add storm.
+    """
+    cache = r.DNSCache()
+    now = r.current_time_millis()
+
+    def actual() -> int:
+        return sum(len(store) for store in cache.cache.values())
+
+    # Fresh inserts: counter follows insert count exactly.
+    addrs = [
+        r.DNSAddress(
+            f"mix-{i}.local.", const._TYPE_A, const._CLASS_IN, 120, bytes((i, 0, 0, 1)), created=now + i
+        )
+        for i in range(20)
+    ]
+    cache.async_add_records(addrs)
+    assert cache._total_records == actual() == 20
+
+    # Re-add of an identical record: no increment (already present).
+    cache.async_add_records([addrs[0]])
+    assert cache._total_records == actual() == 20
+
+    # DNSService writes service_cache too — counter must still match cache size.
+    svc = r.DNSService("svc.local.", const._TYPE_SRV, const._CLASS_IN, 120, 0, 0, 80, "host.local.")
+    cache.async_add_records([svc])
+    assert cache._total_records == actual() == 21
+    cache.async_remove_records([svc])
+    assert cache._total_records == actual() == 20
+
+    # DNSNsec is stored but excluded from the "new" return value; the counter
+    # still tracks it because it occupies a bucket slot.
+    nsec = r.DNSNsec(
+        "nsec.local.",
+        const._TYPE_NSEC,
+        const._CLASS_IN,
+        120,
+        "nsec.local.",
+        [const._TYPE_A],
+    )
+    cache.async_add_records([nsec])
+    assert cache._total_records == actual() == 21
+    cache.async_remove_records([nsec])
+    assert cache._total_records == actual() == 20
+
+    # Shared-key insert/remove: emptying a bucket removes the cache key, but
+    # the counter must still decrement only by the number of records gone.
+    shared_a = r.DNSAddress(
+        "shared.local.", const._TYPE_A, const._CLASS_IN, 120, b"\x01\x01\x01\x01", created=now
+    )
+    shared_b = r.DNSAddress(
+        "shared.local.", const._TYPE_A, const._CLASS_IN, 120, b"\x02\x02\x02\x02", created=now
+    )
+    cache.async_add_records([shared_a, shared_b])
+    assert cache._total_records == actual() == 22
+    cache.async_remove_records([shared_a, shared_b])
+    assert cache._total_records == actual() == 20
+    assert "shared.local." not in cache.cache
+
+    # async_expire path: counter must follow the records dropped.
+    cache.async_expire(now + (200 * 1000))
+    assert cache._total_records == actual() == 0
+    assert not cache.cache
+
+    # Full-cap eviction loop: counter never grows past the cap, never drifts.
+    cap_records = [
+        r.DNSAddress(
+            f"cap-{i}.local.",
+            const._TYPE_A,
+            const._CLASS_IN,
+            120,
+            bytes((i & 0xFF, (i >> 8) & 0xFF, 0, 1)),
+            created=now + i,
+        )
+        for i in range(const._MAX_CACHE_RECORDS + 50)
+    ]
+    for rec in cap_records:
+        cache.async_add_records([rec])
+        assert cache._total_records == actual()
+    assert cache._total_records == const._MAX_CACHE_RECORDS

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -519,6 +519,19 @@ def test_cache_size_is_bounded() -> None:
         assert f"flood-{i}.local." in cache.cache
 
 
+def test_cache_eviction_empty_heap_returns_without_evicting() -> None:
+    """Eviction tolerates an empty ``_expire_heap`` (invariant-violation safety net)."""
+    cache = r.DNSCache()
+    # By the cache invariant every record in ``_total_records`` has a heap
+    # entry, so eviction should never see an empty heap. Force the broken
+    # state directly to pin the defensive behaviour: ``_async_evict_oldest``
+    # returns without raising and the subsequent insert still lands.
+    cache._total_records = const._MAX_CACHE_RECORDS
+    cache._expire_heap = []
+    cache.async_add_records([_addr("post-empty.local.", 0)])
+    assert "post-empty.local." in cache.cache
+
+
 def test_cache_eviction_skips_stale_heap_entries() -> None:
     """Eviction skips stale heap entries left by TTL re-adds."""
     cache = r.DNSCache()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -482,3 +482,60 @@ async def test_cache_heap_pops_order() -> None:
         ts, _ = heappop(cache._expire_heap)
         assert ts >= start_ts
         start_ts = ts
+
+
+def test_cache_size_is_bounded() -> None:
+    """A flood of unique-name records is capped at ``_MAX_CACHE_RECORDS``."""
+    cache = r.DNSCache()
+    now = r.current_time_millis()
+    overflow = 1000
+    flood_size = const._MAX_CACHE_RECORDS + overflow
+
+    cache.async_add_records(
+        r.DNSAddress(
+            f"flood-{i}.local.",
+            const._TYPE_A,
+            const._CLASS_IN,
+            120,
+            bytes((i & 0xFF, (i >> 8) & 0xFF, 0, 1)),
+            created=now + i,
+        )
+        for i in range(flood_size)
+    )
+
+    total = sum(len(store) for store in cache.cache.values())
+    assert total == const._MAX_CACHE_RECORDS
+    assert cache._total_records == const._MAX_CACHE_RECORDS
+    # FIFO-ish: the earliest-created records (closest to expiration) get
+    # evicted first, so the names that remain are from the tail.
+    for i in range(overflow):
+        assert f"flood-{i}.local." not in cache.cache
+    for i in range(flood_size - overflow, flood_size):
+        assert f"flood-{i}.local." in cache.cache
+
+
+def test_cache_eviction_decrements_total_records() -> None:
+    """Natural removal (goodbyes, expirations) must keep ``_total_records`` in sync."""
+    cache = r.DNSCache()
+    now = r.current_time_millis()
+    records = [
+        r.DNSAddress(
+            f"sync-{i}.local.",
+            const._TYPE_A,
+            const._CLASS_IN,
+            120,
+            bytes((i & 0xFF, (i >> 8) & 0xFF, 0, 1)),
+            created=now,
+        )
+        for i in range(50)
+    ]
+    cache.async_add_records(records)
+    assert cache._total_records == 50
+
+    cache.async_remove_records(records[:20])
+    assert cache._total_records == 30
+
+    # async_expire on a future time should drop the rest
+    cache.async_expire(now + (200 * 1000))
+    assert cache._total_records == 0
+    assert not cache.cache

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -439,7 +439,9 @@ async def test_cache_heap_multi_name_cleanup() -> None:
         )
         cache.async_add_records([record])
 
-    assert len(cache._expire_heap) == min_records_to_cleanup + 5
+    # ``_async_add`` rebuilds ``_expire_heap`` proactively when stale entries
+    # dominate (heap > 2x expirations), so the heap is already capped at
+    # ~one entry per unique record long before ``async_expire`` is called.
     assert len(cache.async_entries_with_name(name)) == 1
     assert len(cache.async_entries_with_name(name2)) == 5
 
@@ -473,7 +475,8 @@ async def test_cache_heap_pops_order() -> None:
         )
         cache.async_add_records([record])
 
-    assert len(cache._expire_heap) == min_records_to_cleanup + 5
+    # ``_async_add`` proactively rebuilds the heap when stale entries dominate,
+    # so the heap holds only one entry per unique record by this point.
     assert len(cache.async_entries_with_name(name)) == 1
     assert len(cache.async_entries_with_name(name2)) == 5
 
@@ -484,6 +487,18 @@ async def test_cache_heap_pops_order() -> None:
         start_ts = ts
 
 
+def _addr(name: str, idx: int, *, ttl: int = 120, created: float | None = None) -> r.DNSAddress:
+    """Build a DNSAddress with idx-derived payload for the bound/eviction tests."""
+    return r.DNSAddress(
+        name,
+        const._TYPE_A,
+        const._CLASS_IN,
+        ttl,
+        bytes((idx & 0xFF, (idx >> 8) & 0xFF, 0, 1)),
+        created=r.current_time_millis() if created is None else created,
+    )
+
+
 def test_cache_size_is_bounded() -> None:
     """A flood of unique-name records is capped at ``_MAX_CACHE_RECORDS``."""
     cache = r.DNSCache()
@@ -491,17 +506,7 @@ def test_cache_size_is_bounded() -> None:
     overflow = 1000
     flood_size = const._MAX_CACHE_RECORDS + overflow
 
-    cache.async_add_records(
-        r.DNSAddress(
-            f"flood-{i}.local.",
-            const._TYPE_A,
-            const._CLASS_IN,
-            120,
-            bytes((i & 0xFF, (i >> 8) & 0xFF, 0, 1)),
-            created=now + i,
-        )
-        for i in range(flood_size)
-    )
+    cache.async_add_records(_addr(f"flood-{i}.local.", i, created=now + i) for i in range(flood_size))
 
     total = sum(len(store) for store in cache.cache.values())
     assert total == const._MAX_CACHE_RECORDS
@@ -515,293 +520,139 @@ def test_cache_size_is_bounded() -> None:
 
 
 def test_cache_eviction_skips_stale_heap_entries() -> None:
-    """Eviction must skip stale ``_expire_heap`` entries left by TTL re-adds."""
+    """Eviction skips stale heap entries left by TTL re-adds."""
     cache = r.DNSCache()
     now = r.current_time_millis()
-    # Fill to one shy of the cap so a single add triggers exactly one eviction
     cache.async_add_records(
-        r.DNSAddress(
-            f"stale-{i}.local.",
-            const._TYPE_A,
-            const._CLASS_IN,
-            120,
-            bytes((i & 0xFF, (i >> 8) & 0xFF, 0, 1)),
-            created=now + i,
-        )
-        for i in range(const._MAX_CACHE_RECORDS)
+        _addr(f"stale-{i}.local.", i, created=now + i) for i in range(const._MAX_CACHE_RECORDS)
     )
     assert cache._total_records == const._MAX_CACHE_RECORDS
 
-    # Re-add the closest-to-expiration record with a longer TTL. The original
-    # (when, record) tuple stays at the head of _expire_heap as a stale entry;
-    # _expirations[record] now points to the new (later) expiration. Eviction
-    # must pop and skip that stale tuple before settling on a real victim.
+    # Re-add the closest-to-expiration record with a longer TTL; the prior
+    # ``(when, record)`` tuple stays as stale, eviction must skip it.
     victim_name = "stale-0.local."
-    refreshed = r.DNSAddress(
-        victim_name,
-        const._TYPE_A,
-        const._CLASS_IN,
-        7200,
-        bytes((0, 0, 0, 1)),
-        created=now + 0,
-    )
-    cache.async_add_records([refreshed])
+    cache.async_add_records([_addr(victim_name, 0, ttl=7200, created=now)])
     assert cache._total_records == const._MAX_CACHE_RECORDS
 
-    # Force one eviction. The next-oldest legitimate record must go; the
-    # refreshed record stays alive.
-    cache.async_add_records(
-        [
-            r.DNSAddress(
-                "trigger.local.",
-                const._TYPE_A,
-                const._CLASS_IN,
-                120,
-                b"\xff\xff\xff\xff",
-                created=now + const._MAX_CACHE_RECORDS,
-            )
-        ]
-    )
+    cache.async_add_records([_addr("trigger.local.", 0xFFFF, created=now + const._MAX_CACHE_RECORDS)])
     assert cache._total_records == const._MAX_CACHE_RECORDS
     assert victim_name in cache.cache
     assert "stale-1.local." not in cache.cache
 
 
 def test_cache_eviction_victim_shares_key_with_new_record() -> None:
-    """Eviction must not orphan the new record when it collides on ``record.key``.
-
-    If the closest-to-expiration record is the *last* one stored under
-    ``record.key`` and the incoming record uses the same key,
-    ``_remove_key`` deletes ``self.cache[record.key]`` during eviction.
-    A previous capture of ``store = self.cache.get(record.key)`` would
-    then write the new record into an orphaned dict not reachable via
-    the cache. Pin that the new record is reachable.
-    """
+    """Inserting a record whose key collides with the eviction victim keeps it reachable."""
     cache = r.DNSCache()
     now = r.current_time_millis()
-    # Fill the cache to one shy of the cap with unique-name records, each
-    # with a later created time than the shared-key victim below.
     cache.async_add_records(
-        r.DNSAddress(
-            f"filler-{i}.local.",
-            const._TYPE_A,
-            const._CLASS_IN,
-            120,
-            bytes((i & 0xFF, (i >> 8) & 0xFF, 0, 1)),
-            created=now + 1000 + i,
-        )
-        for i in range(const._MAX_CACHE_RECORDS - 1)
+        _addr(f"filler-{i}.local.", i, created=now + 1000 + i) for i in range(const._MAX_CACHE_RECORDS - 1)
     )
 
-    # Insert a record at "shared.local." with the earliest expiration —
-    # this is the one closest_to_expiration eviction will pick.
+    # Insert at "shared.local." with the earliest expiration so eviction
+    # picks it. ``_remove_key`` then deletes ``cache["shared.local."]``.
     shared_key = "shared.local."
-    old_shared = r.DNSAddress(
-        shared_key,
-        const._TYPE_A,
-        const._CLASS_IN,
-        120,
-        b"\x01\x02\x03\x04",
-        created=now,
-    )
-    cache.async_add_records([old_shared])
+    cache.async_add_records([_addr(shared_key, 0x0102, created=now)])
     assert cache._total_records == const._MAX_CACHE_RECORDS
-    assert shared_key in cache.cache
 
-    # Add a new record with the SAME key. Eviction will remove old_shared,
-    # which empties cache[shared_key], so _remove_key deletes that bucket.
-    # If _async_add captured the store before eviction it will now be
-    # writing into an orphaned dict.
-    new_shared = r.DNSAddress(
-        shared_key,
-        const._TYPE_A,
-        const._CLASS_IN,
-        120,
-        b"\x05\x06\x07\x08",
-        created=now + 999,
-    )
+    # Adding a new record under the SAME key: a pre-eviction-captured
+    # ``store`` would write into an orphaned dict; the fix re-resolves.
+    new_shared = _addr(shared_key, 0x0506, created=now + 999)
     cache.async_add_records([new_shared])
 
-    # The new record must be reachable via the cache.
     assert shared_key in cache.cache, "new record orphaned: cache bucket missing"
     assert new_shared in cache.cache[shared_key]
     assert cache.async_get_unique(new_shared) == new_shared
-    # And the counter accounting must still match observable state.
     total = sum(len(store) for store in cache.cache.values())
     assert total == cache._total_records
 
 
-def test_cache_eviction_rebuilds_heap_when_mostly_stale() -> None:
-    """Eviction rebuilds ``_expire_heap`` up front when stale entries dominate.
-
-    Without the rebuild, a single ``_async_add`` at cap could pop a long
-    stale prefix one entry at a time — O(stale_prefix * log n). The
-    rebuild is the same heuristic ``async_expire`` already uses: when
-    ``len(heap) > 2 * len(expirations)``, the heap is reconstructed
-    from only the valid entries in one O(n) pass before the pop loop.
-    """
+def test_cache_re_add_flood_does_not_grow_heap_unbounded() -> None:
+    """Replaying cached records with shifting TTLs cannot grow ``_expire_heap`` unbounded."""
     cache = r.DNSCache()
     now = r.current_time_millis()
-    base_kwargs = {"type_": const._TYPE_A, "class_": const._CLASS_IN}
+    # Stay below the cache cap so eviction never fires; the attack here is
+    # heap growth via re-add, not cap saturation. Clear the
+    # ``_MIN_SCHEDULED_RECORD_EXPIRATION`` floor so the rebuild engages.
+    record_count = 200
+    cache.async_add_records(_addr(f"flood-{i}.local.", i, created=now) for i in range(record_count))
+    assert cache._total_records == record_count
 
-    cache.async_add_records(
-        r.DNSAddress(
-            f"r-{i}.local.",
-            ttl=120,
-            address=bytes((i & 0xFF, (i >> 8) & 0xFF, 0, 1)),
-            created=now + i,
-            **base_kwargs,
-        )
-        for i in range(const._MAX_CACHE_RECORDS)
-    )
-    # Two re-adds with distinct TTLs leave two stale entries per record
-    # in ``_expire_heap`` while ``_expirations`` stays at MAX. Heap reaches
-    # ~3x MAX, which trips the ``len(heap) > 2 * len(expirations)``
-    # threshold on the next eviction.
-    for ttl in (7200, 14400):
+    # 10 cycles x ``record_count`` stale pushes each. Without
+    # ``_maybe_rebuild_heap`` firing inside ``_async_add``, the heap would
+    # grow to ~11 x record_count.
+    for cycle in range(10):
         cache.async_add_records(
-            r.DNSAddress(
-                f"r-{i}.local.",
-                ttl=ttl,
-                address=bytes((i & 0xFF, (i >> 8) & 0xFF, 0, 1)),
-                created=now + i,
-                **base_kwargs,
-            )
-            for i in range(const._MAX_CACHE_RECORDS)
+            _addr(f"flood-{i}.local.", i, ttl=7200 + cycle, created=now) for i in range(record_count)
         )
-    assert len(cache._expire_heap) > 2 * len(cache._expirations)
 
-    # One more insert pushes us over the cap; eviction fires and must
-    # rebuild before scanning.
-    cache.async_add_records(
-        [
-            r.DNSAddress(
-                "trigger.local.",
-                ttl=120,
-                address=b"\xff\xff\xff\xff",
-                created=now + const._MAX_CACHE_RECORDS,
-                **base_kwargs,
-            )
-        ]
-    )
-    # Rebuild dropped the stale entries; heap and expirations now match.
-    assert len(cache._expire_heap) == len(cache._expirations) == const._MAX_CACHE_RECORDS
-    assert cache._total_records == const._MAX_CACHE_RECORDS
+    # Heap is bounded near the rebuild threshold; ``+ record_count`` of slack
+    # to stay resilient to where in a re-add cycle the rebuild last fired.
+    assert len(cache._expire_heap) <= 2 * len(cache._expirations) + record_count
+    assert cache._total_records == record_count
 
 
 def test_cache_eviction_decrements_total_records() -> None:
-    """Natural removal (goodbyes, expirations) must keep ``_total_records`` in sync."""
+    """Natural removal (goodbyes, expirations) keeps ``_total_records`` in sync."""
     cache = r.DNSCache()
     now = r.current_time_millis()
-    records = [
-        r.DNSAddress(
-            f"sync-{i}.local.",
-            const._TYPE_A,
-            const._CLASS_IN,
-            120,
-            bytes((i & 0xFF, (i >> 8) & 0xFF, 0, 1)),
-            created=now,
-        )
-        for i in range(50)
-    ]
+    records = [_addr(f"sync-{i}.local.", i, created=now) for i in range(50)]
     cache.async_add_records(records)
     assert cache._total_records == 50
 
     cache.async_remove_records(records[:20])
     assert cache._total_records == 30
 
-    # async_expire on a future time should drop the rest
     cache.async_expire(now + (200 * 1000))
     assert cache._total_records == 0
     assert not cache.cache
 
 
 def test_cache_total_records_invariant_under_mixed_ops() -> None:
-    """``_total_records`` must equal ``sum(len(store) for store in cache.values())``.
-
-    Walks the counter through every code path that touches it — new inserts,
-    re-adds of an existing record (no increment), DNSService (extra
-    service_cache write), DNSNsec (stored but not counted as "new" by the
-    flag), shared-key inserts that empty their bucket on removal, full-cap
-    eviction, async_expire, manual async_remove_records — and asserts the
-    invariant after every step. Any future change that misses an increment
-    or doubles a decrement will trip this immediately; ``_total_records`` is
-    ``cdef unsigned int`` in the Cython build, so silent underflow would
-    otherwise propagate as a permanent eviction-on-every-add storm.
-    """
+    """``_total_records`` stays equal to the sum of bucket sizes across all touched paths."""
     cache = r.DNSCache()
     now = r.current_time_millis()
 
     def actual() -> int:
         return sum(len(store) for store in cache.cache.values())
 
-    # Fresh inserts: counter follows insert count exactly.
-    addrs = [
-        r.DNSAddress(
-            f"mix-{i}.local.", const._TYPE_A, const._CLASS_IN, 120, bytes((i, 0, 0, 1)), created=now + i
-        )
-        for i in range(20)
-    ]
+    addrs = [_addr(f"mix-{i}.local.", i, created=now + i) for i in range(20)]
     cache.async_add_records(addrs)
     assert cache._total_records == actual() == 20
 
-    # Re-add of an identical record: no increment (already present).
+    # Re-add of an identical record: no increment.
     cache.async_add_records([addrs[0]])
     assert cache._total_records == actual() == 20
 
-    # DNSService writes service_cache too — counter must still match cache size.
+    # DNSService writes service_cache too — counter still matches cache size.
     svc = r.DNSService("svc.local.", const._TYPE_SRV, const._CLASS_IN, 120, 0, 0, 80, "host.local.")
     cache.async_add_records([svc])
     assert cache._total_records == actual() == 21
     cache.async_remove_records([svc])
     assert cache._total_records == actual() == 20
 
-    # DNSNsec is stored but excluded from the "new" return value; the counter
-    # still tracks it because it occupies a bucket slot.
-    nsec = r.DNSNsec(
-        "nsec.local.",
-        const._TYPE_NSEC,
-        const._CLASS_IN,
-        120,
-        "nsec.local.",
-        [const._TYPE_A],
-    )
+    # DNSNsec is stored but excluded from the "new" return; counter tracks it anyway.
+    nsec = r.DNSNsec("nsec.local.", const._TYPE_NSEC, const._CLASS_IN, 120, "nsec.local.", [const._TYPE_A])
     cache.async_add_records([nsec])
     assert cache._total_records == actual() == 21
     cache.async_remove_records([nsec])
     assert cache._total_records == actual() == 20
 
-    # Shared-key insert/remove: emptying a bucket removes the cache key, but
-    # the counter must still decrement only by the number of records gone.
-    shared_a = r.DNSAddress(
-        "shared.local.", const._TYPE_A, const._CLASS_IN, 120, b"\x01\x01\x01\x01", created=now
-    )
-    shared_b = r.DNSAddress(
-        "shared.local.", const._TYPE_A, const._CLASS_IN, 120, b"\x02\x02\x02\x02", created=now
-    )
+    # Shared-key insert/remove: emptying the bucket drops the cache key but
+    # counter decrements only by the records that left.
+    shared_a = _addr("shared.local.", 0x0101, created=now)
+    shared_b = _addr("shared.local.", 0x0202, created=now)
     cache.async_add_records([shared_a, shared_b])
     assert cache._total_records == actual() == 22
     cache.async_remove_records([shared_a, shared_b])
     assert cache._total_records == actual() == 20
     assert "shared.local." not in cache.cache
 
-    # async_expire path: counter must follow the records dropped.
     cache.async_expire(now + (200 * 1000))
     assert cache._total_records == actual() == 0
     assert not cache.cache
 
     # Full-cap eviction loop: counter never grows past the cap, never drifts.
-    cap_records = [
-        r.DNSAddress(
-            f"cap-{i}.local.",
-            const._TYPE_A,
-            const._CLASS_IN,
-            120,
-            bytes((i & 0xFF, (i >> 8) & 0xFF, 0, 1)),
-            created=now + i,
-        )
-        for i in range(const._MAX_CACHE_RECORDS + 50)
-    ]
+    cap_records = [_addr(f"cap-{i}.local.", i, created=now + i) for i in range(const._MAX_CACHE_RECORDS + 50)]
     for rec in cap_records:
         cache.async_add_records([rec])
         assert cache._total_records == actual()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -583,6 +583,31 @@ def test_cache_eviction_victim_shares_key_with_new_record() -> None:
     assert total == cache._total_records
 
 
+def test_cache_dnsnsec_at_cap_evicts_prior_record() -> None:
+    """A single DNSNsec arriving at the cap evicts one prior record and stays reachable."""
+    cache = r.DNSCache()
+    now = r.current_time_millis()
+    cache.async_add_records(
+        _addr(f"fill-{i}.local.", i, created=now + i) for i in range(const._MAX_CACHE_RECORDS)
+    )
+    assert cache._total_records == const._MAX_CACHE_RECORDS
+
+    nsec = r.DNSNsec(
+        "nsec-arrival.local.",
+        const._TYPE_NSEC,
+        const._CLASS_IN,
+        120,
+        "nsec-arrival.local.",
+        [const._TYPE_A],
+    )
+    cache.async_add_records([nsec])
+
+    assert cache._total_records == const._MAX_CACHE_RECORDS
+    assert nsec in cache.cache[nsec.key]
+    # The earliest-created fill record is gone (FIFO-ish eviction).
+    assert "fill-0.local." not in cache.cache
+
+
 def test_cache_dnsnsec_flood_is_bounded() -> None:
     """DNSNsec records honour ``_MAX_CACHE_RECORDS`` (no bypass via the ``new`` flag)."""
     cache = r.DNSCache()


### PR DESCRIPTION
## Summary

Closes #1715. A LAN-local peer multicasting unique-name mDNS responses
can grow `DNSCache.cache` / `_expirations` / `service_cache` /
`_expire_heap` without bound. With `_DNS_PTR_MIN_TTL = 1125`
extending attacker-injected PTR records to ~19 min and `async_expire`
only running every `_CACHE_CLEANUP_INTERVAL = 10` s, a low-Mbps
multicast flood OOMs a Raspberry-Pi-class deployment in minutes.

Adds a hard cap on the total record count with closest-to-expiration
eviction on overflow, plus a shared `_maybe_rebuild_heap` helper that
keeps `_expire_heap` bounded against a second variant of the same
attack (record replay with shifting TTLs, which leaves stale heap
entries without changing the cache size).

## Details

### Cache cap

- `_MAX_CACHE_RECORDS = 10_000` added to `const.py`. Picked as a
  ceiling well above any realistic legitimate workload — Home
  Assistant deployments typically sit in the low hundreds — while
  staying low enough to keep memory bounded at a few MB worst-case.
- `DNSCache` gains `_total_records: unsigned int` (declared in
  `_cache.pxd`). Incremented in `_async_add` on genuinely-new
  inserts; decremented in `_async_remove`. The counter is
  authoritative — the cap check uses it directly rather than walking
  `self.cache`.
- New `_async_evict_oldest`: when the cap is hit, `heappop`s the
  closest-to-expiration `(when, record)` from `_expire_heap` and
  removes it before inserting the new arrival. Skips stale heap
  entries via the same expiration-equality check ``async_expire``
  already uses.

### Eviction-victim collision (orphaned-store bug)

The first iteration of this PR captured `store = self.cache.get(record.key)`
*before* eviction. If the closest-to-expiration victim was the last
record under `record.key` (which happens whenever the incoming
record shares its key with the victim — A+AAAA pairs, PTR fan-outs,
TXT/SRV pairs all hit this), `_remove_key` would `del
self.cache[record.key]` during eviction, leaving the captured
`store` pointing at an orphaned dict. The subsequent `store[record]
= record` then wrote into a dict no longer reachable through the
cache; the new record was effectively lost, and a later
`async_expire` of that record would `KeyError` from `_remove_key`.

Fix: defer the bucket creation. Look up `store` first (without
creating), do the eviction-if-needed pass, then `cache.get` again
to pick up any deletion eviction caused. The bucket is only created
with `self.cache[record.key] = {}` after eviction has settled.

### Replay-flood heap growth

The cap above is gated on `is_new`, but a peer that just replays
cached records with different `created`/TTLs hits the `is_new
== False` path: no cap check, no `_total_records` change — yet the
changed `when` makes `_expirations.get(record) != when` true, so a
fresh `(when, record)` tuple is heappushed while the prior tuple
stays behind as stale. `_expire_heap` grows unbounded between
cleanups even though `cache` and `_total_records` stay flat. At
~10k pps for 10 s that's ~1 M stale heap entries × ~100 B ≈ 100 MB
transient.

Factor the heap-rebuild check (`len(heap) > _MIN_SCHEDULED_RECORD_EXPIRATION
and len(heap) > 2 * len(expirations)` → filter-and-heapify) into a
new `_maybe_rebuild_heap` cdef helper. Called from two sites:

- `_async_add` immediately after the conditional heappush, so a
  re-add flood is bounded at every step. Amortized O(1) per push:
  the O(N) rebuild fires at most once per N stale pushes.
- `async_expire` after the pop loop, replacing the existing inline
  rebuild (same behavior, slightly more aggressive — uses post-pop
  heap length instead of pre-pop, no test regression).

`_async_evict_oldest` no longer needs its own rebuild call:
proactive rebuild in `_async_add` keeps the heap bounded before
eviction is ever triggered.

### Why not per-source-IP quotas

The reporter's "Better" suggestion is intentionally not pursued.
mDNS rides on UDP with no source authentication; an attacker on the
local segment can multicast with any source address, so a per-IP
quota is bypassed by source-rotation. The LAN itself is the trust
boundary in mDNS; once an attacker is past it, source IPs are not a
meaningful identity. Per-source bookkeeping would add hot-path
overhead and lifecycle complexity (peer mappings need GC as records
expire) in exchange for a fairness property that doesn't survive
contact with the protocol's threat model.

CWE-400 (Uncontrolled Resource Consumption). LAN-local attack
surface only.

### Cython perf check

`cython -a` on the touched `_cache.py`:

```
_async_add additions (hot path):
  line  75:  self._total_records: int = 0                          score-0
  line 100:  if is_new and self._total_records >= _MAX_CACHE_RECORDS score-0
  line 101:      self._async_evict_oldest()                         score-0
  line 109:      self._total_records += 1                           score-0
  line 120:      self._maybe_rebuild_heap()  (after stale push)     score-0

_async_remove (decrement):
  line 173:  self._total_records -= 1                               score-0

_maybe_rebuild_heap helper body:
  line 153:  expire_heap_len = len(self._expire_heap)               score-9
  line 155:  expire_heap_len > _MIN_SCHEDULED_RECORD_EXPIRATION     score-0
  line 156:  and expire_heap_len > len(self._expirations) * 2       score-12

async_expire (uses helper):
  line 219:  self._maybe_rebuild_heap()                             score-0
```

Generated C compiles the cap check and counter ops to direct
`unsigned int` arithmetic, helper invocations to C-level vtable
dispatch. The yellow inside `_maybe_rebuild_heap` is one
`PyObject_RichCompare` per list-comp iteration (type-generic
equality against `_expirations.get(...)`) — unavoidable, and only
runs during the rare rebuild path. The hot path on duplicate
re-adds (same `when`) never enters the helper at all because the
`if self._expirations.get(record) != when:` gate trips first.

Wall-clock smoke test: below-cap adds run at ~159 ns/record;
sustained-eviction adds run at ~195 ns/record (+36 ns/record for the
heappop + cache delete).

## Test plan

- [x] `poetry run pytest tests/test_cache.py --timeout=60 -v` — 33
      passed including five regressions:
  - `test_cache_size_is_bounded` — cap holds exactly under unique-name
    flood, FIFO eviction order
  - `test_cache_eviction_skips_stale_heap_entries` — heap stale-skip
    selects next valid victim
  - `test_cache_eviction_victim_shares_key_with_new_record` —
    reproduces the orphan bug against pre-`931358a` code
  - `test_cache_re_add_flood_does_not_grow_heap_unbounded` — replay
    attack bounded by the `_maybe_rebuild_heap` helper
  - `test_cache_total_records_invariant_under_mixed_ops` — pins
    `_total_records == sum(len(store) for store in cache.cache.values())`
    after every code path that touches it (fresh inserts, re-adds,
    DNSService, DNSNsec, shared-key emptying its bucket, full-cap
    eviction loop, `async_expire`, `async_remove_records`); any
    future off-by-one fails loudly rather than silently underflowing
    the unsigned counter
- [x] `poetry run pytest --timeout=60` — 345 passed, 3 skipped (full
      suite)
- [x] `poetry run pre-commit run --files <changed files>` — all hooks
      pass
- [x] `REQUIRE_CYTHON=1 poetry install --only=main,dev` — extension
      rebuilds against the new `.pxd` (added `_total_records` field,
      `_async_evict_oldest` and `_maybe_rebuild_heap` cdefs)
- [x] CodSpeed bench at `tests/benchmarks/test_cache_bound.py`
      covering below-cap and at-cap add paths
- [ ] (optional) draft a GitHub Security Advisory so a CVE can be
      assigned alongside the patched release
