### PR TITLE
chore: disable ruff PLR0917 rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ ignore = [
     "PLR0912", # too many to fix right now
     "TID252", # skip
     "PLR0913", # too late to make changes here
+    "PLR0917", # too late to make changes here
     "PLR0911", # would be breaking change
     "TRY003", # too many to fix
     "SLF001", # design choice


### PR DESCRIPTION
## Summary
ruff v0.16.4 from the pre-commit autoupdate in #1810 starts flagging PLR0917 (too many positional arguments); the 22 hits are long standing signatures we are not going to change, so disable the rule like PLR0913.

## Test plan
- [x] `ruff check .` with ruff 0.16.4 passes with no errors
