### PR TITLE
test: make test_qu_response deterministic by injecting the announcement

### DIFF
--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -636,8 +636,10 @@ def test_qu_response(quick_timing: None) -> None:
         "ash-other.local.",
         addresses=[socket.inet_aton("10.0.4.2")],
     )
-    # register
-    zc.register_service(info)
+    # Register and inject the announcement directly so the cache state is
+    # deterministic; announcing on loopback would race the phases below.
+    zc.registry.async_add(info)
+    _inject_response(zc, r.DNSIncoming(zc.generate_service_broadcast(info, None).packets()[0]))
 
     def _validate_complete_response(answers):
         has_srv = has_txt = has_a = has_aaaa = has_nsec = False


### PR DESCRIPTION
## Summary
`test_qu_response` flaked on the macOS 3.11 skip_cython job with `mcast_now` empty in the probe phase.

## Details
The test registered the service with `register_service`, which announces on loopback; `register_service` waits for the sends but the loopback receive of the last announcement is processed on the loop thread afterwards. On a slow runner it lands after `_clear_cache`, the PTR becomes recent again, and the QU probe answer goes to unicast only. The first phase had the mirror race since it needs the announcement cached.

The service is now added to the registry directly and the announcement is injected with `_inject_response`, the same pattern the rest of `test_handlers.py` uses, so nothing arrives from the wire mid test.

## Test plan
- [x] `tests/test_handlers.py::test_qu_response` passes on repeated runs
- [x] pre-commit passes
