### PR TITLE
revert: drop riscv64 wheel builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,19 +318,6 @@ jobs:
             qemu: armv7l
             musl: ""
             pyver: cp314t
-          # qemu is slow, make a single runner per Python version
-          - {os: ubuntu-latest, qemu: riscv64, musl: "musllinux", pyver: cp310}
-          - {os: ubuntu-latest, qemu: riscv64, musl: "musllinux", pyver: cp311}
-          - {os: ubuntu-latest, qemu: riscv64, musl: "musllinux", pyver: cp312}
-          - {os: ubuntu-latest, qemu: riscv64, musl: "musllinux", pyver: cp313}
-          - {os: ubuntu-latest, qemu: riscv64, musl: "musllinux", pyver: cp314}
-          - {os: ubuntu-latest, qemu: riscv64, musl: "musllinux", pyver: cp314t}
-          - {os: ubuntu-latest, qemu: riscv64, musl: "", pyver: cp310}
-          - {os: ubuntu-latest, qemu: riscv64, musl: "", pyver: cp311}
-          - {os: ubuntu-latest, qemu: riscv64, musl: "", pyver: cp312}
-          - {os: ubuntu-latest, qemu: riscv64, musl: "", pyver: cp313}
-          - {os: ubuntu-latest, qemu: riscv64, musl: "", pyver: cp314}
-          - {os: ubuntu-latest, qemu: riscv64, musl: "", pyver: cp314t}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4


### PR DESCRIPTION
## Summary

Reverts #1666 as part of #1835; the riscv64 wheel builds came from a contributor whose consent path resolved to a decline, and we do not actually need these wheels.

## Details

* clean revert of the 13 line matrix addition; riscv64 users can still build from source or install the pure python fallback
* part of the removal work promised in #1835

## Test plan

- [x] workflow yaml validates; the change only removes qemu wheel matrix entries
