### PR TITLE
fix: fail service resolution fast when nsec denies the needed address types

### DIFF
--- a/src/zeroconf/_services/info.pxd
+++ b/src/zeroconf/_services/info.pxd
@@ -60,6 +60,8 @@ cdef class ServiceInfo(RecordUpdateListener):
     cdef public str key
     cdef public cython.list _ipv4_addresses
     cdef public cython.list _ipv6_addresses
+    cdef public bint _ipv4_denied
+    cdef public bint _ipv6_denied
     cdef public object port
     cdef public object weight
     cdef public object priority
@@ -80,7 +82,7 @@ cdef class ServiceInfo(RecordUpdateListener):
     cdef public cython.set _query_record_types
     cdef public bint _txt_seen
 
-    @cython.locals(record_update=RecordUpdate, update=bint, cache=DNSCache)
+    @cython.locals(record_update=RecordUpdate, record=DNSRecord, update=bint, cache=DNSCache, nsec_records=list)
     cpdef void async_update_records(self, object zc, double now, cython.list records)
 
     @cython.locals(cache=DNSCache)
@@ -115,8 +117,16 @@ cdef class ServiceInfo(RecordUpdateListener):
     )
     cdef bint _process_record_threadsafe(self, object zc, DNSRecord record, double now)
 
-    @cython.locals(rdtypes=cython.list)
-    cdef bint _process_nsec_record(self, DNSNsec record)
+    @cython.locals(cache=DNSCache)
+    cdef void _load_records_for_new_server_from_cache(self, object zc, double now)
+
+    @cython.locals(
+        rdtypes=cython.list,
+        updated=cython.bint,
+        ipv4_denied=cython.bint,
+        ipv6_denied=cython.bint,
+    )
+    cdef bint _process_nsec_record(self, DNSNsec record, str record_key)
 
     @cython.locals(existing_idx=int, existing=object)
     cdef bint _upsert_ipv6_address(self, object ip_addr)

--- a/src/zeroconf/_services/info.pxd
+++ b/src/zeroconf/_services/info.pxd
@@ -82,7 +82,7 @@ cdef class ServiceInfo(RecordUpdateListener):
     cdef public cython.set _query_record_types
     cdef public bint _txt_seen
 
-    @cython.locals(record_update=RecordUpdate, record=DNSRecord, update=bint, cache=DNSCache, nsec_records=list)
+    @cython.locals(record_update=RecordUpdate, record=DNSRecord, nsec_records=list)
     cpdef void async_update_records(self, object zc, double now, cython.list records)
 
     @cython.locals(cache=DNSCache)

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -186,7 +186,9 @@ class ServiceInfo(RecordUpdateListener):
         "_dns_text_cache",
         "_get_address_and_nsec_records_cache",
         "_ipv4_addresses",
+        "_ipv4_denied",
         "_ipv6_addresses",
+        "_ipv6_denied",
         "_name",
         "_new_records_futures",
         "_properties",
@@ -233,6 +235,8 @@ class ServiceInfo(RecordUpdateListener):
         self.key = name.lower()
         self._ipv4_addresses: list[ZeroconfIPv4Address] = []
         self._ipv6_addresses: list[ZeroconfIPv6Address] = []
+        self._ipv4_denied = False
+        self._ipv6_denied = False
         if addresses is not None:
             self.addresses = addresses
         elif parsed_addresses is not None:
@@ -571,8 +575,21 @@ class ServiceInfo(RecordUpdateListener):
         """
         new_records_futures = self._new_records_futures
         updated: bool = False
+        nsec_records = None
         for record_update in records:
-            updated |= self._process_record_threadsafe(zc, record_update.new, now)
+            record = record_update.new
+            # NSEC records are processed last so a denial for an SRV target
+            # learned later in the same batch is not discarded (wire order of
+            # records in a response is not guaranteed).
+            if type(record) is DNSNsec:
+                if nsec_records is None:
+                    nsec_records = []
+                nsec_records.append(record)
+                continue
+            updated |= self._process_record_threadsafe(zc, record, now)
+        if nsec_records is not None:
+            for record in nsec_records:
+                updated |= self._process_record_threadsafe(zc, record, now)
         if updated and new_records_futures:
             _resolve_all_futures_to_none(new_records_futures)
 
@@ -620,6 +637,14 @@ class ServiceInfo(RecordUpdateListener):
                 assert isinstance(ip_addr, ZeroconfIPv6Address)
             return self._upsert_ipv6_address(ip_addr)
 
+        if record_type is DNSNsec:
+            if record_key not in (self.server_key, self.key):
+                return False
+            dns_nsec_record = record
+            if TYPE_CHECKING:
+                assert isinstance(dns_nsec_record, DNSNsec)
+            return self._process_nsec_record(dns_nsec_record, record_key)
+
         if record_key != self.key:
             return False
 
@@ -644,29 +669,48 @@ class ServiceInfo(RecordUpdateListener):
             self.weight = dns_service_record.weight
             self.priority = dns_service_record.priority
             if old_server_key != self.server_key:
-                self._set_ipv4_addresses_from_cache(zc, now)
-                self._set_ipv6_addresses_from_cache(zc, now)
+                self._load_records_for_new_server_from_cache(zc, now)
             return True
-
-        if record_type is DNSNsec:
-            dns_nsec_record = record
-            if TYPE_CHECKING:
-                assert isinstance(dns_nsec_record, DNSNsec)
-            return self._process_nsec_record(dns_nsec_record)
 
         return False
 
-    def _process_nsec_record(self, record: DNSNsec) -> bool:
-        """Record a TXT denial from an NSEC record at the service name."""
+    def _load_records_for_new_server_from_cache(self, zc: Zeroconf, now: float_) -> None:
+        """Re-derive per-host state, denials included, after the SRV target changed."""
+        self._ipv4_denied = False
+        self._ipv6_denied = False
+        self._set_ipv4_addresses_from_cache(zc, now)
+        self._set_ipv6_addresses_from_cache(zc, now)
+        if TYPE_CHECKING:
+            assert self.server_key is not None
+        cache = zc.cache
+        cached_server_nsec_record = cache.get_by_details(self.server_key, _TYPE_NSEC, _CLASS_IN)
+        if cached_server_nsec_record:
+            self._process_record_threadsafe(zc, cached_server_nsec_record, now)
+
+    def _process_nsec_record(self, record: DNSNsec, record_key: str_) -> bool:
+        """Record the denials asserted by an NSEC record (RFC 6762 §6.1)."""
         rdtypes = record.rdtypes
-        # RFC 6762 §6.1: the type bitmap lists the rrtypes that exist, so SRV
-        # present with TXT absent denies the TXT record. Requiring the SRV bit
-        # also keeps older python-zeroconf NSECs, which listed the missing
-        # address types, from being misread as a TXT denial.
-        if self._txt_seen or _TYPE_SRV not in rdtypes or _TYPE_TXT in rdtypes:
-            return False
-        self._txt_seen = True
-        return True
+        updated = False
+        if record_key == self.server_key:
+            # Each NSEC is an authoritative snapshot of what exists at the
+            # host, so recompute both flags instead of accumulating denials.
+            ipv4_denied = _TYPE_A not in rdtypes
+            ipv6_denied = _TYPE_AAAA not in rdtypes
+            if ipv4_denied != self._ipv4_denied or ipv6_denied != self._ipv6_denied:
+                self._ipv4_denied = ipv4_denied
+                self._ipv6_denied = ipv6_denied
+                updated = True
+        if (
+            record_key == self.key
+            and not self._txt_seen
+            and _TYPE_SRV in rdtypes
+            and _TYPE_TXT not in rdtypes
+        ):
+            # Requiring the SRV bit keeps older python-zeroconf NSECs, which listed the
+            # missing address types, from being misread as a TXT denial.
+            self._txt_seen = True
+            updated = True
+        return updated
 
     def dns_addresses(
         self,
@@ -866,6 +910,9 @@ class ServiceInfo(RecordUpdateListener):
         """
         cache = zc.cache
         original_server_key = self.server_key
+        # Denials are only trusted until the next cache load re-derives them.
+        self._ipv4_denied = False
+        self._ipv6_denied = False
         cached_srv_record = cache.get_by_details(self._name, _TYPE_SRV, _CLASS_IN)
         if cached_srv_record:
             self._process_record_threadsafe(zc, cached_srv_record, now)
@@ -878,12 +925,16 @@ class ServiceInfo(RecordUpdateListener):
                 self._process_record_threadsafe(zc, cached_nsec_record, now)
         if original_server_key == self.server_key:
             # If there is a srv which changes the server_key,
-            # A and AAAA will already be loaded from the cache
-            # and we do not want to do it twice
+            # A, AAAA, and the server NSEC will already be loaded
+            # from the cache and we do not want to do it twice
             for record in self._get_address_records_from_cache_by_type(zc, _TYPE_A):
                 self._process_record_threadsafe(zc, record, now)
             for record in self._get_address_records_from_cache_by_type(zc, _TYPE_AAAA):
                 self._process_record_threadsafe(zc, record, now)
+            if self.server_key and not self._is_complete:
+                cached_server_nsec_record = cache.get_by_details(self.server_key, _TYPE_NSEC, _CLASS_IN)
+                if cached_server_nsec_record:
+                    self._process_record_threadsafe(zc, cached_server_nsec_record, now)
         return self._is_complete
 
     @property
@@ -896,6 +947,14 @@ class ServiceInfo(RecordUpdateListener):
         (RFC 6762 section 6.1); a missing one does not.
         """
         return bool(self._txt_seen and (self._ipv4_addresses or self._ipv6_addresses))
+
+    @property
+    def _is_denied(self) -> bool:
+        """Every address type this request needs was denied via NSEC (RFC 6762 section 6.1)."""
+        query_types = self._query_record_types
+        return (_TYPE_A not in query_types or (self._ipv4_denied and not self._ipv4_addresses)) and (
+            _TYPE_AAAA not in query_types or (self._ipv6_denied and not self._ipv6_addresses)
+        )
 
     def request(
         self,
@@ -978,7 +1037,7 @@ class ServiceInfo(RecordUpdateListener):
         try:
             zc.async_add_listener(self, None)
             while not self._is_complete:
-                if last <= now:
+                if last <= now or self._is_denied:
                     return False
                 if next_ <= now:
                     this_question_type = question_type or (QU_QUESTION if first_request else QM_QUESTION)

--- a/tests/services/test_info.py
+++ b/tests/services/test_info.py
@@ -7,7 +7,9 @@ import logging
 import os
 import socket
 import threading
+import time
 import unittest
+from collections.abc import Callable
 from ipaddress import ip_address
 from threading import Event
 from unittest.mock import patch
@@ -2597,3 +2599,479 @@ async def test_own_nsec_response_does_not_complete_service(aiozc_loopback: Async
 
     info = ServiceInfo(type_, registration_name)
     assert info.load_from_cache(zc) is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("resolver_class", "nsec_rdtypes"),
+    [
+        (r.AddressResolverIPv4, [const._TYPE_AAAA]),
+        (r.AddressResolverIPv6, [const._TYPE_A]),
+    ],
+)
+async def test_address_resolver_bails_on_nsec_denial(
+    aiozc_loopback: AsyncZeroconf,
+    resolver_class: Callable[[str], ServiceInfo],
+    nsec_rdtypes: list[int],
+) -> None:
+    """A cached NSEC denying the wanted address type fails the request without waiting."""
+    host = "nsec-addr-denial.local."
+    await aiozc_loopback.zeroconf.async_wait_for_start()
+    zc = aiozc_loopback.zeroconf
+
+    zc.record_manager.async_updates_from_response(
+        mock_incoming_msg(
+            [
+                r.DNSNsec(
+                    host,
+                    const._TYPE_NSEC,
+                    const._CLASS_IN | const._CLASS_UNIQUE,
+                    120,
+                    host,
+                    nsec_rdtypes,
+                )
+            ]
+        )
+    )
+
+    resolver = resolver_class(host)
+    start = time.monotonic()
+    with patch.object(zc, "async_send") as mock_send:
+        assert await resolver.async_request(zc, 10000) is False
+    assert time.monotonic() - start < 2
+    # a cached denial fails without putting a query on the wire
+    assert mock_send.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_address_resolver_bails_on_live_nsec_denial(aiozc_loopback: AsyncZeroconf) -> None:
+    """An NSEC denial arriving mid request wakes the waiter and fails it early."""
+    host = "nsec-live-denial.local."
+    await aiozc_loopback.zeroconf.async_wait_for_start()
+    zc = aiozc_loopback.zeroconf
+
+    resolver = r.AddressResolverIPv6(host)
+    start = time.monotonic()
+    with patch.object(zc, "async_send"):
+        task = asyncio.ensure_future(resolver.async_request(zc, 10000))
+        await asyncio.sleep(0.1)
+        assert not task.done()
+        zc.record_manager.async_updates_from_response(
+            mock_incoming_msg(
+                [
+                    r.DNSNsec(
+                        host,
+                        const._TYPE_NSEC,
+                        const._CLASS_IN | const._CLASS_UNIQUE,
+                        120,
+                        host,
+                        [const._TYPE_A],
+                    )
+                ]
+            )
+        )
+        assert await task is False
+    assert time.monotonic() - start < 2
+
+
+@pytest.mark.asyncio
+async def test_address_resolver_succeeds_despite_partial_denial(
+    aiozc_loopback: AsyncZeroconf,
+) -> None:
+    """Denial of one address family does not fail a resolver that accepts either."""
+    host = "nsec-partial-denial.local."
+    await aiozc_loopback.zeroconf.async_wait_for_start()
+    zc = aiozc_loopback.zeroconf
+
+    zc.record_manager.async_updates_from_response(
+        mock_incoming_msg(
+            [
+                r.DNSAddress(
+                    host,
+                    const._TYPE_A,
+                    const._CLASS_IN | const._CLASS_UNIQUE,
+                    120,
+                    socket.inet_aton("127.0.0.1"),
+                ),
+                r.DNSNsec(
+                    host,
+                    const._TYPE_NSEC,
+                    const._CLASS_IN | const._CLASS_UNIQUE,
+                    120,
+                    host,
+                    [const._TYPE_A],
+                ),
+            ]
+        )
+    )
+
+    resolver = r.AddressResolver(host)
+    with patch.object(zc, "async_send"):
+        assert await resolver.async_request(zc, QUICK_REQUEST_TIMEOUT_MS) is True
+    assert resolver.addresses == [socket.inet_aton("127.0.0.1")]
+
+
+@pytest.mark.asyncio
+async def test_address_resolver_bails_when_other_family_is_present(
+    aiozc_loopback: AsyncZeroconf,
+) -> None:
+    """A cached NSEC denial bails a single family resolver even when the other family resolved."""
+    host = "nsec-mixed-denial.local."
+    await aiozc_loopback.zeroconf.async_wait_for_start()
+    zc = aiozc_loopback.zeroconf
+
+    zc.record_manager.async_updates_from_response(
+        mock_incoming_msg(
+            [
+                r.DNSAddress(
+                    host,
+                    const._TYPE_A,
+                    const._CLASS_IN | const._CLASS_UNIQUE,
+                    120,
+                    socket.inet_aton("127.0.0.1"),
+                ),
+                r.DNSNsec(
+                    host,
+                    const._TYPE_NSEC,
+                    const._CLASS_IN | const._CLASS_UNIQUE,
+                    120,
+                    host,
+                    [const._TYPE_A],
+                ),
+            ]
+        )
+    )
+
+    resolver = r.AddressResolverIPv6(host)
+    start = time.monotonic()
+    with patch.object(zc, "async_send"):
+        assert await resolver.async_request(zc, 10000) is False
+    assert time.monotonic() - start < 2
+
+
+@pytest.mark.asyncio
+async def test_address_denial_cleared_on_new_request(aiozc_loopback: AsyncZeroconf) -> None:
+    """A denial only lasts one request; a host that gains the record resolves again."""
+    host = "nsec-denial-reset.local."
+    await aiozc_loopback.zeroconf.async_wait_for_start()
+    zc = aiozc_loopback.zeroconf
+
+    zc.record_manager.async_updates_from_response(
+        mock_incoming_msg(
+            [
+                r.DNSNsec(
+                    host,
+                    const._TYPE_NSEC,
+                    const._CLASS_IN | const._CLASS_UNIQUE,
+                    120,
+                    host,
+                    [const._TYPE_A],
+                )
+            ]
+        )
+    )
+
+    resolver = r.AddressResolverIPv6(host)
+    with patch.object(zc, "async_send"):
+        assert await resolver.async_request(zc, 10000) is False
+
+    v6 = socket.inet_pton(socket.AF_INET6, "fd00::1")
+    zc.record_manager.async_updates_from_response(
+        mock_incoming_msg(
+            [
+                r.DNSAddress(
+                    host,
+                    const._TYPE_AAAA,
+                    const._CLASS_IN | const._CLASS_UNIQUE,
+                    120,
+                    v6,
+                )
+            ]
+        )
+    )
+    with patch.object(zc, "async_send"):
+        assert await resolver.async_request(zc, QUICK_REQUEST_TIMEOUT_MS) is True
+    assert resolver.ip_addresses_by_version(IPVersion.V6Only)
+
+
+@pytest.mark.asyncio
+async def test_service_info_bails_when_all_address_types_denied(
+    aiozc_loopback: AsyncZeroconf,
+) -> None:
+    """An NSEC denying both address families at the host fails the request early."""
+    type_ = "_http._tcp.local."
+    registration_name = f"alldenied.{type_}"
+    host = "alldenied-host.local."
+    await aiozc_loopback.zeroconf.async_wait_for_start()
+    zc = aiozc_loopback.zeroconf
+
+    zc.record_manager.async_updates_from_response(
+        mock_incoming_msg(
+            [
+                r.DNSService(
+                    registration_name,
+                    const._TYPE_SRV,
+                    const._CLASS_IN | const._CLASS_UNIQUE,
+                    120,
+                    0,
+                    0,
+                    80,
+                    host,
+                ),
+                r.DNSText(
+                    registration_name,
+                    const._TYPE_TXT,
+                    const._CLASS_IN | const._CLASS_UNIQUE,
+                    120,
+                    b"\x05ttl=2",
+                ),
+                r.DNSNsec(
+                    host,
+                    const._TYPE_NSEC,
+                    const._CLASS_IN | const._CLASS_UNIQUE,
+                    120,
+                    host,
+                    [const._TYPE_TXT],
+                ),
+            ]
+        )
+    )
+
+    info = ServiceInfo(type_, registration_name)
+    start = time.monotonic()
+    with patch.object(zc, "async_send"):
+        assert await info.async_request(zc, 10000) is False
+    assert time.monotonic() - start < 2
+
+
+def test_nsec_for_unrelated_name_is_ignored(zc_loopback: r.Zeroconf) -> None:
+    """An NSEC for a name that is neither the service nor the server changes nothing."""
+    type_ = "_http._tcp.local."
+    registration_name = f"unrelatednsec.{type_}"
+    info = ServiceInfo(type_, registration_name)
+    foreign_nsec = r.DNSNsec(
+        "other-host.local.",
+        const._TYPE_NSEC,
+        const._CLASS_IN | const._CLASS_UNIQUE,
+        120,
+        "other-host.local.",
+        [const._TYPE_A],
+    )
+    info.async_update_records(zc_loopback, r.current_time_millis(), [RecordUpdate(foreign_nsec, None)])
+    assert info._ipv4_denied is False
+    assert info._ipv6_denied is False
+    assert info._txt_seen is False
+
+
+def _nsec(name: str, rdtypes: list[int]) -> r.DNSNsec:
+    return r.DNSNsec(
+        name,
+        const._TYPE_NSEC,
+        const._CLASS_IN | const._CLASS_UNIQUE,
+        120,
+        name,
+        rdtypes,
+    )
+
+
+def _srv(name: str, host: str) -> r.DNSService:
+    return r.DNSService(
+        name,
+        const._TYPE_SRV,
+        const._CLASS_IN | const._CLASS_UNIQUE,
+        120,
+        0,
+        0,
+        80,
+        host,
+    )
+
+
+@pytest.mark.parametrize("nsec_first", [False, True])
+def test_nsec_and_srv_in_same_batch_record_denial(zc_loopback: r.Zeroconf, nsec_first: bool) -> None:
+    """A batch with an SRV and an NSEC for its target records the denial in either order."""
+    type_ = "_http._tcp.local."
+    registration_name = f"nsecfirst.{type_}"
+    host = "nsecfirst-host.local."
+    info = ServiceInfo(type_, registration_name)
+    now = r.current_time_millis()
+    records = [_nsec(host, [const._TYPE_TXT]), _srv(registration_name, host)]
+    if not nsec_first:
+        records.reverse()
+    info.async_update_records(zc_loopback, now, [RecordUpdate(record, None) for record in records])
+    assert (info._ipv4_denied, info._ipv6_denied) == (True, True)
+
+
+def test_denial_is_reset_when_srv_changes_server(zc_loopback: r.Zeroconf) -> None:
+    """A denial learned for the old SRV target does not apply to a new target."""
+    type_ = "_http._tcp.local."
+    registration_name = f"srvmove.{type_}"
+    old_host = "srvmove-old.local."
+    new_host = "srvmove-new.local."
+    denied_host = "srvmove-denied.local."
+    info = ServiceInfo(type_, registration_name)
+    now = r.current_time_millis()
+
+    info.async_update_records(
+        zc_loopback,
+        now,
+        [
+            RecordUpdate(_srv(registration_name, old_host), None),
+            RecordUpdate(_nsec(old_host, [const._TYPE_TXT]), None),
+        ],
+    )
+    assert (info._ipv4_denied, info._ipv6_denied) == (True, True)
+
+    # moving to a host with no cached NSEC clears the denial
+    info.async_update_records(zc_loopback, now, [RecordUpdate(_srv(registration_name, new_host), None)])
+    assert (info._ipv4_denied, info._ipv6_denied) == (False, False)
+
+    # moving to a host with a cached NSEC re-establishes it from the cache
+    zc_loopback.cache.async_add_records([_nsec(denied_host, [const._TYPE_TXT])])
+    info.async_update_records(zc_loopback, now, [RecordUpdate(_srv(registration_name, denied_host), None)])
+    assert (info._ipv4_denied, info._ipv6_denied) == (True, True)
+
+
+def test_newer_nsec_clears_previous_denial(zc_loopback: r.Zeroconf) -> None:
+    """A later NSEC whose bitmap includes a previously denied type clears that denial."""
+    type_ = "_http._tcp.local."
+    registration_name = f"nsecrefresh.{type_}"
+    host = "nsecrefresh-host.local."
+    info = ServiceInfo(type_, registration_name)
+    now = r.current_time_millis()
+    info.async_update_records(zc_loopback, now, [RecordUpdate(_srv(registration_name, host), None)])
+
+    info.async_update_records(zc_loopback, now, [RecordUpdate(_nsec(host, [const._TYPE_A]), None)])
+    assert (info._ipv4_denied, info._ipv6_denied) == (False, True)
+
+    info.async_update_records(
+        zc_loopback, now, [RecordUpdate(_nsec(host, [const._TYPE_A, const._TYPE_AAAA]), None)]
+    )
+    assert (info._ipv4_denied, info._ipv6_denied) == (False, False)
+
+
+def test_multiple_nsec_records_in_one_batch(zc_loopback: r.Zeroconf) -> None:
+    """A batch with more than one NSEC processes every denial it carries."""
+    type_ = "_http._tcp.local."
+    registration_name = f"multinsec.{type_}"
+    host = "multinsec-host.local."
+    info = ServiceInfo(type_, registration_name)
+    now = r.current_time_millis()
+    records = [
+        _srv(registration_name, host),
+        _nsec(registration_name, [const._TYPE_SRV]),
+        _nsec(host, [const._TYPE_TXT]),
+    ]
+    info.async_update_records(zc_loopback, now, [RecordUpdate(record, None) for record in records])
+    assert info._txt_seen is True
+    assert (info._ipv4_denied, info._ipv6_denied) == (True, True)
+
+
+@pytest.mark.asyncio
+async def test_v4_only_host_with_nsec_still_resolves(aiozc_loopback: AsyncZeroconf) -> None:
+    """The common case: a v4 only host denying AAAA via NSEC still resolves the service."""
+    type_ = "_http._tcp.local."
+    registration_name = f"v4onlynsec.{type_}"
+    host = "v4onlynsec-host.local."
+    await aiozc_loopback.zeroconf.async_wait_for_start()
+    zc = aiozc_loopback.zeroconf
+
+    zc.record_manager.async_updates_from_response(
+        mock_incoming_msg(
+            [
+                _srv(registration_name, host),
+                r.DNSText(
+                    registration_name,
+                    const._TYPE_TXT,
+                    const._CLASS_IN | const._CLASS_UNIQUE,
+                    120,
+                    b"\x05ttl=2",
+                ),
+                r.DNSAddress(
+                    host,
+                    const._TYPE_A,
+                    const._CLASS_IN | const._CLASS_UNIQUE,
+                    120,
+                    socket.inet_aton("127.0.0.1"),
+                ),
+                _nsec(host, [const._TYPE_A]),
+            ]
+        )
+    )
+
+    info = ServiceInfo(type_, registration_name)
+    with patch.object(zc, "async_send"):
+        assert await info.async_request(zc, QUICK_REQUEST_TIMEOUT_MS) is True
+    assert info.properties == {b"ttl": b"2"}
+    assert info.addresses == [socket.inet_aton("127.0.0.1")]
+
+
+def test_legacy_inverted_nsec_at_own_name_does_not_fail_request(zc_loopback: r.Zeroconf) -> None:
+    """A pre-0.150.4 inverted NSEC from a service with server == name never denies the request.
+
+    Legacy responders listed the missing address types, so the snapshot records
+    the wrong family; a single wrong flag must never make _is_denied true.
+    """
+    type_ = "_http._tcp.local."
+    registration_name = f"legacyownname.{type_}"
+    info = ServiceInfo(type_, registration_name)
+    now = r.current_time_millis()
+    # legacy v4 only responder registered without server=: NSEC at its own
+    # name with the inverted bitmap listing the missing AAAA
+    info.async_update_records(
+        zc_loopback,
+        now,
+        [
+            RecordUpdate(_srv(registration_name, registration_name), None),
+            RecordUpdate(_nsec(registration_name, [const._TYPE_AAAA]), None),
+        ],
+    )
+    assert (info._ipv4_denied, info._ipv6_denied) == (True, False)
+    assert info._is_denied is False
+
+    info.async_update_records(
+        zc_loopback,
+        now,
+        [
+            RecordUpdate(
+                r.DNSAddress(
+                    registration_name,
+                    const._TYPE_A,
+                    const._CLASS_IN | const._CLASS_UNIQUE,
+                    120,
+                    socket.inet_aton("127.0.0.1"),
+                ),
+                None,
+            )
+        ],
+    )
+    assert info.addresses == [socket.inet_aton("127.0.0.1")]
+    assert info._is_denied is False
+
+
+def test_denied_flag_is_ignored_when_address_is_held(zc_loopback: r.Zeroconf) -> None:
+    """A denial never vetoes an address the client already holds."""
+    type_ = "_http._tcp.local."
+    registration_name = f"guardednsec.{type_}"
+    host = "guardednsec-host.local."
+    zc_loopback.cache.async_add_records(
+        [
+            _srv(registration_name, host),
+            r.DNSAddress(
+                host,
+                const._TYPE_A,
+                const._CLASS_IN | const._CLASS_UNIQUE,
+                120,
+                socket.inet_aton("127.0.0.1"),
+            ),
+            _nsec(host, [const._TYPE_TXT]),
+        ]
+    )
+
+    info = ServiceInfo(type_, registration_name)
+    # incomplete only because the TXT record is still missing
+    assert info.load_from_cache(zc_loopback) is False
+    assert (info._ipv4_denied, info._ipv6_denied) == (True, True)
+    assert info.addresses == [socket.inet_aton("127.0.0.1")]
+    # the held A record keeps the request querying instead of fast failing
+    assert info._is_denied is False

--- a/tests/services/test_info.py
+++ b/tests/services/test_info.py
@@ -3007,11 +3007,7 @@ async def test_v4_only_host_with_nsec_still_resolves(aiozc_loopback: AsyncZeroco
 
 
 def test_legacy_inverted_nsec_at_own_name_does_not_fail_request(zc_loopback: r.Zeroconf) -> None:
-    """A pre-0.150.4 inverted NSEC from a service with server == name never denies the request.
-
-    Legacy responders listed the missing address types, so the snapshot records
-    the wrong family; a single wrong flag must never make _is_denied true.
-    """
+    """A pre-0.150.4 inverted NSEC from a service with server == name never denies the request."""
     type_ = "_http._tcp.local."
     registration_name = f"legacyownname.{type_}"
     info = ServiceInfo(type_, registration_name)


### PR DESCRIPTION
## Summary

Follow up to #1825. When an NSEC record at the host name denies every address type a request still needs, `async_request` now fails fast instead of waiting out the full timeout; RFC 6762 §6.1 makes such an NSEC an authoritative nonexistence assertion.

## Details

* NSEC records at the server name now set per family denial flags; the bitmap lists the types that exist, so an absent bit denies that family.
* A new `_is_denied` check derives the wanted families from `_query_record_types`, so `AddressResolverIPv4`, `AddressResolverIPv6`, `AddressResolver`, and plain `ServiceInfo` all share one definition with no overrides.
* Denials are re derived on every cache load, so a host that later gains the record resolves normally on the next request.
* `_load_from_cache` also consults a cached NSEC at the server name when the request is still incomplete, covering the case where the other address family already resolved.
* NSEC records are processed last within each update batch, so a denial for an SRV target learned later in the same response is not lost to wire ordering; when an SRV update changes the target host, denials are reset and re derived from the new host's cached NSEC.
* Each NSEC is treated as an authoritative snapshot, so a newer bitmap that includes a previously denied family clears the stale denial.
* Foreign NSEC records still bail on the key checks before any processing; the hot dispatch path is unchanged for other record types, confirmed against the Cython annotate output.

## Test plan

- [x] `poetry run pytest tests` passes, 480 passed
- [x] new tests cover both single family resolvers, a denial arriving mid request, partial denial with the other family present, denial reset on a later request, the all types denied case for plain `ServiceInfo`, NSEC and SRV arriving in either order in one batch, denial reset when the SRV target moves, a newer bitmap clearing a stale denial, and NSECs for unrelated names being ignored
- [x] Cython annotate comparison against master shows untouched hot functions unchanged; the new cost sits only on NSEC record lines and cold paths
- [x] verified on a live network; an IPv6 resolve of a real v4 only device now fails in about 120ms instead of the 10s timeout, while IPv4, either family, and dual stack resolves are unaffected
