### PR TITLE
test: widen loopback find timeout on macos

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import asyncio
 import platform
 import socket
+import sys
 import time
 from collections.abc import Iterable
 from functools import cache
@@ -38,6 +39,7 @@ from zeroconf._history import QuestionHistory
 _MONOTONIC_RESOLUTION = time.get_clock_info("monotonic").resolution
 
 _IS_PYPY = platform.python_implementation() == "PyPy"
+_IS_MACOS = sys.platform == "darwin"
 
 # get_service_info / async_request timeout for tests using the
 # `quick_request_timing` fixture. The fixture cuts the initial-query
@@ -55,7 +57,10 @@ QUICK_REQUEST_TIMEOUT_MS = 50
 # the registrar's response lands inside ~10ms and 75ms is ~7x headroom.
 # PyPy's JIT is still warming up the first time this path runs early in
 # the suite, so the round trip is too slow for 75ms; give it more room.
-LOOPBACK_FIND_TIMEOUT = 0.3 if _IS_PYPY else 0.075
+# GitHub's macOS runners stall the whole process for longer than 75ms
+# often enough that the response lands after `find()` has already
+# cancelled the browser, so they get the same room.
+LOOPBACK_FIND_TIMEOUT = 0.3 if _IS_PYPY or _IS_MACOS else 0.075
 
 # IPv6-only `find()` on Linux GitHub runners can hit `[Errno 101] Network
 # is unreachable` on the `::1` socket and falls back to the `fe80::` link-


### PR DESCRIPTION
## Summary

`test_integration_with_subtype_and_listener` failed twice recently, both times on macos runners (3.10 and 3.13), with the second `find()` returning `()`; the captured log shows the registrar's PTR response was sent and received, it just landed after the 75ms `find()` sleep had already cancelled the browser.

## Details

- `find()` is a fixed `time.sleep(timeout)`, so the timeout is a hard budget for the whole query and response round trip; locally that round trip is 1 to 7ms for every test in the file, on GitHub's macos runners the process stalls for longer than 75ms often enough to lose the answer
- macos now gets the same 300ms `LOOPBACK_FIND_TIMEOUT` PyPy already uses, other platforms keep 75ms; this adds about 1.8s to each macos job

## Test plan

- [x] `tests/services/test_types.py` passes locally on macos with the new budget
- [x] measured the query to `add_service` latency for both `find()` phases of the plain and subtype tests, 1 to 7ms in every run, so the failures are runner stalls rather than a systematic slow path
