### PR TITLE
ci: scope release env and OIDC permissions to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,16 +150,43 @@ jobs:
           run: poetry run pytest --no-cov -vvvvv --codspeed tests/benchmarks
           mode: instrumentation
 
+  # Dry run on PRs and non-master pushes. No environment, no publish
+  # permissions, no OIDC, so PR runs carry no release blast radius.
+  release-dry-run:
+    needs:
+      - test
+      - lint
+    if: github.ref_name != 'master' && github.repository_owner == 'python-zeroconf'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref }}
+
+      - name: Create local branch name
+        env:
+          BRANCH: ${{ github.head_ref || github.ref_name }}
+        run: git switch -C "$BRANCH"
+
+      - name: Test release
+        uses: python-semantic-release/python-semantic-release@350c48fcb3ffcdfd2e0a235206bc2ecea6b69df0 # v10.5.3
+        with:
+          no_operation_mode: true
+
+  # Real release, only on master. The release environment and write/OIDC
+  # permissions are scoped to this job so they never apply to PR runs.
   release:
     needs:
       - test
       - lint
-    if: ${{ github.repository_owner }} == "python-zeroconf"
-
+    if: github.ref_name == 'master' && github.repository_owner == 'python-zeroconf'
     runs-on: ubuntu-latest
     environment: release
     concurrency:
-      group: release-${{ github.head_ref || github.ref }}
+      group: release-${{ github.ref }}
       cancel-in-progress: false
     permissions:
       id-token: write
@@ -175,20 +202,13 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Create local branch name
-        run: git switch -C ${{ github.head_ref || github.ref_name }}
+        env:
+          BRANCH: ${{ github.ref_name }}
+        run: git switch -C "$BRANCH"
 
-      # Do a dry run of PSR
-      - name: Test release
-        uses: python-semantic-release/python-semantic-release@350c48fcb3ffcdfd2e0a235206bc2ecea6b69df0 # v10.5.3
-        if: github.ref_name != 'master'
-        with:
-          no_operation_mode: true
-
-      # On main branch: actual PSR + upload to PyPI & GitHub
       - name: Release
         uses: python-semantic-release/python-semantic-release@350c48fcb3ffcdfd2e0a235206bc2ecea6b69df0 # v10.5.3
         id: release
-        if: github.ref_name == 'master'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

The single `release` job held `id-token: write`, `contents: write`, and the `release` environment on every trigger including pull requests, even though it only published on master; this splits it into two jobs so PR runs no longer carry release credentials.

## Details

- `release-dry-run` runs on PRs and non-master pushes with only `contents: read`, no environment and no OIDC, just the python-semantic-release dry run.
- `release` runs only on master and keeps the `release` environment, `id-token: write` and `contents: write` scoped to that job, so the privileges never apply to untrusted PR code.
- The branch-name `git switch` now reads the ref from an env var instead of interpolating it straight into the run script.

Same split already adopted in pySwitchbot and nexia; resolves the dbus-fast issue tracked at Bluetooth-Devices/dbus-fast#769, which also affects this repo.

## Test plan

- [ ] YAML parses clean (`yaml.safe_load`)
- [ ] CI dry-run job runs on this PR, publish job stays skipped
