### PR TITLE
ci: key venv cache on resolved python patch version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
       - name: Install poetry
         run: uv tool install poetry
       - name: Set up Python
+        id: setup-python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
         with:
           python-version: ${{ matrix.python-version }}
@@ -96,7 +97,7 @@ jobs:
           path: |
             .venv
             src/zeroconf/**/*.so
-          key: venv-v1-${{ runner.os }}-py${{ matrix.python-version }}-${{ matrix.extension }}-${{ hashFiles('poetry.lock', 'pyproject.toml', 'build_ext.py', 'src/zeroconf/**/*.py', 'src/zeroconf/**/*.pxd') }}
+          key: venv-v1-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-${{ matrix.extension }}-${{ hashFiles('poetry.lock', 'pyproject.toml', 'build_ext.py', 'src/zeroconf/**/*.py', 'src/zeroconf/**/*.pxd') }}
       - name: Install Dependencies no cython
         if: ${{ matrix.extension == 'skip_cython' && steps.cache-venv.outputs.cache-hit != 'true' }}
         env:
@@ -119,6 +120,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
       - name: Setup Python 3.13
+        id: setup-python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
         with:
           python-version: 3.13
@@ -135,7 +137,7 @@ jobs:
           path: |
             .venv
             src/zeroconf/**/*.so
-          key: venv-v1-${{ runner.os }}-benchmark-py3.13-${{ hashFiles('poetry.lock', 'pyproject.toml', 'build_ext.py', 'src/zeroconf/**/*.py', 'src/zeroconf/**/*.pxd') }}
+          key: venv-v1-${{ runner.os }}-benchmark-py${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('poetry.lock', 'pyproject.toml', 'build_ext.py', 'src/zeroconf/**/*.py', 'src/zeroconf/**/*.pxd') }}
       - name: Install Dependencies
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |


### PR DESCRIPTION
## Summary
Extracts the CI cache fix from #1743 so it can land on its own; the venv cache key now uses the Python version that `setup-python` resolves, so a patch upgrade on the runner invalidates the cache instead of silently reusing stale built artifacts.

## Details
The cache key previously used `matrix.python-version`, which is just the minor version like 3.13, so a patch upgrade on the runner kept the old cache around; switching to `steps.setup-python.outputs.python-version` pins the cache to the exact patch version that was actually installed.

## Test plan
- [ ] CI passes on this branch.
