### PR TITLE
fix: bound QuestionHistory per-entry known-answer payload

### DIFF
--- a/src/zeroconf/_history.pxd
+++ b/src/zeroconf/_history.pxd
@@ -5,6 +5,7 @@ from ._dns cimport DNSQuestion
 
 cdef cython.double _DUPLICATE_QUESTION_INTERVAL
 cdef unsigned int _MAX_QUESTION_HISTORY_ENTRIES
+cdef unsigned int _MAX_KNOWN_ANSWERS_PER_HISTORY_ENTRY
 
 cdef class QuestionHistory:
 

--- a/src/zeroconf/_history.py
+++ b/src/zeroconf/_history.py
@@ -23,7 +23,11 @@ USA
 from __future__ import annotations
 
 from ._dns import DNSQuestion, DNSRecord
-from .const import _DUPLICATE_QUESTION_INTERVAL, _MAX_QUESTION_HISTORY_ENTRIES
+from .const import (
+    _DUPLICATE_QUESTION_INTERVAL,
+    _MAX_KNOWN_ANSWERS_PER_HISTORY_ENTRY,
+    _MAX_QUESTION_HISTORY_ENTRIES,
+)
 
 # The QuestionHistory is used to implement Duplicate Question Suppression
 # https://datatracker.ietf.org/doc/html/rfc6762#section-7.3
@@ -40,6 +44,15 @@ class QuestionHistory:
 
     def add_question_at_time(self, question: DNSQuestion, now: _float, known_answers: set[DNSRecord]) -> None:
         """Remember a question with known answers."""
+        if len(known_answers) > _MAX_KNOWN_ANSWERS_PER_HISTORY_ENTRY:
+            # Refuse to pin an attacker-sized known-answer payload.
+            # Any pre-existing entry for this question stays in place
+            # so legitimate suppression continues; the cost is missing
+            # one round of suppression for this (likely malicious)
+            # query. Truncating instead would over-suppress because
+            # `suppresses()` matches when the stored set is a subset
+            # of the incoming known-answers (smaller set, easier match).
+            return
         if question not in self._history and len(self._history) >= _MAX_QUESTION_HISTORY_ENTRIES:
             self._evict_to_make_room(now)
         self._history[question] = (now, known_answers)

--- a/src/zeroconf/const.py
+++ b/src/zeroconf/const.py
@@ -77,6 +77,21 @@ _MAX_CACHE_RECORDS = 10000
 # flooding distinct questions (RFC 6762 §7.3, defense-in-depth).
 _MAX_QUESTION_HISTORY_ENTRIES = 10000
 
+# Per-entry cap on the number of known-answer records QuestionHistory
+# will retain. Each TC-deferred reassembly can carry up to ~12k records
+# (~750 records/packet x _MAX_DEFERRED_PER_ADDR fragments), and the
+# resulting set is stored by reference under each non-unicast question
+# in the history dict; without a per-entry cap a LAN attacker can pin
+# hundreds of MB across the _MAX_QUESTION_HISTORY_ENTRIES dimension.
+# 256 is well above any RFC-realistic known-answer list for a single
+# question; oversized payloads are dropped from the history (no
+# suppression for that one query) rather than truncated, since a
+# truncated stored set would over-suppress legitimate follow-up
+# queries (`suppresses()` returns True when stored set is a subset of
+# the incoming known-answers, so a smaller stored set matches more
+# easily).
+_MAX_KNOWN_ANSWERS_PER_HISTORY_ENTRY = 256
+
 # Per-addr cap on the number of truncated (TC-bit) packets retained for
 # RFC 6762 §18.5 reassembly. The spec anticipates only a handful of
 # segments per truncated query; 16 is well above legitimate need and

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -133,3 +133,62 @@ def test_question_history_opportunistic_expire():
 
     assert fresh in history._history
     assert len(history._history) == 1
+
+
+def _make_known_answers(count: int) -> set[r.DNSRecord]:
+    """Build a set of ``count`` distinct PTR records for use as known-answers."""
+    return {
+        r.DNSPointer(
+            "_svc._tcp.local.",
+            const._TYPE_PTR,
+            const._CLASS_IN,
+            10000,
+            f"target{i}._svc._tcp.local.",
+        )
+        for i in range(count)
+    }
+
+
+def test_question_history_oversized_known_answers_dropped():
+    """Known-answer sets above the per-entry cap are not stored."""
+    history = QuestionHistory()
+    now = r.current_time_millis()
+    question = r.DNSQuestion("_svc._tcp.local.", const._TYPE_PTR, const._CLASS_IN)
+
+    oversized = _make_known_answers(const._MAX_KNOWN_ANSWERS_PER_HISTORY_ENTRY + 1)
+    history.add_question_at_time(question, now, oversized)
+
+    assert question not in history._history
+
+
+def test_question_history_oversized_preserves_existing_entry():
+    """An oversized payload must not displace a pre-existing small entry."""
+    history = QuestionHistory()
+    now = r.current_time_millis()
+    question = r.DNSQuestion("_svc._tcp.local.", const._TYPE_PTR, const._CLASS_IN)
+
+    small = _make_known_answers(2)
+    history.add_question_at_time(question, now, small)
+    assert history.suppresses(question, now, small)
+
+    # An oversized follow-up must be ignored; the small entry stays and
+    # continues to drive suppression.
+    oversized = _make_known_answers(const._MAX_KNOWN_ANSWERS_PER_HISTORY_ENTRY + 1)
+    history.add_question_at_time(question, now, oversized)
+
+    stored_set = history._history[question][1]
+    assert stored_set is small
+    assert history.suppresses(question, now, small)
+
+
+def test_question_history_at_cap_known_answers_is_stored():
+    """A known-answer set exactly at the per-entry cap is retained."""
+    history = QuestionHistory()
+    now = r.current_time_millis()
+    question = r.DNSQuestion("_svc._tcp.local.", const._TYPE_PTR, const._CLASS_IN)
+
+    at_cap = _make_known_answers(const._MAX_KNOWN_ANSWERS_PER_HISTORY_ENTRY)
+    history.add_question_at_time(question, now, at_cap)
+
+    assert question in history._history
+    assert history._history[question][1] is at_cap


### PR DESCRIPTION
## Summary

`QuestionHistory._history[question] = (now, known_answers)` stores the incoming known-answers set by reference. The dict's entry count is capped at `_MAX_QUESTION_HISTORY_ENTRIES = 10000` (PR #1733), but each entry's set was unbounded. `QueryHandler.async_response` builds the set from the union of every TC-deferred fragment's answers; up to `_MAX_DEFERRED_PER_ADDR = 16` packets x ~750 records each, so a LAN peer sustaining TC-fragmented queries with large known-answer lists can pin hundreds of MB across the `_MAX_QUESTION_HISTORY_ENTRIES` dimension. The records never enter the DNS cache, so `_MAX_CACHE_RECORDS` does not bound this path either.

Fixes #1754.

## Details

- `_MAX_KNOWN_ANSWERS_PER_HISTORY_ENTRY = 256` (`src/zeroconf/const.py`); well above any RFC-realistic single-question known-answer list; cdef'd in `_history.pxd` so the bound check is a direct C integer compare under Cython.
- `QuestionHistory.add_question_at_time` (`src/zeroconf/_history.py`) drops the insert when `len(known_answers) > _MAX_KNOWN_ANSWERS_PER_HISTORY_ENTRY`. Any pre-existing smaller entry for the same question key is left untouched, so legitimate suppression continues to work even while the attacker hammers the same question with oversized payloads.
- **Why drop instead of truncate**: `suppresses()` returns `not previous_known_answers - known_answers`, i.e., it suppresses when the stored set is a subset of the incoming known-answers. Truncating the stored set to a smaller subset would make the subset relation hold more easily, which means over-suppression — we would drop responses that the legitimate querier was entitled to. The conservative direction under uncertainty is to forgo suppression for the one oversized query (cost: one extra response), not to retain a partial snapshot (cost: silent suppression of legitimate follow-ups).

## Test plan

- [x] New tests in `tests/test_history.py`:
  - `test_question_history_oversized_known_answers_dropped`: a set of `_MAX_KNOWN_ANSWERS_PER_HISTORY_ENTRY + 1` known-answers does not appear in `_history`.
  - `test_question_history_oversized_preserves_existing_entry`: a pre-existing 2-record entry survives an oversized follow-up call for the same question; the stored set object is unchanged.
  - `test_question_history_at_cap_known_answers_is_stored`: a set of exactly `_MAX_KNOWN_ANSWERS_PER_HISTORY_ENTRY` records is retained (boundary check).
- [x] `REQUIRE_CYTHON=1 poetry install --only=main,dev && poetry run pytest tests/ --no-cov --timeout=60`: 384 passed, 3 skipped.
- [x] `SKIP_CYTHON=1 poetry run pytest tests/ --no-cov --timeout=60`: 384 passed, 3 skipped.
- [x] `poetry run pre-commit run` on touched files: ruff, ruff format, mypy, codespell, flake8, cython-lint all green.
- [x] `cython -a` confirms the bound compare lands as `__pyx_t_8 = (__pyx_t_7 > __pyx_v_8zeroconf_8_history__MAX_KNOWN_ANSWERS_PER_HISTORY_ENTRY)` (pure C int compare against the cdef'd `unsigned int`).