### PR TITLE
fix: bound DNS compression-pointer chain depth in DNSIncoming

### DIFF
--- a/src/zeroconf/_protocol/incoming.pxd
+++ b/src/zeroconf/_protocol/incoming.pxd
@@ -83,7 +83,7 @@ cdef class DNSIncoming:
         link_py_int=object,
         linked_labels=cython.list
     )
-    cdef unsigned int _decode_labels_at_offset(self, unsigned int off, cython.list labels, cython.set seen_pointers)
+    cdef unsigned int _decode_labels_at_offset(self, unsigned int off, cython.list labels, cython.set seen_pointers, unsigned int depth)
 
     @cython.locals(offset="unsigned int")
     cdef void _read_header(self)

--- a/src/zeroconf/_protocol/incoming.py
+++ b/src/zeroconf/_protocol/incoming.py
@@ -60,7 +60,7 @@ DNS_COMPRESSION_POINTER_LEN = 2
 MAX_DNS_LABELS = 128
 MAX_NAME_LENGTH = 253
 
-DECODE_EXCEPTIONS = (IndexError, struct.error, IncomingDecodeError)
+DECODE_EXCEPTIONS = (IndexError, struct.error, IncomingDecodeError, RecursionError)
 
 
 _seen_logs: dict[str, int | tuple] = {}
@@ -409,7 +409,7 @@ class DNSIncoming:
         labels: list[str] = []
         seen_pointers: set[int] = set()
         original_offset = self.offset
-        self.offset = self._decode_labels_at_offset(original_offset, labels, seen_pointers)
+        self.offset = self._decode_labels_at_offset(original_offset, labels, seen_pointers, 0)
         self._name_cache[original_offset] = labels
         name = ".".join(labels) + "."
         if len(name) > MAX_NAME_LENGTH:
@@ -418,8 +418,14 @@ class DNSIncoming:
             )
         return name
 
-    def _decode_labels_at_offset(self, off: _int, labels: list[str], seen_pointers: set[int]) -> int:
+    def _decode_labels_at_offset(
+        self, off: _int, labels: list[str], seen_pointers: set[int], depth: _int
+    ) -> int:
         # This is a tight loop that is called frequently, small optimizations can make a difference.
+        if depth > MAX_DNS_LABELS:
+            raise IncomingDecodeError(
+                f"DNS compression pointer chain exceeds {MAX_DNS_LABELS} at {off} from {self.source}"
+            )
         view = self.view
         while off < self._data_len:
             length = view[off]
@@ -457,7 +463,7 @@ class DNSIncoming:
             if not linked_labels:
                 linked_labels = []
                 seen_pointers.add(link_py_int)
-                self._decode_labels_at_offset(link, linked_labels, seen_pointers)
+                self._decode_labels_at_offset(link, linked_labels, seen_pointers, depth + 1)
                 self._name_cache[link_py_int] = linked_labels
             labels.extend(linked_labels)
             if len(labels) > MAX_DNS_LABELS:

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1011,6 +1011,28 @@ def test_label_compression_attack():
     assert len(parsed.answers()) == 1
 
 
+def test_dns_compression_pointer_chain_depth_attack() -> None:
+    """Test our wire parser rejects deeply chained compression pointers without recursing."""
+    # Build a packet with one question whose name is a 1500-deep chain of forward
+    # compression pointers, ending in a root label. Each pointer is 2 bytes,
+    # so chain length easily exceeds CPython's default recursion limit.
+    header = b"\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00"
+    # Question at offset 12: pointer to offset 18 (past the question's type/class).
+    question_name = bytes([0xC0, 18])
+    question_type_class = b"\x00\x01\x00\x01"
+    chain_depth = 1500
+    chain = bytearray()
+    for i in range(chain_depth):
+        target = 18 + 2 * (i + 1)
+        chain.append(0xC0 | (target >> 8))
+        chain.append(target & 0xFF)
+    chain.append(0x00)
+    packet = header + question_name + question_type_class + bytes(chain)
+    parsed = r.DNSIncoming(packet, ("1.2.3.4", 5353))
+    assert parsed.valid is False
+    assert parsed.questions == []
+
+
 def test_dns_compression_loop_attack():
     """Test our wire parser does not loop forever when dns compression is in a loop."""
     packet = (


### PR DESCRIPTION
## Summary

Closes #1713. A crafted mDNS packet chaining thousands of forward DNS
name-compression pointers (RFC 1035 §4.1.4) into a single ~3 kB datagram
blows ``DNSIncoming._decode_labels_at_offset`` through CPython's default
recursion limit (``sys.getrecursionlimit() == 1000``). ``RecursionError``
was not in ``DECODE_EXCEPTIONS``, so it escaped ``DNSIncoming.__init__``
and bubbled up to asyncio's default exception handler — turning a single
small multicast packet from any host on the local link (a guest on the
same Wi-Fi, a compromised IoT device, a container on a shared bridge)
into sustained CPU burn and debug-log flooding. Home Assistant on
Raspberry-Pi-class hardware is the canonical victim. Adds a hard cap
on the pointer-chain depth, mirroring the existing label cap.

## Details

- ``seen_pointers`` already blocked cycles and ``MAX_DNS_LABELS = 128``
  already capped the *number of labels*, but nothing capped the *chain
  length of unique forward pointers*. A ``_MAX_MSG_ABSOLUTE`` (8966 B)
  packet can carry ~4000 2-byte pointers, each pointing to the next
  unique offset.
- ``_decode_labels_at_offset`` gains a ``depth: unsigned int`` parameter
  (declared in ``_protocol/incoming.pxd``). Top-of-function check raises
  ``IncomingDecodeError`` when ``depth > MAX_DNS_LABELS`` — the same
  bound as the existing label cap, so no new constant. The single
  external caller (``_read_name``) passes ``0``; the recursive call site
  passes ``depth + 1``.
- Choice of bound: ``MAX_DNS_LABELS`` (128) is plenty for any legitimate
  name — a 253-byte name (the RFC 6762 §16 / RFC 1035 §3.1 limit) caps
  out at ~127 single-byte labels even with every label minimized. The
  recursion depth is bounded by the number of pointer follows, which
  in well-formed packets is ≤ the label count, so legitimate traffic
  never approaches the cap.
- Belt-and-braces: ``RecursionError`` is added to ``DECODE_EXCEPTIONS``
  so any future regression that lets the recursion run away is contained
  as an invalid packet rather than logged by asyncio's default handler.
- Per-source-IP rate limiting is out of scope here — this PR closes the
  recursion-DoS class on its own; quotas would be a separate change to
  the listener.
- CWE-674 (Uncontrolled Recursion). LAN-local attack surface only.

### Cython perf check

``cython -a`` on the touched ``_protocol/incoming.py`` shows every new
line as score-0 (no Python interpreter overhead):

```
line 412:  self._decode_labels_at_offset(original_offset, labels, seen_pointers, 0)  (score-0)
line 425:  if depth > MAX_DNS_LABELS:                                                  (score-0)
line 466:  self._decode_labels_at_offset(link, linked_labels, seen_pointers, depth + 1)  (score-0)
```

Generated C compiles ``depth > MAX_DNS_LABELS`` to a direct
``unsigned int > unsigned int`` compare, ``depth + 1`` to a C add,
and the recursive call to the existing C-level vtable dispatch with
one extra ``unsigned int`` argument. Function entry score is unchanged
(score-11, same boilerplate). Wall-clock smoke test on a typical
compressed mDNS response (best-of-10 over 50k iters, ``REQUIRE_CYTHON=1``):

```
PREFIX  best: 1237.2 ns/parse
POSTFIX best: 1234.1 ns/parse
```

Within noise — the per-call overhead is one C compare at function
entry and one C add per pointer follow.

## Test plan

- [x] ``SKIP_CYTHON=1 poetry run pytest tests/test_protocol.py`` —
      47 passed (46 pre-existing + 1 new regression below). Coverage
      report shows 98 % on ``_protocol/incoming.py`` with the 5
      uncovered lines (143, 199–200, 210, 213) all pre-existing and
      unrelated to this PR — every line touched by this diff is hit.
- [x] ``REQUIRE_CYTHON=1 poetry install --only=main,dev`` rebuilds
      the extension against the new ``.pxd``; full suite
      ``poetry run pytest --timeout=60`` — 338 passed, 3 skipped.
- [x] ``poetry run pre-commit run --files <changed files>`` — all
      hooks pass (ruff lint + format, mypy, flake8, codespell,
      cython-lint, pyupgrade).
- [x] New regression: ``tests/test_protocol.py::test_dns_compression_pointer_chain_depth_attack``
      feeds a 1500-pointer forward chain through ``DNSIncoming`` and
      asserts ``valid is False`` with no exception escaping. Verified
      to fail on pre-fix ``master`` with
      ``RecursionError: maximum recursion depth exceeded``.
- [ ] (optional) draft a GitHub Security Advisory so a CVE can be
      assigned alongside the patched release.
