### PR TITLE
fix: correct nsec bitmap semantics and resolve txt denials

### DIFF
--- a/src/zeroconf/_handlers/query_handler.pxd
+++ b/src/zeroconf/_handlers/query_handler.pxd
@@ -2,7 +2,7 @@
 import cython
 
 from .._cache cimport DNSCache
-from .._dns cimport DNSAddress, DNSPointer, DNSQuestion, DNSRecord, DNSRRSet
+from .._dns cimport DNSAddress, DNSNsec, DNSPointer, DNSQuestion, DNSRecord, DNSRRSet
 from .._history cimport QuestionHistory
 from .._protocol.incoming cimport DNSIncoming
 from .._services.info cimport ServiceInfo
@@ -83,7 +83,12 @@ cdef class QueryHandler:
     @cython.locals(service=ServiceInfo)
     cdef void _add_pointer_answers(self, list services, cython.dict answer_set, DNSRRSet known_answers)
 
-    @cython.locals(service=ServiceInfo, dns_address=DNSAddress)
+    @cython.locals(
+        service=ServiceInfo,
+        dns_address=DNSAddress,
+        type_seen=cython.bint,
+        nsec=DNSNsec,
+    )
     cdef void _add_address_answers(self, list services, cython.dict answer_set, DNSRRSet known_answers, cython.uint type_)
 
     @cython.locals(question_lower_name=str, type_=cython.uint, service=ServiceInfo)

--- a/src/zeroconf/_handlers/query_handler.py
+++ b/src/zeroconf/_handlers/query_handler.py
@@ -264,23 +264,24 @@ class QueryHandler:
         for service in services:
             answers: list[DNSAddress] = []
             additionals: set[DNSRecord] = set()
-            seen_types: set[int] = set()
+            type_seen = False
             for dns_address in service._dns_addresses(None, _IPVersion_ALL):
-                seen_types.add(dns_address.type)
                 if dns_address.type != type_:
                     additionals.add(dns_address)
-                elif not known_answers.suppresses(dns_address):
-                    answers.append(dns_address)
-            missing_types: set[int] = _ADDRESS_RECORD_TYPES - seen_types
+                else:
+                    type_seen = True
+                    if not known_answers.suppresses(dns_address):
+                        answers.append(dns_address)
             if answers:
-                if missing_types:
-                    assert service.server is not None, "Service server must be set for NSEC record."
-                    additionals.add(service._dns_nsec(list(missing_types), None))
+                nsec = service._dns_address_nsec(None)
+                if nsec is not None:
+                    additionals.add(nsec)
                 for answer in answers:
                     answer_set[answer] = additionals
-            elif type_ in missing_types:
-                assert service.server is not None, "Service server must be set for NSEC record."
-                answer_set[service._dns_nsec(list(missing_types), None)] = set()
+            elif not type_seen and type_ in _ADDRESS_RECORD_TYPES:
+                nsec = service._dns_address_nsec(None)
+                if nsec is not None:
+                    answer_set[nsec] = set()
 
     def _answer_question(
         self,

--- a/src/zeroconf/_services/info.pxd
+++ b/src/zeroconf/_services/info.pxd
@@ -45,8 +45,6 @@ cdef object QM_QUESTION
 cdef object _IPVersion_All_value
 cdef object _IPVersion_V4Only_value
 
-cdef cython.set _ADDRESS_RECORD_TYPES
-
 cdef unsigned int _DUPLICATE_QUESTION_INTERVAL
 
 cdef bint TYPE_CHECKING
@@ -77,6 +75,7 @@ cdef class ServiceInfo(RecordUpdateListener):
     cdef public DNSService _dns_service_cache
     cdef public DNSText _dns_text_cache
     cdef public cython.list _dns_address_cache
+    cdef public DNSNsec _dns_address_nsec_cache
     cdef public cython.set _get_address_and_nsec_records_cache
     cdef public cython.set _query_record_types
     cdef public bint _txt_seen
@@ -111,9 +110,13 @@ cdef class ServiceInfo(RecordUpdateListener):
     @cython.locals(
         dns_service_record=DNSService,
         dns_text_record=DNSText,
-        dns_address_record=DNSAddress
+        dns_address_record=DNSAddress,
+        dns_nsec_record=DNSNsec
     )
     cdef bint _process_record_threadsafe(self, object zc, DNSRecord record, double now)
+
+    @cython.locals(rdtypes=cython.list)
+    cdef bint _process_nsec_record(self, DNSNsec record)
 
     @cython.locals(existing_idx=int, existing=object)
     cdef bint _upsert_ipv6_address(self, object ip_addr)
@@ -143,7 +146,8 @@ cdef class ServiceInfo(RecordUpdateListener):
     @cython.locals(cacheable=cython.bint)
     cdef DNSText _dns_text(self, object override_ttl)
 
-    cdef DNSNsec _dns_nsec(self, cython.list missing_types, object override_ttl)
+    @cython.locals(cacheable=cython.bint, has_v4=cython.bint, has_v6=cython.bint)
+    cdef DNSNsec _dns_address_nsec(self, object override_ttl)
 
     @cython.locals(cacheable=cython.bint)
     cdef cython.set _get_address_and_nsec_records(self, object override_ttl)

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import asyncio
 import random
+import warnings
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, cast
 
@@ -62,7 +63,6 @@ from .._utils.name import service_type_name
 from .._utils.net import IPVersion, _encode_address
 from .._utils.time import current_time_millis
 from ..const import (
-    _ADDRESS_RECORD_TYPES,
     _CLASS_IN,
     _CLASS_IN_UNIQUE,
     _DNS_HOST_TTL,
@@ -180,6 +180,7 @@ class ServiceInfo(RecordUpdateListener):
     __slots__ = (
         "_decoded_properties",
         "_dns_address_cache",
+        "_dns_address_nsec_cache",
         "_dns_pointer_cache",
         "_dns_service_cache",
         "_dns_text_cache",
@@ -255,6 +256,7 @@ class ServiceInfo(RecordUpdateListener):
         self.other_ttl = other_ttl
         self._new_records_futures: set[asyncio.Future] | None = None
         self._dns_address_cache: list[DNSAddress] | None = None
+        self._dns_address_nsec_cache: DNSNsec | None = None
         self._dns_pointer_cache: DNSPointer | None = None
         self._dns_service_cache: DNSService | None = None
         self._dns_text_cache: DNSText | None = None
@@ -294,6 +296,7 @@ class ServiceInfo(RecordUpdateListener):
         self._ipv4_addresses.clear()
         self._ipv6_addresses.clear()
         self._dns_address_cache = None
+        self._dns_address_nsec_cache = None
         self._get_address_and_nsec_records_cache = None
 
         for address in value:
@@ -336,6 +339,7 @@ class ServiceInfo(RecordUpdateListener):
     def async_clear_cache(self) -> None:
         """Clear the cache for this service info."""
         self._dns_address_cache = None
+        self._dns_address_nsec_cache = None
         self._dns_pointer_cache = None
         self._dns_service_cache = None
         self._dns_text_cache = None
@@ -644,7 +648,25 @@ class ServiceInfo(RecordUpdateListener):
                 self._set_ipv6_addresses_from_cache(zc, now)
             return True
 
+        if record_type is DNSNsec:
+            dns_nsec_record = record
+            if TYPE_CHECKING:
+                assert isinstance(dns_nsec_record, DNSNsec)
+            return self._process_nsec_record(dns_nsec_record)
+
         return False
+
+    def _process_nsec_record(self, record: DNSNsec) -> bool:
+        """Record a TXT denial from an NSEC record at the service name."""
+        rdtypes = record.rdtypes
+        # RFC 6762 §6.1: the type bitmap lists the rrtypes that exist, so SRV
+        # present with TXT absent denies the TXT record. Requiring the SRV bit
+        # also keeps older python-zeroconf NSECs, which listed the missing
+        # address types, from being misread as a TXT denial.
+        if self._txt_seen or _TYPE_SRV not in rdtypes or _TYPE_TXT in rdtypes:
+            return False
+        self._txt_seen = True
+        return True
 
     def dns_addresses(
         self,
@@ -751,39 +773,58 @@ class ServiceInfo(RecordUpdateListener):
             self._dns_text_cache = record
         return record
 
-    def dns_nsec(self, missing_types: list[int], override_ttl: int_ | None = None) -> DNSNsec:
-        """Return DNSNsec from ServiceInfo."""
-        return self._dns_nsec(missing_types, override_ttl)
+    def dns_nsec(self, missing_types: list[int], override_ttl: int_ | None = None) -> DNSNsec | None:
+        """Deprecated: use dns_address_nsec instead; missing_types is ignored."""
+        warnings.warn(
+            "dns_nsec is deprecated, and will be removed in a future version. "
+            "Use dns_address_nsec instead; missing_types is ignored.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._dns_address_nsec(override_ttl)
 
-    def _dns_nsec(self, missing_types: list[int_], override_ttl: int_ | None) -> DNSNsec:
-        """Return DNSNsec from ServiceInfo."""
-        return DNSNsec(
-            self._name,
+    def dns_address_nsec(self, override_ttl: int_ | None = None) -> DNSNsec | None:
+        """Return DNSNsec asserting which address types exist, or None if not applicable."""
+        return self._dns_address_nsec(override_ttl)
+
+    def _dns_address_nsec(self, override_ttl: int_ | None) -> DNSNsec | None:
+        cacheable = override_ttl is None
+        if self._dns_address_nsec_cache is not None and cacheable:
+            return self._dns_address_nsec_cache
+        # RFC 6762 §6.1: the type bitmap lists the rrtypes that exist at the
+        # name. Both families present leaves nothing to deny; neither leaves
+        # nothing to assert (an empty bitmap is unencodable).
+        has_v4 = bool(self._ipv4_addresses)
+        has_v6 = bool(self._ipv6_addresses)
+        if has_v4 == has_v6:
+            return None
+        assert self.server is not None, "Service server must be set for NSEC record."
+        record = DNSNsec(
+            self.server,
             _TYPE_NSEC,
             _CLASS_IN_UNIQUE,
             override_ttl if override_ttl is not None else self.host_ttl,
-            self._name,
-            missing_types,
+            self.server,
+            [_TYPE_A] if has_v4 else [_TYPE_AAAA],
             0.0,
         )
+        if cacheable:
+            self._dns_address_nsec_cache = record
+        return record
 
     def get_address_and_nsec_records(self, override_ttl: int_ | None = None) -> set[DNSRecord]:
-        """Build a set of address records and NSEC records for non-present record types."""
+        """Build a set of address records plus an NSEC asserting which address types exist."""
         return self._get_address_and_nsec_records(override_ttl)
 
     def _get_address_and_nsec_records(self, override_ttl: int_ | None) -> set[DNSRecord]:
-        """Build a set of address records and NSEC records for non-present record types."""
+        """Build a set of address records plus an NSEC asserting which address types exist."""
         cacheable = override_ttl is None
         if self._get_address_and_nsec_records_cache is not None and cacheable:
             return self._get_address_and_nsec_records_cache
-        missing_types: set[int] = _ADDRESS_RECORD_TYPES.copy()
-        records: set[DNSRecord] = set()
-        for dns_address in self._dns_addresses(override_ttl, IPVersion.All):
-            missing_types.discard(dns_address.type)
-            records.add(dns_address)
-        if missing_types:
-            assert self.server is not None, "Service server must be set for NSEC record."
-            records.add(self._dns_nsec(list(missing_types), override_ttl))
+        records: set[DNSRecord] = set(self._dns_addresses(override_ttl, IPVersion.All))
+        nsec = self._dns_address_nsec(override_ttl)
+        if nsec is not None:
+            records.add(nsec)
         if cacheable:
             self._get_address_and_nsec_records_cache = records
         return records
@@ -831,6 +872,10 @@ class ServiceInfo(RecordUpdateListener):
         cached_txt_record = cache.get_by_details(self._name, _TYPE_TXT, _CLASS_IN)
         if cached_txt_record:
             self._process_record_threadsafe(zc, cached_txt_record, now)
+        if not self._txt_seen:
+            cached_nsec_record = cache.get_by_details(self._name, _TYPE_NSEC, _CLASS_IN)
+            if cached_nsec_record:
+                self._process_record_threadsafe(zc, cached_nsec_record, now)
         if original_server_key == self.server_key:
             # If there is a srv which changes the server_key,
             # A and AAAA will already be loaded from the cache
@@ -847,7 +892,8 @@ class ServiceInfo(RecordUpdateListener):
 
         RFC 6763 section 6 requires every DNS-SD service to have a TXT record,
         so a service is not complete until one has been seen. An empty TXT
-        record counts as seen; a missing one does not.
+        record counts as seen, as does an NSEC record denying its existence
+        (RFC 6762 section 6.1); a missing one does not.
         """
         return bool(self._txt_seen and (self._ipv4_addresses or self._ipv6_addresses))
 

--- a/tests/services/test_info.py
+++ b/tests/services/test_info.py
@@ -2029,18 +2029,45 @@ async def test_release_wait_when_new_recorded_added_concurrency():
 
 
 @pytest.mark.asyncio
-async def test_service_info_nsec_records():
-    """Test we can generate nsec records from ServiceInfo."""
+async def test_service_info_address_nsec_records() -> None:
+    """Test we can generate address nsec records from ServiceInfo."""
     type_ = "_http._tcp.local."
     registration_name = f"multiareccon.{type_}"
     desc = {"path": "/~paulsm/"}
     host = "multahostcon.local."
-    info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, host)
-    nsec_record = info.dns_nsec([const._TYPE_A, const._TYPE_AAAA], 50)
-    assert nsec_record.name == registration_name
+    info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, host, addresses=[b"\x7f\x00\x00\x01"])
+    nsec_record = info.dns_address_nsec(50)
+    assert nsec_record is not None
+    assert nsec_record.name == host
+    assert nsec_record.next_name == host
     assert nsec_record.type == const._TYPE_NSEC
     assert nsec_record.ttl == 50
-    assert nsec_record.rdtypes == [const._TYPE_A, const._TYPE_AAAA]
+    assert nsec_record.rdtypes == [const._TYPE_A]
+
+    # the no-override call is memoized; mutating addresses must drop the cache
+    assert info.dns_address_nsec() is not None
+    assert info.dns_address_nsec() is info.dns_address_nsec()
+    info.addresses = []
+    assert info.dns_address_nsec() is None
+
+    v6 = socket.inet_pton(socket.AF_INET6, "2001:db8::1")
+    info.addresses = [b"\x7f\x00\x00\x01", v6]
+    assert info.dns_address_nsec() is None
+
+
+def test_service_info_dns_nsec_deprecated() -> None:
+    """dns_nsec warns and delegates to dns_address_nsec, ignoring missing_types."""
+    type_ = "_http._tcp.local."
+    registration_name = f"depnsec.{type_}"
+    host = "depnsec-host.local."
+    info = ServiceInfo(
+        type_, registration_name, 80, 0, 0, {"path": "/~paulsm/"}, host, addresses=[b"\x7f\x00\x00\x01"]
+    )
+    with pytest.warns(DeprecationWarning, match="dns_address_nsec"):
+        record = info.dns_nsec([const._TYPE_AAAA], 50)
+    assert record == info.dns_address_nsec(50)
+    assert record is not None
+    assert record.rdtypes == [const._TYPE_A]
 
 
 @pytest.mark.asyncio
@@ -2339,3 +2366,229 @@ async def test_async_request_incomplete_without_txt_record(quick_request_timing)
     assert info.properties == {b"ttl": b"2"}
 
     await aiozc.async_close()
+
+
+@pytest.mark.parametrize(
+    ("nsec_rdtypes", "expected_complete"),
+    [
+        # SRV bit set with TXT absent is a TXT denial (RFC 6762 §6.1)
+        ([const._TYPE_SRV], True),
+        # no SRV bit: the inverted bitmap older releases emitted, not a denial
+        ([const._TYPE_AAAA], False),
+    ],
+)
+def test_load_from_cache_with_nsec(
+    zc_loopback: r.Zeroconf, nsec_rdtypes: list[int], expected_complete: bool
+) -> None:
+    """An NSEC listing SRV but not TXT denies the TXT record and completes the service."""
+    type_ = "_http._tcp.local."
+    registration_name = f"nsecdenial.{type_}"
+    host = "nsecdenial.local."
+    zc = zc_loopback
+    zc.cache.async_add_records(
+        [
+            r.DNSService(
+                registration_name,
+                const._TYPE_SRV,
+                const._CLASS_IN | const._CLASS_UNIQUE,
+                120,
+                0,
+                0,
+                80,
+                host,
+            ),
+            r.DNSNsec(
+                registration_name,
+                const._TYPE_NSEC,
+                const._CLASS_IN | const._CLASS_UNIQUE,
+                120,
+                registration_name,
+                nsec_rdtypes,
+            ),
+            r.DNSAddress(
+                host,
+                const._TYPE_A,
+                const._CLASS_IN | const._CLASS_UNIQUE,
+                120,
+                socket.inet_aton("127.0.0.1"),
+            ),
+        ]
+    )
+
+    info = ServiceInfo(type_, registration_name)
+    assert info.load_from_cache(zc) is expected_complete
+    if expected_complete:
+        assert info.properties == {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("quick_request_timing")
+async def test_async_request_completes_on_nsec_txt_denial(aiozc_loopback: AsyncZeroconf) -> None:
+    """async_request succeeds promptly when the responder denies the TXT record via NSEC."""
+    type_ = "_http._tcp.local."
+    registration_name = f"nsecrequest.{type_}"
+    host = "nsecrequest.local."
+    await aiozc_loopback.zeroconf.async_wait_for_start()
+    zc = aiozc_loopback.zeroconf
+
+    zc.record_manager.async_updates_from_response(
+        mock_incoming_msg(
+            [
+                r.DNSService(
+                    registration_name,
+                    const._TYPE_SRV,
+                    const._CLASS_IN | const._CLASS_UNIQUE,
+                    120,
+                    0,
+                    0,
+                    80,
+                    host,
+                ),
+                r.DNSAddress(
+                    host,
+                    const._TYPE_A,
+                    const._CLASS_IN | const._CLASS_UNIQUE,
+                    120,
+                    socket.inet_aton("127.0.0.1"),
+                ),
+            ]
+        )
+    )
+
+    info = ServiceInfo(type_, registration_name)
+    with patch.object(zc, "async_send"):
+        assert await info.async_request(zc, QUICK_REQUEST_TIMEOUT_MS) is False
+
+    zc.record_manager.async_updates_from_response(
+        mock_incoming_msg(
+            [
+                r.DNSNsec(
+                    registration_name,
+                    const._TYPE_NSEC,
+                    const._CLASS_IN | const._CLASS_UNIQUE,
+                    120,
+                    registration_name,
+                    [const._TYPE_SRV],
+                )
+            ]
+        )
+    )
+    with patch.object(zc, "async_send"):
+        assert await info.async_request(zc, QUICK_REQUEST_TIMEOUT_MS) is True
+    assert info.properties == {}
+
+    zc.record_manager.async_updates_from_response(
+        mock_incoming_msg(
+            [
+                r.DNSText(
+                    registration_name,
+                    const._TYPE_TXT,
+                    const._CLASS_IN | const._CLASS_UNIQUE,
+                    120,
+                    b"\x05ttl=2",
+                )
+            ]
+        )
+    )
+    assert info.load_from_cache(zc) is True
+    assert info.properties == {b"ttl": b"2"}
+
+
+@pytest.mark.asyncio
+async def test_nsec_after_txt_record_is_ignored(aiozc_loopback: AsyncZeroconf) -> None:
+    """An NSEC arriving after a real TXT record does not clear the properties."""
+    type_ = "_http._tcp.local."
+    registration_name = f"nsecaftertxt.{type_}"
+    host = "nsecaftertxt.local."
+    await aiozc_loopback.zeroconf.async_wait_for_start()
+    zc = aiozc_loopback.zeroconf
+
+    zc.record_manager.async_updates_from_response(
+        mock_incoming_msg(
+            [
+                r.DNSService(
+                    registration_name,
+                    const._TYPE_SRV,
+                    const._CLASS_IN | const._CLASS_UNIQUE,
+                    120,
+                    0,
+                    0,
+                    80,
+                    host,
+                ),
+                r.DNSText(
+                    registration_name,
+                    const._TYPE_TXT,
+                    const._CLASS_IN | const._CLASS_UNIQUE,
+                    120,
+                    b"\x05ttl=2",
+                ),
+                r.DNSAddress(
+                    host,
+                    const._TYPE_A,
+                    const._CLASS_IN | const._CLASS_UNIQUE,
+                    120,
+                    socket.inet_aton("127.0.0.1"),
+                ),
+            ]
+        )
+    )
+
+    info = ServiceInfo(type_, registration_name)
+    assert info.load_from_cache(zc) is True
+
+    nsec_record = r.DNSNsec(
+        registration_name,
+        const._TYPE_NSEC,
+        const._CLASS_IN | const._CLASS_UNIQUE,
+        120,
+        registration_name,
+        [const._TYPE_SRV],
+    )
+    info.async_update_records(zc, r.current_time_millis(), [RecordUpdate(nsec_record, None)])
+    assert info.properties == {b"ttl": b"2"}
+    assert info._is_complete
+
+
+def test_unhandled_record_type_at_service_name_is_ignored(zc_loopback: r.Zeroconf) -> None:
+    """A record type with no handler at the service name does not change state."""
+    type_ = "_http._tcp.local."
+    registration_name = f"unhandledrec.{type_}"
+    info = ServiceInfo(type_, registration_name)
+    ptr_record = r.DNSPointer(
+        registration_name,
+        const._TYPE_PTR,
+        const._CLASS_IN,
+        120,
+        f"other.{type_}",
+    )
+    info.async_update_records(zc_loopback, r.current_time_millis(), [RecordUpdate(ptr_record, None)])
+    assert info._txt_seen is False
+    assert info._is_complete is False
+
+
+@pytest.mark.asyncio
+async def test_own_nsec_response_does_not_complete_service(aiozc_loopback: AsyncZeroconf) -> None:
+    """The NSEC our own responder emits for a missing address type must not deny the TXT record."""
+    type_ = "_http._tcp.local."
+    registration_name = f"ownnsec.{type_}"
+    host = "ownnsec.local."
+    await aiozc_loopback.zeroconf.async_wait_for_start()
+    zc = aiozc_loopback.zeroconf
+
+    registered = ServiceInfo(
+        type_,
+        registration_name,
+        80,
+        0,
+        0,
+        {"path": "/~paulsm/"},
+        host,
+        addresses=[socket.inet_aton("10.0.1.2")],
+    )
+    zc.record_manager.async_updates_from_response(
+        mock_incoming_msg([registered.dns_service(), *registered.get_address_and_nsec_records()])
+    )
+
+    info = ServiceInfo(type_, registration_name)
+    assert info.load_from_cache(zc) is False

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -811,8 +811,12 @@ def test_known_answer_supression():
     assert question_answers
     assert not question_answers.ucast
     expected_nsec_record = cast(r.DNSNsec, next(iter(question_answers.mcast_now)))
-    assert const._TYPE_A not in expected_nsec_record.rdtypes
-    assert const._TYPE_AAAA in expected_nsec_record.rdtypes
+    # RFC 6762 §6.1: the bitmap lists the types that exist at the server name
+    assert expected_nsec_record.name == server_name
+    assert expected_nsec_record.next_name == server_name
+    assert const._TYPE_A in expected_nsec_record.rdtypes
+    assert const._TYPE_AAAA not in expected_nsec_record.rdtypes
+    assert const._TYPE_NSEC not in expected_nsec_record.rdtypes
     assert not question_answers.mcast_aggregate
     assert not question_answers.mcast_aggregate_last_second
 
@@ -865,6 +869,31 @@ def test_known_answer_supression():
     assert not question_answers.mcast_aggregate_last_second
 
     # unregister
+    zc.registry.async_remove(info)
+    zc.close()
+
+
+def test_no_nsec_answer_for_service_without_addresses() -> None:
+    """A service with no address records cannot assert which types exist, so no NSEC is sent."""
+    zc = Zeroconf(interfaces=["127.0.0.1"])
+    type_ = "_noaddrnsec._tcp.local."
+    registration_name = f"noaddr.{type_}"
+    server_name = "noaddr-host.local."
+    info = ServiceInfo(type_, registration_name, 80, 0, 0, {"path": "/~paulsm/"}, server_name)
+    zc.registry.async_add(info)
+    _clear_cache(zc)
+
+    generated = r.DNSOutgoing(const._FLAGS_QR_QUERY)
+    question = r.DNSQuestion(server_name, const._TYPE_AAAA, const._CLASS_IN)
+    generated.add_question(question)
+    packets = generated.packets()
+    question_answers = zc.query_handler.async_response([r.DNSIncoming(packet) for packet in packets], False)
+    assert question_answers
+    assert not question_answers.ucast
+    assert not question_answers.mcast_now
+    assert not question_answers.mcast_aggregate
+    assert not question_answers.mcast_aggregate_last_second
+
     zc.registry.async_remove(info)
     zc.close()
 


### PR DESCRIPTION
## Summary

Follow up to #1821. Outgoing NSEC records now follow RFC 6762 §6.1, and `ServiceInfo` consumes an NSEC that denies the TXT record so `async_request` resolves promptly instead of burning the full timeout.

## Details

* The type bitmap was inverted; we listed the missing address types, but RFC 4034 §4.1.2 and RFC 6762 §6.1 require the types that exist at the name. A real Bonjour capture in `test_protocol.py` confirms this encoding.
* The NSEC was owned by the service instance name; address denials now use the server name, matching the A/AAAA question they answer, with `next_name` set to the record's own name per RFC 6762 §6.1.
* An NSEC at the service name with the SRV bit set and the TXT bit absent now counts as a TXT denial; the service completes with empty properties, since RFC 6763 §6 requires a TXT record yet some devices deny it instead. Requiring the SRV bit keeps NSECs from older python-zeroconf releases, which carried the inverted bitmap, from being misread as denials.
* `dns_address_nsec()` replaces the public `dns_nsec()`, which produced protocol invalid records; `dns_nsec()` stays for one release as a deprecated shim that warns, delegates, and ignores `missing_types`.
* A service registered without any addresses no longer emits an NSEC; an empty bitmap is not encodable.
* Out of scope: letting `AddressResolver` bail early on an address denial, left as a follow up.

## Test plan

- [x] `poetry run pytest tests` passes, 466 passed
- [x] new tests in `tests/services/test_info.py` and `tests/test_handlers.py` cover denial, the legacy bitmap guard, cache loading, and responder output
- [x] extension builds with `REQUIRE_CYTHON=1` under Cython 3.3.0
- [x] verified on a live network; a v4 only responder answers an AAAA question with an NSEC owned by the host name listing only A, a crafted no TXT responder resolves immediately with empty properties, and 15 of 15 real LAN services still resolve with their TXT data
