### PR TITLE
ci: build the asan workflow extensions through poetry install

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -28,16 +28,12 @@ jobs:
         with:
           python-version: "3.13"
           cache: "poetry"
-      - name: Install dependencies
-        env:
-          REQUIRE_CYTHON: 1
-        run: poetry install --only=main,dev
-      - name: Rebuild the extensions with AddressSanitizer
+      - name: Install dependencies with AddressSanitizer instrumentation
         env:
           REQUIRE_CYTHON: 1
           CFLAGS: "-fsanitize=address -g -O1"
           LDFLAGS: "-fsanitize=address"
-        run: poetry run python setup.py build_ext --inplace --force
+        run: poetry install --only=main,dev
       - name: Fuzz the parser under ASan
         env:
           HYPOTHESIS_PROFILE: ${{ inputs.profile }}


### PR DESCRIPTION
The dispatch run failed because setup.py is generated by poetry-core at install time and is not checked in. The fix moves the ASan flags onto `poetry install` itself; a fresh checkout compiles every extension from scratch, so the instrumentation lands without a separate build step. Verified locally that a clean install with these flags links the ASan runtime into the extensions. The failed run is currently the latest on master, so the asan-status gate blocks CI until this merges and a re-dispatch goes green.