### PR TITLE
fix: prune dead transports from the engine on connection loss

### DIFF
--- a/src/zeroconf/_engine.py
+++ b/src/zeroconf/_engine.py
@@ -126,6 +126,21 @@ class AsyncEngine:
             if s in self._respond_sockets:
                 self._respond_sockets.remove(s)
 
+    def _async_remove_listener(self, listener: AsyncListener) -> None:
+        """Drop a listener and its wrapped transports from the engine lists.
+
+        Called from ``AsyncListener.connection_lost`` so a transport that
+        dies (interface down, IP changed) stops being used as a sender
+        instead of raising ``EHOSTUNREACH`` on every send forever.
+        """
+        wrapped = listener.transport
+        transport = wrapped.transport if wrapped is not None else None
+        if listener in self.protocols:
+            self.protocols.remove(listener)
+        if transport is not None:
+            self.readers = [w for w in self.readers if w.transport is not transport]
+            self.senders = [w for w in self.senders if w.transport is not transport]
+
     def _async_cache_cleanup(self) -> None:
         """Periodic cache cleanup."""
         now = current_time_millis()

--- a/src/zeroconf/_engine.py
+++ b/src/zeroconf/_engine.py
@@ -127,12 +127,7 @@ class AsyncEngine:
                 self._respond_sockets.remove(s)
 
     def _async_remove_listener(self, listener: AsyncListener) -> None:
-        """Drop a listener and its wrapped transports from the engine lists.
-
-        Called from ``AsyncListener.connection_lost`` so a transport that
-        dies (interface down, IP changed) stops being used as a sender
-        instead of raising ``EHOSTUNREACH`` on every send forever.
-        """
+        """Drop a listener and its wrapped transports from the engine lists."""
         wrapped = listener.transport
         transport = wrapped.transport if wrapped is not None else None
         if listener in self.protocols:

--- a/src/zeroconf/_listener.py
+++ b/src/zeroconf/_listener.py
@@ -356,4 +356,5 @@ class AsyncListener:
         self.sock_description = f"{wrapped_transport.fileno} ({wrapped_transport.sock_name})"
 
     def connection_lost(self, exc: Exception | None) -> None:
-        """Handle connection lost."""
+        """Prune this transport from the engine so a dead socket is not reused."""
+        self.zc.engine._async_remove_listener(self)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 import pytest
 
 import zeroconf as r
-from zeroconf import _engine, const
+from zeroconf import _engine, _listener, const
 from zeroconf.asyncio import AsyncZeroconf
 
 log = logging.getLogger("zeroconf")
@@ -106,6 +106,24 @@ async def test_connection_lost_prunes_transport(aiozc_loopback: AsyncZeroconf) -
     assert all(w.transport is not dead_transport for w in engine.senders)
     assert all(w.transport is not dead_transport for w in engine.readers)
     assert protocol not in engine.protocols
+
+
+@pytest.mark.asyncio
+async def test_connection_lost_without_transport_is_noop(aiozc_loopback: AsyncZeroconf) -> None:
+    """connection_lost on a listener that never bound a transport leaves the lists intact."""
+    await aiozc_loopback.zeroconf.async_wait_for_start()
+    engine = aiozc_loopback.zeroconf.engine
+    reader_count = len(engine.readers)
+    sender_count = len(engine.senders)
+    protocol_count = len(engine.protocols)
+
+    orphan = _listener.AsyncListener(aiozc_loopback.zeroconf)
+    assert orphan.transport is None
+    orphan.connection_lost(None)
+
+    assert len(engine.readers) == reader_count
+    assert len(engine.senders) == sender_count
+    assert len(engine.protocols) == protocol_count
 
 
 @pytest.mark.asyncio

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -85,6 +85,30 @@ async def test_setup_releases_socket_ownership(aiozc_loopback: AsyncZeroconf) ->
 
 
 @pytest.mark.asyncio
+async def test_connection_lost_prunes_transport(aiozc_loopback: AsyncZeroconf) -> None:
+    """A lost transport is removed from the engine reader/sender/protocol lists."""
+    await aiozc_loopback.zeroconf.async_wait_for_start()
+    engine = aiozc_loopback.zeroconf.engine
+    assert engine.senders
+    reader_count = len(engine.readers)
+    sender_count = len(engine.senders)
+    protocol_count = len(engine.protocols)
+
+    dead_transport = engine.senders[0].transport
+    protocol = next(
+        p for p in engine.protocols if p.transport is not None and p.transport.transport is dead_transport
+    )
+    protocol.connection_lost(None)
+
+    assert len(engine.senders) == sender_count - 1
+    assert len(engine.readers) == reader_count - 1
+    assert len(engine.protocols) == protocol_count - 1
+    assert all(w.transport is not dead_transport for w in engine.senders)
+    assert all(w.transport is not dead_transport for w in engine.readers)
+    assert protocol not in engine.protocols
+
+
+@pytest.mark.asyncio
 async def test_async_close_propagates_outer_cancellation(aiozc_loopback: AsyncZeroconf) -> None:
     """Outer-task cancellation while awaiting setup propagates to the caller."""
     await aiozc_loopback.zeroconf.async_wait_for_start()


### PR DESCRIPTION
## Summary

When an interface goes down or changes IP at runtime, its per interface sender transport stays in the engine forever; every multicast send then raises EHOSTUNREACH (No route to host), logged once then retried silently for the life of the instance, so the only recovery is to recreate the whole `Zeroconf`. This makes `AsyncListener.connection_lost` prune itself, dropping its reader and sender wrappers and its protocol from the engine lists so a dead socket stops being used.

## Details

- New `AsyncEngine._async_remove_listener` is the first incremental remove path; it mirrors the list semantics of `_async_shutdown` and matches both wrapper objects by the shared underlying transport identity (`wrapper.transport is dead_transport`), since one per interface socket is wrapped twice (once into `readers`, once into `senders`).
- Runs on the loop thread only, so it is free threading safe; guards make it a no op if the listener was already gone or never registered.
- This only self heals on real transport death; a transient route flap is not pruned here, that is left to a later interface rescan.

## Test plan

- [x] `tests/test_engine.py::test_connection_lost_prunes_transport` asserts `readers`, `senders`, and `protocols` shrink and no longer reference the lost transport.
- [x] Full `tests/test_engine.py` green under both the compiled Cython build (`REQUIRE_CYTHON=1`) and pure Python (`SKIP_CYTHON=1`).
- [x] `pre-commit run` clean.
