### PR TITLE
ci: set UV_PYTHON_PREFERENCE to only-managed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ concurrency:
 
 env:
   POETRY_VIRTUALENVS_IN_PROJECT: "true"
+  UV_PYTHON_PREFERENCE: only-managed  # avoid ancient system Python
 
 jobs:
   lint:


### PR DESCRIPTION
## Summary
Set `UV_PYTHON_PREFERENCE: only-managed` at the workflow level so uv resolves to uv managed Pythons; this avoids falling back to whatever ancient or system Python happens to be on the runner.

## Test plan
- [ ] CI green across the test matrix
