### PR TITLE
refactor: extract loopback Zeroconf fixtures and mock_incoming_msg helper

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -26,12 +26,13 @@ import asyncio
 import platform
 import socket
 import time
+from collections.abc import Iterable
 from functools import cache
 from unittest import mock
 
 import ifaddr
 
-from zeroconf import DNSIncoming, DNSQuestion, DNSRecord, Zeroconf
+from zeroconf import DNSIncoming, DNSOutgoing, DNSQuestion, DNSRecord, Zeroconf, const
 from zeroconf._history import QuestionHistory
 
 _MONOTONIC_RESOLUTION = time.get_clock_info("monotonic").resolution
@@ -68,6 +69,14 @@ IPV6_LOOPBACK_FIND_TIMEOUT = 0.5
 class QuestionHistoryWithoutSuppression(QuestionHistory):
     def suppresses(self, question: DNSQuestion, now: float, known_answers: set[DNSRecord]) -> bool:
         return False
+
+
+def mock_incoming_msg(records: Iterable[DNSRecord]) -> DNSIncoming:
+    """Build a `DNSIncoming` response message from a list of `DNSRecord`s."""
+    generated = DNSOutgoing(const._FLAGS_QR_RESPONSE)
+    for record in records:
+        generated.add_answer_at_time(record, 0)
+    return DNSIncoming(generated.packets()[0])
 
 
 def _inject_responses(zc: Zeroconf, msgs: list[DNSIncoming]) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,15 +3,17 @@
 from __future__ import annotations
 
 import threading
-from collections.abc import Generator
+from collections.abc import AsyncGenerator, Generator
 from unittest.mock import patch
 
 import pytest
+import pytest_asyncio
 
-from zeroconf import _core, const
+from zeroconf import Zeroconf, _core, const
 from zeroconf._handlers import query_handler
 from zeroconf._services import browser as service_browser
 from zeroconf._services import info as service_info
+from zeroconf.asyncio import AsyncZeroconf
 
 
 @pytest.fixture(autouse=True)
@@ -21,6 +23,36 @@ def verify_threads_ended():
     yield
     threads = frozenset(threading.enumerate()) - threads_before
     assert not threads
+
+
+@pytest.fixture
+def zc_loopback() -> Generator[Zeroconf]:
+    """Yield a loopback `Zeroconf` and close it on teardown.
+
+    Replaces the inline `zc = Zeroconf(interfaces=["127.0.0.1"])` +
+    explicit `zc.close()` pattern duplicated across the suite. Calling
+    `zc.close()` inside a test is still safe — `close()` is idempotent.
+    """
+    zc = Zeroconf(interfaces=["127.0.0.1"])
+    try:
+        yield zc
+    finally:
+        zc.close()
+
+
+@pytest_asyncio.fixture
+async def aiozc_loopback() -> AsyncGenerator[AsyncZeroconf]:
+    """Yield a loopback `AsyncZeroconf` and close it on teardown.
+
+    Replaces the inline `aiozc = AsyncZeroconf(interfaces=["127.0.0.1"])`
+    + explicit `await aiozc.async_close()` pattern duplicated across the
+    suite. Calling `async_close()` inside a test is still safe.
+    """
+    aiozc = AsyncZeroconf(interfaces=["127.0.0.1"])
+    try:
+        yield aiozc
+    finally:
+        await aiozc.async_close()
 
 
 @pytest.fixture

--- a/tests/services/test_browser.py
+++ b/tests/services/test_browser.py
@@ -8,7 +8,6 @@ import os
 import socket
 import time
 import unittest
-from collections.abc import Iterable
 from threading import Event
 from typing import cast
 from unittest.mock import patch
@@ -36,6 +35,7 @@ from .. import (
     _inject_response,
     _wait_for_start,
     has_working_ipv6,
+    mock_incoming_msg,
     time_changed_millis,
 )
 
@@ -52,13 +52,6 @@ def setup_module():
 def teardown_module():
     if original_logging_level != logging.NOTSET:
         log.setLevel(original_logging_level)
-
-
-def mock_incoming_msg(records: Iterable[r.DNSRecord]) -> r.DNSIncoming:
-    generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
-    for record in records:
-        generated.add_answer_at_time(record, 0)
-    return r.DNSIncoming(generated.packets()[0])
 
 
 def test_service_browser_cancel_multiple_times():

--- a/tests/services/test_info.py
+++ b/tests/services/test_info.py
@@ -8,7 +8,6 @@ import os
 import socket
 import threading
 import unittest
-from collections.abc import Iterable
 from ipaddress import ip_address
 from threading import Event
 from unittest.mock import patch
@@ -23,7 +22,7 @@ from zeroconf._services.info import ServiceInfo
 from zeroconf._utils.net import IPVersion
 from zeroconf.asyncio import AsyncZeroconf
 
-from .. import QUICK_REQUEST_TIMEOUT_MS, _inject_response, has_working_ipv6
+from .. import QUICK_REQUEST_TIMEOUT_MS, _inject_response, has_working_ipv6, mock_incoming_msg
 
 log = logging.getLogger("zeroconf")
 original_logging_level = logging.NOTSET
@@ -279,14 +278,6 @@ class TestServiceInfo(unittest.TestCase):
         # patch the zeroconf send
         with patch.object(zc, "async_send", send):
 
-            def mock_incoming_msg(records: Iterable[r.DNSRecord]) -> r.DNSIncoming:
-                generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
-
-                for record in records:
-                    generated.add_answer_at_time(record, 0)
-
-                return r.DNSIncoming(generated.packets()[0])
-
             def get_service_info_helper(zc, type, name):
                 nonlocal service_info
                 service_info = zc.get_service_info(type, name)
@@ -422,14 +413,6 @@ class TestServiceInfo(unittest.TestCase):
         # patch the zeroconf send
         with patch.object(zc, "async_send", send):
 
-            def mock_incoming_msg(records: Iterable[r.DNSRecord]) -> r.DNSIncoming:
-                generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
-
-                for record in records:
-                    generated.add_answer_at_time(record, 0)
-
-                return r.DNSIncoming(generated.packets()[0])
-
             def get_service_info_helper(zc, type, name, timeout):
                 nonlocal service_info
                 service_info = zc.get_service_info(type, name, timeout)
@@ -551,12 +534,6 @@ class TestServiceInfo(unittest.TestCase):
                 socket.inet_pton(socket.AF_INET, service_address),
             ),
         ]
-
-        def mock_incoming_msg(records: Iterable[r.DNSRecord]) -> r.DNSIncoming:
-            generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
-            for record in records:
-                generated.add_answer_at_time(record, 0)
-            return r.DNSIncoming(generated.packets()[0])
 
         sent_queries: list[r.DNSOutgoing] = []
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -74,39 +74,31 @@ async def test_reaper():
 
 
 @pytest.mark.asyncio
-async def test_setup_releases_socket_ownership() -> None:
+async def test_setup_releases_socket_ownership(aiozc_loopback: AsyncZeroconf) -> None:
     """Engine releases its pending-socket refs once each socket has a transport."""
-    aiozc = AsyncZeroconf(interfaces=["127.0.0.1"])
-    try:
-        await aiozc.zeroconf.async_wait_for_start()
-        engine = aiozc.zeroconf.engine
-        assert engine._listen_socket is None
-        assert engine._respond_sockets == []
-        assert engine.readers
-        assert engine.senders
-    finally:
-        await aiozc.async_close()
+    await aiozc_loopback.zeroconf.async_wait_for_start()
+    engine = aiozc_loopback.zeroconf.engine
+    assert engine._listen_socket is None
+    assert engine._respond_sockets == []
+    assert engine.readers
+    assert engine.senders
 
 
 @pytest.mark.asyncio
-async def test_async_close_propagates_outer_cancellation() -> None:
+async def test_async_close_propagates_outer_cancellation(aiozc_loopback: AsyncZeroconf) -> None:
     """Outer-task cancellation while awaiting setup propagates to the caller."""
-    aiozc = AsyncZeroconf(interfaces=["127.0.0.1"])
+    await aiozc_loopback.zeroconf.async_wait_for_start()
+    engine = aiozc_loopback.zeroconf.engine
+    loop = asyncio.get_running_loop()
+    original_task = engine._setup_task
+    fake_task = loop.create_future()
+    fake_task.set_exception(asyncio.CancelledError())
+    engine._setup_task = fake_task  # type: ignore[assignment]
     try:
-        await aiozc.zeroconf.async_wait_for_start()
-        engine = aiozc.zeroconf.engine
-        loop = asyncio.get_running_loop()
-        original_task = engine._setup_task
-        fake_task = loop.create_future()
-        fake_task.set_exception(asyncio.CancelledError())
-        engine._setup_task = fake_task  # type: ignore[assignment]
-        try:
-            with pytest.raises(asyncio.CancelledError):
-                await engine._async_close()
-        finally:
-            engine._setup_task = original_task
+        with pytest.raises(asyncio.CancelledError):
+            await engine._async_close()
     finally:
-        await aiozc.async_close()
+        engine._setup_task = original_task
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Lifts the helper + fixtures sketched in #1757, removes the duplicated `mock_incoming_msg` definitions that already exist in the suite, and adopts the new fixtures in `tests/test_engine.py` so the new infrastructure pays for itself within the same PR.

Replaces and closes #1757.

## Details

- `tests/__init__.py`: adds `mock_incoming_msg(records: Iterable[DNSRecord]) -> DNSIncoming`, fully typed. The four local copies (one in `tests/services/test_browser.py`, three in `tests/services/test_info.py`) are removed and replaced with imports from `tests/__init__.py`. The dedicated copy in `tests/test_core.py` is left in place since it has a different signature (takes a `ServiceStateChange`).
- `tests/conftest.py`: adds `zc_loopback` and `aiozc_loopback` fixtures returning `Generator[Zeroconf]` and `AsyncGenerator[AsyncZeroconf]` respectively. Both yield a loopback-only instance and close it on teardown via try/finally. `close()` / `async_close()` are idempotent, so tests can still call them mid-test (e.g. to assert post-close behavior) without conflicting with fixture cleanup.
- `aiozc_loopback` uses `@pytest_asyncio.fixture` so it works under pytest-asyncio's strict mode (the project default; this is enforced by `asyncio_mode = "strict"` in `pyproject.toml`).
- `tests/test_engine.py`: converts `test_setup_releases_socket_ownership` and `test_async_close_propagates_outer_cancellation` to use `aiozc_loopback`, removing the explicit try/finally + `async_close()` boilerplate from each. `test_reaper` and `test_reaper_aborts_when_done` deliberately call `async_close()` mid-test to exercise post-close behavior, so they keep their inline setup; the fixture would still work there but the conversion would be less obviously useful and is left for a follow-up.

## Test plan

- [x] `REQUIRE_CYTHON=1 poetry install --only=main,dev && poetry run pytest tests/ --no-cov --timeout=60`: 384 passed, 3 skipped.
- [x] `SKIP_CYTHON=1 poetry run pytest tests/ --no-cov --timeout=60`: 384 passed, 3 skipped.
- [x] `poetry run pre-commit run` on touched files: ruff, ruff format, mypy, codespell, flake8, cython-lint all green.
- [x] `poetry run mypy tests/__init__.py tests/conftest.py tests/test_engine.py`: clean. New helper and fixtures are fully typed.

## Follow-up opportunities

Once landed, `zc_loopback` / `aiozc_loopback` and `mock_incoming_msg` can replace boilerplate in a long tail of tests (`test_handlers.py`, `test_asyncio.py`, `tests/services/test_browser.py`, etc.). Holding those off so this PR stays mechanically reviewable; subsequent PRs can each tackle one file at a time.