### PR TITLE
fix: keep `key=` distinct from a valueless `key` in TXT records

### DIFF
--- a/src/zeroconf/_services/info.pxd
+++ b/src/zeroconf/_services/info.pxd
@@ -86,7 +86,14 @@ cdef class ServiceInfo(RecordUpdateListener):
     @cython.locals(cache=DNSCache)
     cpdef bint _load_from_cache(self, object zc, double now)
 
-    @cython.locals(length="unsigned char", index="unsigned int", key_value=bytes, key_sep_value=tuple)
+    @cython.locals(
+        length="unsigned char",
+        index="unsigned int",
+        key_value=bytes,
+        key=bytes,
+        sep=bytes,
+        value=bytes,
+    )
     cdef void _unpack_text_into_properties(self)
 
     @cython.locals(k=bytes, v=bytes)

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -467,10 +467,7 @@ class ServiceInfo(RecordUpdateListener):
             if key not in properties:
                 # RFC 6763 section 6.4 distinguishes a key with no '=' (a
                 # boolean attribute: present, no value) from `key=` (present
-                # with an empty value). Testing the separator rather than the
-                # value keeps them apart; `value or None` collapsed both to
-                # None, so re-serialising a received `key=` emitted a bare
-                # `key`.
+                # with an empty value), so test the separator, not the value.
                 properties[key] = value if sep else None
             index += length
 

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -463,10 +463,15 @@ class ServiceInfo(RecordUpdateListener):
             length = text[index]
             index += 1
             key_value = text[index : index + length]
-            key_sep_value = key_value.partition(b"=")
-            key = key_sep_value[0]
+            key, sep, value = key_value.partition(b"=")
             if key not in properties:
-                properties[key] = key_sep_value[2] or None
+                # RFC 6763 section 6.4 distinguishes a key with no '=' (a
+                # boolean attribute: present, no value) from `key=` (present
+                # with an empty value). Testing the separator rather than the
+                # value keeps them apart; `value or None` collapsed both to
+                # None, so re-serialising a received `key=` emitted a bare
+                # `key`.
+                properties[key] = value if sep else None
             index += length
 
         self._properties = properties

--- a/tests/services/test_info.py
+++ b/tests/services/test_info.py
@@ -631,13 +631,7 @@ class TestServiceInfo(unittest.TestCase):
         zc.close()
 
     def test_service_info_empty_value_txt_record(self):
-        """Verify `key=` stays distinct from a valueless `key`.
-
-        RFC 6763 section 6.4 defines a key with no '=' as a boolean attribute
-        (present, no value), and `key=` as present with an empty value. If both
-        decode to None they are indistinguishable, and re-encoding a received
-        `key=` emits a bare `key` -- a different record than the one received.
-        """
+        """Verify `key=` decodes to an empty value, not to a valueless `key`."""
         zc = r.Zeroconf(interfaces=["127.0.0.1"])
         service_name = "name._type._tcp.local."
         service_type = "_type._tcp.local."
@@ -678,19 +672,20 @@ class TestServiceInfo(unittest.TestCase):
         assert info.decoded_properties["rs"] is None
         assert info.decoded_properties["ve"] == "05"
 
-        # Re-encoding the decoded properties must reproduce the received rdata.
-        assert (
-            ServiceInfo(
-                service_type,
-                service_name,
-                22,
-                0,
-                0,
-                info.properties,
-                service_server,
-            ).text
-            == text
-        )
+        # Re-encoding either view of the properties must reproduce the received rdata.
+        for properties in (info.properties, info.decoded_properties):
+            assert (
+                ServiceInfo(
+                    service_type,
+                    service_name,
+                    22,
+                    0,
+                    0,
+                    properties,
+                    service_server,
+                ).text
+                == text
+            )
         zc.close()
 
 

--- a/tests/services/test_info.py
+++ b/tests/services/test_info.py
@@ -630,6 +630,69 @@ class TestServiceInfo(unittest.TestCase):
         assert info.properties[b"ci"] == b"2"
         zc.close()
 
+    def test_service_info_empty_value_txt_record(self):
+        """Verify `key=` stays distinct from a valueless `key`.
+
+        RFC 6763 section 6.4 defines a key with no '=' as a boolean attribute
+        (present, no value), and `key=` as present with an empty value. If both
+        decode to None they are indistinguishable, and re-encoding a received
+        `key=` emits a bare `key` -- a different record than the one received.
+        """
+        zc = r.Zeroconf(interfaces=["127.0.0.1"])
+        service_name = "name._type._tcp.local."
+        service_type = "_type._tcp.local."
+        service_server = "ash-1.local."
+        text = b"\x03rm=\x02rs\x05ve=05"
+        info = ServiceInfo(
+            service_type,
+            service_name,
+            22,
+            0,
+            0,
+            {"path": "/~paulsm/"},
+            service_server,
+            addresses=[socket.inet_aton("10.0.1.2")],
+        )
+        info.async_update_records(
+            zc,
+            r.current_time_millis(),
+            [
+                r.RecordUpdate(
+                    r.DNSText(
+                        service_name,
+                        const._TYPE_TXT,
+                        const._CLASS_IN | const._CLASS_UNIQUE,
+                        120,
+                        text,
+                    ),
+                    None,
+                )
+            ],
+        )
+        assert info.properties[b"rm"] == b""
+        assert info.properties[b"rs"] is None
+        assert info.properties[b"ve"] == b"05"
+
+        # The string-facing API must preserve the distinction too.
+        assert info.decoded_properties["rm"] == ""
+        assert info.decoded_properties["rs"] is None
+        assert info.decoded_properties["ve"] == "05"
+
+        # Re-encoding the decoded properties must reproduce the received rdata.
+        assert (
+            ServiceInfo(
+                service_type,
+                service_name,
+                22,
+                0,
+                0,
+                info.properties,
+                service_server,
+            ).text
+            == text
+        )
+        zc.close()
+
 
 def test_multiple_addresses():
     type_ = "_http._tcp.local."


### PR DESCRIPTION
RFC 6763 6.4: a key with no '=' is a boolean attribute; `key=` is present with an empty value. Collapsing both to None makes them indistinguishable, so a received `key=` re-encodes as a bare `key`.

Regression in #1225 (first released in 0.80.0), which replaced explicit branching on the separator with `value or None`. Restores the behaviour #226 introduced.