### PR TITLE
ci: notify contributors that the license is changing to Apache 2.0

### DIFF
--- a/.github/workflows/license-notice.yml
+++ b/.github/workflows/license-notice.yml
@@ -1,0 +1,68 @@
+name: License Change Notice
+
+# The project is transitioning from LGPL-2.1 to Apache 2.0
+# (https://github.com/python-zeroconf/python-zeroconf/issues/1835).
+# Every newly opened pull request gets a comment stating that opening
+# it means agreeing to license the contribution, and the author's
+# previous contributions, under Apache 2.0. If the pull request author
+# replies that they do not agree, the pull request is closed.
+
+on:
+  pull_request_target:
+    types:
+      - opened
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  notice:
+    name: Post license notice
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: [
+                "Heads up: this project is changing its license from LGPL-2.1 to Apache 2.0, see #1835.",
+                "",
+                "By opening this pull request you agree that your contribution, and all of your previous contributions to this repository, are licensed under Apache 2.0.",
+                "",
+                "If you do not agree, reply with the exact phrase `I do not agree to the Apache 2.0 license` and this pull request will be closed.",
+              ].join("\n"),
+            });
+
+  objection:
+    name: Close on objection
+    if: >
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      github.event.comment.user.login == github.event.issue.user.login &&
+      contains(github.event.comment.body, 'I do not agree to the Apache 2.0 license')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const number = context.payload.issue.number;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: number,
+              body: "Closing as requested; this contribution is not offered under the Apache 2.0 license change.",
+            });
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: number,
+              state: "closed",
+            });

--- a/.github/workflows/license-notice.yml
+++ b/.github/workflows/license-notice.yml
@@ -39,7 +39,7 @@ jobs:
                 "",
                 "By continuing with this pull request you are okay with your contribution, and your previous contributions to this repository, being offered under Apache 2.0.",
                 "",
-                "If that does not work for you, no hard feelings; reply with the exact phrase `I do not agree to the Apache 2.0 license` and we will close this so nothing of yours is included in the change.",
+                "If that does not work for you, no hard feelings; reply with the exact phrase `I do not agree to the Apache 2.0 license` or simply close this pull request, and nothing of yours will be included in the change.",
               ].join("\n"),
             });
 

--- a/.github/workflows/license-notice.yml
+++ b/.github/workflows/license-notice.yml
@@ -35,11 +35,11 @@ jobs:
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
               body: [
-                "Heads up: this project is changing its license from LGPL-2.1 to Apache 2.0, see #1835.",
+                "Thanks for contributing! A quick note: this project is in the process of moving from LGPL-2.1 to Apache 2.0, see #1835.",
                 "",
-                "By opening this pull request you agree that your contribution, and all of your previous contributions to this repository, are licensed under Apache 2.0.",
+                "By continuing with this pull request you are okay with your contribution, and your previous contributions to this repository, being offered under Apache 2.0.",
                 "",
-                "If you do not agree, reply with the exact phrase `I do not agree to the Apache 2.0 license` and this pull request will be closed.",
+                "If that does not work for you, no hard feelings; reply with the exact phrase `I do not agree to the Apache 2.0 license` and we will close this so nothing of yours is included in the change.",
               ].join("\n"),
             });
 

--- a/.github/workflows/license-notice.yml
+++ b/.github/workflows/license-notice.yml
@@ -22,7 +22,9 @@ permissions:
 jobs:
   notice:
     name: Post license notice
-    if: github.event_name == 'pull_request_target'
+    if: >
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.user.type != 'Bot'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0


### PR DESCRIPTION
## Summary
Adds the same license change notice workflow used in yalexs-ble. The relicensing consent period in #1835 will run for a while, so every pull request opened in the meantime gets a comment stating that opening it means the contribution, and the author's previous contributions, are offered under Apache 2.0. If the author replies with the objection phrase the pull request is closed.

## Test plan
- [x] workflow copied from the version that ran in yalexs-ble before its relicense completed
- [x] action pinned by commit sha
