### PR TITLE
test: widen QM follow-up window in info_asking_default test

### DIFF
--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -44,7 +44,6 @@ from zeroconf.const import _LISTENER_TIME
 
 from . import (
     LOOPBACK_FIND_TIMEOUT,
-    QUICK_REQUEST_TIMEOUT_MS,
     QuestionHistoryWithoutSuppression,
     _clear_cache,
     has_working_ipv6,
@@ -1191,10 +1190,12 @@ async def test_info_asking_default_is_asking_qm_questions_after_the_first_qu(qui
     with patch.object(zeroconf_info, "async_send", send):
         aiosinfo = AsyncServiceInfo(type_, registration_name)
         # Patch _is_complete so we send multiple times. Under
-        # `quick_request_timing` both the QU query at 0ms and the QM
-        # query at ~15ms land well inside QUICK_REQUEST_TIMEOUT_MS.
+        # `quick_request_timing` the QU query fires at 0ms and the QM
+        # follow-up at ~11-15ms (10ms _LISTENER_TIME + 1-5ms jitter);
+        # 300ms absorbs macOS short-sleep quantization so the QM wake
+        # lands before the loop times out.
         with patch("zeroconf.asyncio.AsyncServiceInfo._is_complete", False):
-            await aiosinfo.async_request(aiozc.zeroconf, QUICK_REQUEST_TIMEOUT_MS)
+            await aiosinfo.async_request(aiozc.zeroconf, 300)
         try:
             assert first_outgoing.questions[0].unicast is True  # type: ignore[union-attr]
             assert second_outgoing.questions[0].unicast is False  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

`test_info_asking_default_is_asking_qm_questions_after_the_first_qu` flakes on macOS-latest skip_cython; the 50ms `QUICK_REQUEST_TIMEOUT_MS` budget leaves about 35ms of headroom for the QM follow-up that fires at roughly 11 to 15ms after the QU, and macOS asyncio short-sleep quantization occasionally pushes the wake past the 50ms cap so the loop returns before the QM is sent and `second_outgoing` stays None.

## Details

- The test asserts only that the second outgoing query is QM, the exact wall-clock budget is not part of the contract.
- Bump this test's timeout to 300ms; that absorbs macOS scheduling jitter without changing the shared `QUICK_REQUEST_TIMEOUT_MS` constant that other tests rely on.
- Drop the now unused `QUICK_REQUEST_TIMEOUT_MS` import from `tests/test_asyncio.py`.

Observed in [run 26185961578](https://github.com/python-zeroconf/python-zeroconf/actions/runs/26185961578/job/77041414992) on PR #1764; the failure is timing only and not related to that PR's contents.

## Test plan

- [ ] `SKIP_CYTHON=1 poetry run pytest tests/test_asyncio.py::test_info_asking_default_is_asking_qm_questions_after_the_first_qu`
- [ ] `SKIP_CYTHON=1 poetry run pytest tests/test_asyncio.py`
- [ ] pre-commit clean on the modified file
