### PR TITLE
test: allow coverage data lock in blockbuster

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,6 +71,11 @@ def blockbuster(
         yield None
         return
     with blockbuster_ctx() as bb:
+        # coverage's C tracer acquires its data lock from whatever frame
+        # is running when tracing starts on a new thread, which can be an
+        # event-loop callback and is not a blocking call zeroconf makes.
+        for func in ("threading.Lock.acquire", "threading.Lock.acquire_lock"):
+            bb.functions[func].can_block_in("coverage/collector.py", "lock_data")
         yield bb
 
 


### PR DESCRIPTION
## Summary

`test_update_record` flaked on windows 3.12 with `BlockingError: Blocking call to lock.acquire` inside `_ServiceBrowserBase._async_start`; the acquire came from coverage's C tracer (`coverage/collector.py` `lock_data`), which grabs its data lock from whatever frame is running when tracing starts on a new thread, so the browser callback died, no service was added, and the browser threads leaked into teardown.

## Details

- blockbuster only flags a contended `Lock.acquire`; the race needs another thread holding coverage's data lock at the moment the tracer fires in an event loop frame, which is why it only shows up occasionally
- the fixture now allowlists `threading.Lock.acquire` and `acquire_lock` when the frame is `lock_data` in `coverage/collector.py`; blockbuster normalizes frame paths with `as_posix`, so the match also works on windows

## Test plan

- [x] simulated coverage's frame with a compiled `coverage/collector.py` filename and a held lock; without the fix it raises `BlockingError`, with the fix it is allowed, and a contended acquire from any other frame still raises
- [x] `tests/services/test_browser.py` passes locally
