### PR TITLE
fix: accept str addresses in ServiceInfo.addresses under cython

### DIFF
--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -219,7 +219,7 @@ class ServiceInfo(RecordUpdateListener):
         host_ttl: int = _DNS_HOST_TTL,
         other_ttl: int = _DNS_OTHER_TTL,
         *,
-        addresses: list[bytes] | None = None,
+        addresses: Sequence[bytes | str | int] | None = None,
         parsed_addresses: list[str] | None = None,
         interface_index: int | None = None,
     ) -> None:
@@ -292,7 +292,7 @@ class ServiceInfo(RecordUpdateListener):
         return self.addresses_by_version(IPVersion.V4Only)
 
     @addresses.setter
-    def addresses(self, value: list[bytes]) -> None:
+    def addresses(self, value: Sequence[bytes | str | int]) -> None:
         """Replace the addresses list.
 
         This replaces all currently stored addresses, both IPv4 and IPv6.
@@ -304,7 +304,7 @@ class ServiceInfo(RecordUpdateListener):
         self._get_address_and_nsec_records_cache = None
 
         for address in value:
-            if len(address) == 16 and self.interface_index is not None:
+            if self.interface_index is not None and isinstance(address, bytes) and len(address) == 16:
                 addr = ip_bytes_and_scope_to_address(address, self.interface_index)
             else:
                 addr = cached_ip_addresses(address)

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -219,7 +219,7 @@ class ServiceInfo(RecordUpdateListener):
         host_ttl: int = _DNS_HOST_TTL,
         other_ttl: int = _DNS_OTHER_TTL,
         *,
-        addresses: Sequence[bytes | str | int] | None = None,
+        addresses: Sequence[bytes | str] | None = None,
         parsed_addresses: list[str] | None = None,
         interface_index: int | None = None,
     ) -> None:
@@ -292,7 +292,7 @@ class ServiceInfo(RecordUpdateListener):
         return self.addresses_by_version(IPVersion.V4Only)
 
     @addresses.setter
-    def addresses(self, value: Sequence[bytes | str | int]) -> None:
+    def addresses(self, value: Sequence[bytes | str]) -> None:
         """Replace the addresses list.
 
         This replaces all currently stored addresses, both IPv4 and IPv6.
@@ -304,7 +304,7 @@ class ServiceInfo(RecordUpdateListener):
         self._get_address_and_nsec_records_cache = None
 
         for address in value:
-            if self.interface_index is not None and isinstance(address, bytes) and len(address) == 16:
+            if len(address) == 16 and self.interface_index is not None:
                 addr = ip_bytes_and_scope_to_address(address, self.interface_index)
             else:
                 addr = cached_ip_addresses(address)

--- a/src/zeroconf/_utils/ipaddress.py
+++ b/src/zeroconf/_utils/ipaddress.py
@@ -137,7 +137,7 @@ def get_ip_address_object_from_record(
 
 
 def ip_bytes_and_scope_to_address(
-    address: bytes_, scope: int_
+    address: bytes_ | str, scope: int_
 ) -> ZeroconfIPv4Address | ZeroconfIPv6Address | None:
     """Convert the bytes and scope to an IP address object."""
     base_address = cached_ip_addresses_wrapper(address)

--- a/tests/services/test_info.py
+++ b/tests/services/test_info.py
@@ -3078,12 +3078,11 @@ def test_denied_flag_is_ignored_when_address_is_held(zc_loopback: r.Zeroconf) ->
     [
         ["10.0.1.2", "2001:db8::1"],
         [socket.inet_aton("10.0.1.2"), socket.inet_pton(socket.AF_INET6, "2001:db8::1")],
-        [int(ip_address("10.0.1.2")), int(ip_address("2001:db8::1"))],
         ["10.0.1.2", socket.inet_pton(socket.AF_INET6, "2001:db8::1")],
     ],
 )
-def test_addresses_setter_accepts_str_bytes_and_int(addresses):
-    """The addresses setter accepts str, bytes, and int addresses."""
+def test_addresses_setter_accepts_str_and_bytes(addresses):
+    """The addresses setter accepts str and bytes addresses."""
     type_ = "_http._tcp.local."
     info = ServiceInfo(type_, f"xxxyyy.{type_}", 80, server="ash-2.local.")
     info.addresses = addresses

--- a/tests/services/test_info.py
+++ b/tests/services/test_info.py
@@ -3071,3 +3071,31 @@ def test_denied_flag_is_ignored_when_address_is_held(zc_loopback: r.Zeroconf) ->
     assert info.addresses == [socket.inet_aton("127.0.0.1")]
     # the held A record keeps the request querying instead of fast failing
     assert info._is_denied is False
+
+
+@pytest.mark.parametrize(
+    "addresses",
+    [
+        ["10.0.1.2", "2001:db8::1"],
+        [socket.inet_aton("10.0.1.2"), socket.inet_pton(socket.AF_INET6, "2001:db8::1")],
+        [int(ip_address("10.0.1.2")), int(ip_address("2001:db8::1"))],
+        ["10.0.1.2", socket.inet_pton(socket.AF_INET6, "2001:db8::1")],
+    ],
+)
+def test_addresses_setter_accepts_str_bytes_and_int(addresses):
+    """The addresses setter accepts str, bytes, and int addresses."""
+    type_ = "_http._tcp.local."
+    info = ServiceInfo(type_, f"xxxyyy.{type_}", 80, server="ash-2.local.")
+    info.addresses = addresses
+    assert info.parsed_addresses() == ["10.0.1.2", "2001:db8::1"]
+
+    info = ServiceInfo(type_, f"xxxyyy.{type_}", 80, server="ash-2.local.", addresses=addresses)
+    assert info.parsed_addresses() == ["10.0.1.2", "2001:db8::1"]
+
+
+def test_addresses_setter_rejects_invalid_address():
+    """The addresses setter raises TypeError for invalid addresses."""
+    type_ = "_http._tcp.local."
+    info = ServiceInfo(type_, f"xxxyyy.{type_}", 80, server="ash-2.local.")
+    with pytest.raises(TypeError, match="Addresses must either be"):
+        info.addresses = ["not an address"]


### PR DESCRIPTION
## Summary
Under the Cython 3.3 build, assigning `ServiceInfo.addresses` with string addresses raises `TypeError: Expected bytes, got str`; the pure Python build still accepts them. This restores the setter contract, which has always advertised str as well as bytes.

## Details
- The setter and the `addresses` constructor kwarg were annotated `list[bytes]`; Cython 3.3 uses the element type to narrow the loop variable, so any non bytes item is rejected before `cached_ip_addresses` ever sees it. The annotation is now `Sequence[bytes | str]`, matching what `cached_ip_addresses` accepts.
- `ip_bytes_and_scope_to_address` already handled str at runtime; its parameter type is widened to match so mypy is satisfied. Its `.pxd` declares the argument as `object`, so no `.pxd` change is needed.
- The runtime body of the setter is unchanged.

## Test plan
- [x] New parametrized test in `tests/services/test_info.py` covering str, bytes, and mixed lists for both the setter and the constructor kwarg, plus a TypeError case for an invalid address
- [x] `tests/services/test_info.py`, `tests/utils/test_ipaddress.py` and `tests/test_core.py` pass on the Cython build (`REQUIRE_CYTHON=1 poetry install`)
- [x] pre-commit green
