### PR TITLE
test: widen LOOPBACK_FIND_TIMEOUT under PyPy

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -23,6 +23,7 @@ USA
 from __future__ import annotations
 
 import asyncio
+import platform
 import socket
 import time
 from functools import cache
@@ -34,6 +35,8 @@ from zeroconf import DNSIncoming, DNSQuestion, DNSRecord, Zeroconf
 from zeroconf._history import QuestionHistory
 
 _MONOTONIC_RESOLUTION = time.get_clock_info("monotonic").resolution
+
+_IS_PYPY = platform.python_implementation() == "PyPy"
 
 # get_service_info / async_request timeout for tests using the
 # `quick_request_timing` fixture. The fixture cuts the initial-query
@@ -49,7 +52,9 @@ QUICK_REQUEST_TIMEOUT_MS = 50
 # the `quick_timing` fixture, which shrinks the browser's first-query
 # delay from RFC 6762 §5.2's 20-120ms window to 1-5ms; with that shave
 # the registrar's response lands inside ~10ms and 75ms is ~7x headroom.
-LOOPBACK_FIND_TIMEOUT = 0.075
+# PyPy's JIT is still warming up the first time this path runs early in
+# the suite, so the round trip is too slow for 75ms; give it more room.
+LOOPBACK_FIND_TIMEOUT = 0.3 if _IS_PYPY else 0.075
 
 # IPv6-only `find()` on Linux GitHub runners can hit `[Errno 101] Network
 # is unreachable` on the `::1` socket and falls back to the `fe80::` link-


### PR DESCRIPTION
## Summary

The 75ms loopback budget for `ZeroconfServiceTypes.find()` races PyPy's JIT warmup the first time the path runs early in the suite; two back to back runs on master flaked at the same 21% point, once on `test_integration_with_listener` and once on `test_integration_with_listener_v6_records`. Bump the timeout to 300ms on PyPy only; CPython keeps the existing 75ms budget so the fast path stays fast.

## Test plan

- [ ] CI PyPy job passes without flaking on the early `tests/services/test_types.py::test_integration_with_listener*` tests
- [ ] CPython jobs still finish in the same time as before