### PR TITLE
ci: skip existing files when uploading to pypi

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,3 +383,5 @@ jobs:
 
       - uses:
           pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          skip-existing: true


### PR DESCRIPTION
## Summary
Adds `skip-existing: true` to the PyPI publish step. The 0.150.2 upload failed partway through on a transient PyPI error; the rerun only succeeded because it reused the same artifacts, so the bytes were identical. If the wheels had been rebuilt, the rerun would have failed with file already exists on everything uploaded before the error, leaving the release stuck partially published.

## Test plan
- [ ] pre-commit passes on the workflow file
- [ ] matches the documented `skip-existing` input of gh-action-pypi-publish v1.14.0
