### PR TITLE
chore(pre-commit.ci): pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,13 +35,13 @@ repos:
       - id: pyupgrade
         args: [--py310-plus]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.20
+    rev: v0.16.4
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.2
+    rev: v2.4.3
     hooks:
       - id: codespell
   - repo: https://github.com/PyCQA/flake8
@@ -49,7 +49,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v2.1.0
+    rev: v2.3.1
     hooks:
       - id: mypy
         additional_dependencies: [ifaddr]


### PR DESCRIPTION
## Summary

Supersedes #1810, which cannot pass CI as is; its branch predates the cython 3.3.0 build fix (#1820) and the ruff PLR0917 disable (#1819), so the same hook updates are rebased on current master here.

## Details

- ruff-pre-commit v0.15.20 to v0.16.4
- codespell v2.4.2 to v2.4.3
- mirrors-mypy v2.1.0 to v2.3.1

## Test plan

- [x] `pre-commit run --all-files` passes locally with the new hook versions
