### PR TITLE
test: give IPv6-only loopback find() its own timeout

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -51,6 +51,14 @@ QUICK_REQUEST_TIMEOUT_MS = 50
 # the registrar's response lands inside ~10ms and 75ms is ~7x headroom.
 LOOPBACK_FIND_TIMEOUT = 0.075
 
+# IPv6-only `find()` on Linux GitHub runners can hit `[Errno 101] Network
+# is unreachable` on the `::1` socket and falls back to the `fe80::` link-
+# local interface, which adds latency the IPv4 loopback path never pays.
+# PyPy widens that further with JIT warmup. The 75ms budget that works on
+# IPv4 loopback is too tight for the V6Only path under those conditions
+# — give it more headroom.
+IPV6_LOOPBACK_FIND_TIMEOUT = 0.5
+
 
 class QuestionHistoryWithoutSuppression(QuestionHistory):
     def suppresses(self, question: DNSQuestion, now: float, known_answers: set[DNSRecord]) -> bool:

--- a/tests/services/test_types.py
+++ b/tests/services/test_types.py
@@ -11,7 +11,7 @@ import unittest
 import zeroconf as r
 from zeroconf import ServiceInfo, Zeroconf, ZeroconfServiceTypes
 
-from .. import LOOPBACK_FIND_TIMEOUT, _clear_cache, has_working_ipv6
+from .. import IPV6_LOOPBACK_FIND_TIMEOUT, LOOPBACK_FIND_TIMEOUT, _clear_cache, has_working_ipv6
 
 log = logging.getLogger("zeroconf")
 original_logging_level = logging.NOTSET
@@ -116,11 +116,11 @@ def test_integration_with_listener_ipv6(quick_timing, disable_duplicate_packet_s
     zeroconf_registrar.registry.async_add(info)
     try:
         service_types = ZeroconfServiceTypes.find(
-            ip_version=r.IPVersion.V6Only, timeout=LOOPBACK_FIND_TIMEOUT
+            ip_version=r.IPVersion.V6Only, timeout=IPV6_LOOPBACK_FIND_TIMEOUT
         )
         assert type_ in service_types
         _clear_cache(zeroconf_registrar)
-        service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=LOOPBACK_FIND_TIMEOUT)
+        service_types = ZeroconfServiceTypes.find(zc=zeroconf_registrar, timeout=IPV6_LOOPBACK_FIND_TIMEOUT)
         assert type_ in service_types
 
     finally:


### PR DESCRIPTION
## Summary

`tests/services/test_types.py::test_integration_with_listener_ipv6` flaked on
the PyPy 3.10 / ubuntu / `skip_cython` runner ([failed job][failure]) after
#1720 dropped `LOOPBACK_FIND_TIMEOUT` to 75ms. Give the V6Only path its own
500ms budget; leave the IPv4 loopback tests at 75ms.

## Details

`ZeroconfServiceTypes.find()` is just `time.sleep(timeout)` — the timeout is
the test's runtime, not a deadline that gets short-circuited by the first
matching response. PR #1720 made that budget viable on loopback by also
patching `_FIRST_QUERY_DELAY_RANDOM_INTERVAL` from RFC 6762 §5.2's 20–120ms
down to 1–5ms via the `quick_timing` fixture, so the response normally lands
inside ~10ms with 7× headroom.

The V6Only path doesn't behave the same way on GitHub's Linux runners:

```
WARNING zeroconf:_logger.py:111 Error with socket 18 (('::1', 5353, 0, 0))): [Errno 101] Network is unreachable
```

Every outgoing send on the `::1` socket fails and the listener has to fall
back to the `fe80::` link-local interface. That fallback adds latency the
IPv4 loopback path never pays. PyPy widens the gap further with JIT warmup,
and the 75ms budget is no longer enough headroom.

Adding `IPV6_LOOPBACK_FIND_TIMEOUT = 0.5` (matches the pre-#1710 value the
test ran with for years) and routing the V6Only test through it. The three
IPv4-loopback tests keep the 75ms budget — they never hit the `::1` retry
path.

## Test plan

- [x] `poetry run pytest tests/services/test_types.py -v` — all 4 pass
- [x] `poetry run pre-commit run --files tests/__init__.py tests/services/test_types.py` — clean

[failure]: https://github.com/python-zeroconf/python-zeroconf/actions/runs/26014128897/job/76460570964
