### PR TITLE
ci: add a manually dispatched asan fuzzing workflow with a status gate

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -1,0 +1,47 @@
+name: ASan fuzz
+
+on:
+  workflow_dispatch:
+    inputs:
+      profile:
+        description: "Hypothesis profile"
+        default: "long"
+        type: choice
+        options:
+          - ci
+          - long
+
+jobs:
+  asan-fuzz:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+      - name: Set up uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+      - name: Install poetry
+        run: uv tool install poetry
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v5
+        with:
+          python-version: "3.13"
+          cache: "poetry"
+      - name: Install dependencies
+        env:
+          REQUIRE_CYTHON: 1
+        run: poetry install --only=main,dev
+      - name: Rebuild the extensions with AddressSanitizer
+        env:
+          REQUIRE_CYTHON: 1
+          CFLAGS: "-fsanitize=address -g -O1"
+          LDFLAGS: "-fsanitize=address"
+        run: poetry run python setup.py build_ext --inplace --force
+      - name: Fuzz the parser under ASan
+        env:
+          HYPOTHESIS_PROFILE: ${{ inputs.profile }}
+        run: |
+          export LD_PRELOAD=$(gcc -print-file-name=libasan.so)
+          export ASAN_OPTIONS=detect_leaks=0:halt_on_error=1
+          poetry run pytest --timeout=1800 -v --no-cov tests/test_fuzz_incoming.py tests/test_protocol.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,27 @@ jobs:
             didn't match the configured pattern. Please ensure that the subject
             starts with a lowercase character.
 
+  # The ASan fuzz workflow only runs on manual dispatch; this gate keeps a
+  # failed run from rotting silently by blocking CI until it is green again.
+  asan-status:
+    name: Last ASan fuzz run
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    steps:
+      - name: Fail if the most recent ASan fuzz run on master failed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          conclusion=$(gh api \
+            "repos/${{ github.repository }}/actions/workflows/asan.yml/runs?branch=master&status=completed&per_page=1" \
+            --jq '.workflow_runs[0].conclusion // "none"')
+          echo "Most recent ASan fuzz run on master: $conclusion"
+          if [ "$conclusion" = "failure" ]; then
+            echo "The most recent ASan fuzz run failed; fix the regression or re-run the workflow." >&2
+            exit 1
+          fi
+
   test:
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

Adds a manually dispatched workflow that rebuilds every extension with AddressSanitizer and runs the parser fuzz suite under it, plus a CI gate so a failed run blocks pull requests until it is green again.

## Details

* `asan.yml` builds with `-fsanitize=address`, preloads `libasan`, and runs `tests/test_fuzz_incoming.py` and `tests/test_protocol.py` with the deep `HYPOTHESIS_PROFILE=long` profile by default; a `ci` profile input is available for a quick run
* an out of bounds read in the compiled parser is silent without a sanitizer, since small heap overreads rarely fault and the pure python fallback turns every miss into a caught IndexError; ASan redzones turn even a one byte overread into an abort
* the `asan-status` job in the main CI reads the most recent completed run on master and fails if it concluded in failure; a never run or cancelled state passes
* the same setup validated the parser changes locally in a Linux container; 50k hostile packets plus every boundary packet from the bounds audit ran clean

## Test plan

- [x] both workflow files parse as valid yaml; pre-commit clean
- [x] the harness and flags are the ones proven working in the container run
- [ ] dispatch the workflow once after merge to seed a green status
