### PR TITLE
chore: add freshly written docstrings and async examples

### DIFF
--- a/examples/async_browser.py
+++ b/examples/async_browser.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+
+"""Browse for HTTP services with the asyncio API and print each event."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import contextlib
+import logging
+
+from zeroconf import IPVersion, ServiceStateChange, Zeroconf
+from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo, AsyncZeroconf
+
+_background_tasks: set[asyncio.Task] = set()
+
+
+def on_service_state_change(
+    zeroconf: Zeroconf, service_type: str, name: str, state_change: ServiceStateChange
+) -> None:
+    print(f"{state_change.name}: {name}")
+    if state_change is ServiceStateChange.Added:
+        task = asyncio.create_task(show_service_info(zeroconf, service_type, name))
+        _background_tasks.add(task)
+        task.add_done_callback(_background_tasks.discard)
+
+
+async def show_service_info(zeroconf: Zeroconf, service_type: str, name: str) -> None:
+    info = AsyncServiceInfo(service_type, name)
+    if await info.async_request(zeroconf, 3000):
+        print(f"  addresses: {', '.join(info.parsed_scoped_addresses())}")
+        print(f"  server: {info.server} port: {info.port}")
+        print(f"  properties: {info.decoded_properties}")
+
+
+async def main(ip_version: IPVersion) -> None:
+    aiozc = AsyncZeroconf(ip_version=ip_version)
+    browser = AsyncServiceBrowser(aiozc.zeroconf, "_http._tcp.local.", handlers=[on_service_state_change])
+    print("browsing for _http._tcp.local., press ctrl-c to exit")
+    try:
+        await asyncio.Event().wait()
+    finally:
+        await browser.async_cancel()
+        await aiozc.async_close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--debug", action="store_true", help="enable debug logging")
+    parser.add_argument("--v6-only", action="store_true", help="use IPv6 only")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO)
+    ip_version = IPVersion.V6Only if args.v6_only else IPVersion.All
+
+    with contextlib.suppress(KeyboardInterrupt):
+        asyncio.run(main(ip_version))

--- a/examples/async_registration.py
+++ b/examples/async_registration.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+
+"""Register a batch of demo HTTP services with the asyncio API."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import contextlib
+import logging
+import socket
+
+from zeroconf import IPVersion, ServiceInfo
+from zeroconf.asyncio import AsyncZeroconf
+
+SERVICE_COUNT = 250
+
+
+def build_services() -> list[ServiceInfo]:
+    return [
+        ServiceInfo(
+            "_http._tcp.local.",
+            f"Demo Web Service {i}._http._tcp.local.",
+            addresses=[socket.inet_aton("127.0.0.1")],
+            port=8080 + i,
+            properties={"path": "/"},
+            server=f"demo-host-{i}.local.",
+        )
+        for i in range(SERVICE_COUNT)
+    ]
+
+
+async def main(ip_version: IPVersion) -> None:
+    aiozc = AsyncZeroconf(ip_version=ip_version)
+    services = build_services()
+    print(f"registering {len(services)} demo services, press ctrl-c to exit")
+    background_tasks = await asyncio.gather(*(aiozc.async_register_service(service) for service in services))
+    await asyncio.gather(*background_tasks)
+    try:
+        await asyncio.Event().wait()
+    finally:
+        print("unregistering")
+        unregister_tasks = await asyncio.gather(
+            *(aiozc.async_unregister_service(service) for service in services)
+        )
+        await asyncio.gather(*unregister_tasks)
+        await aiozc.async_close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--debug", action="store_true", help="enable debug logging")
+    parser.add_argument("--v6-only", action="store_true", help="use IPv6 only")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO)
+    ip_version = IPVersion.V6Only if args.v6_only else IPVersion.All
+
+    with contextlib.suppress(KeyboardInterrupt):
+        asyncio.run(main(ip_version))

--- a/src/zeroconf/_cache.py
+++ b/src/zeroconf/_cache.py
@@ -210,6 +210,10 @@ class DNSCache:
         return expired
 
     def async_get_unique(self, entry: _UniqueRecordsType) -> DNSRecord | None:
+        """Look up the cached copy of a unique record, or None.
+
+        Event loop only; not threadsafe.
+        """
         store = self.cache.get(entry.key)
         if store is None:
             return None
@@ -232,9 +236,11 @@ class DNSCache:
         return matches
 
     def async_entries_with_name(self, name: str) -> list[DNSRecord]:
+        """All cached records for a name; event loop only, not threadsafe."""
         return self.entries_with_name(name)
 
     def async_entries_with_server(self, name: str) -> list[DNSRecord]:
+        """All cached records for a server name; event loop only, not threadsafe."""
         return self.entries_with_server(name)
 
     # The below functions are threadsafe and do not need to be run in the
@@ -279,6 +285,7 @@ class DNSCache:
         return [entry for entry in list(records.values()) if type_ == entry.type and class_ == entry.class_]
 
     def entries_with_server(self, server: str) -> list[DNSRecord]:
+        """All cached records whose server field matches."""
         if entries := self.service_cache.get(server.lower()):
             return list(entries.values())
         return []

--- a/src/zeroconf/_core.py
+++ b/src/zeroconf/_core.py
@@ -280,6 +280,7 @@ class Zeroconf(QuietLogger):
         return self.record_manager.listeners
 
     async def async_wait(self, timeout: float) -> None:
+        """Suspend the calling task for timeout milliseconds, or less when notified."""
         loop = self.loop
         assert loop is not None
         await wait_for_future_set_or_timeout(loop, self._notify_futures, timeout)
@@ -302,6 +303,13 @@ class Zeroconf(QuietLogger):
         timeout: int = 3000,
         question_type: DNSQuestionType | None = None,
     ) -> ServiceInfo | None:
+        """Look up details for a service on the network.
+
+        Queries for the given fully qualified type and name, waiting up to
+        timeout milliseconds, and returns a populated ServiceInfo or None
+        when nothing answered in time. question_type forces QM or QU
+        questions instead of the automatic choice.
+        """
         info = ServiceInfo(type_, name)
         if info.request(self, timeout, question_type):
             return info
@@ -331,6 +339,12 @@ class Zeroconf(QuietLogger):
         cooperating_responders: bool = False,
         strict: bool = True,
     ) -> None:
+        """Announce a service on the network.
+
+        Probes for conflicts first; with allow_name_change the instance
+        name is renamed until it is unique. May raise EventLoopBlocked
+        when the event loop cannot complete the registration in time.
+        """
         assert self.loop is not None
         run_coro_with_timeout(
             await_awaitable(
@@ -348,6 +362,12 @@ class Zeroconf(QuietLogger):
         cooperating_responders: bool = False,
         strict: bool = True,
     ) -> Awaitable:
+        """Announce a service on the network from the event loop.
+
+        Returns an awaitable that completes once the announcements have
+        been sent. Prefer setting TTLs on the ServiceInfo over the ttl
+        argument.
+        """
         if ttl is not None:
             # ttl argument is used to maintain backward compatibility
             # Setting TTLs via ServiceInfo is preferred
@@ -361,6 +381,11 @@ class Zeroconf(QuietLogger):
         return asyncio.ensure_future(self._async_broadcast_service(info, _REGISTER_TIME, None))
 
     def update_service(self, info: ServiceInfo) -> None:
+        """Publish updated records for an already registered service.
+
+        May raise EventLoopBlocked when the event loop cannot complete
+        the update in time.
+        """
         assert self.loop is not None
         run_coro_with_timeout(
             await_awaitable(self.async_update_service(info)),
@@ -369,6 +394,10 @@ class Zeroconf(QuietLogger):
         )
 
     async def async_update_service(self, info: ServiceInfo) -> Awaitable:
+        """Publish updated records for an already registered service.
+
+        Returns an awaitable that completes once the rebroadcasts finish.
+        """
         self.registry.async_update(info)
         return asyncio.ensure_future(self._async_broadcast_service(info, _REGISTER_TIME, None))
 
@@ -464,6 +493,13 @@ class Zeroconf(QuietLogger):
         timeout: int = 3000,
         question_type: DNSQuestionType | None = None,
     ) -> AsyncServiceInfo | None:
+        """Look up details for a service on the network from the event loop.
+
+        Queries for the given fully qualified type and name, waiting up to
+        timeout milliseconds, and returns a populated AsyncServiceInfo or
+        None when nothing answered in time. question_type forces QM or QU
+        questions instead of the automatic choice.
+        """
         info = AsyncServiceInfo(type_, name)
         if await info.async_request(self, timeout, question_type):
             return info

--- a/src/zeroconf/_dns.py
+++ b/src/zeroconf/_dns.py
@@ -158,6 +158,8 @@ class DNSQuestion(DNSEntry):
 
 
 class DNSRecord(DNSEntry):  # noqa: PLW1641
+    """A DNS entry that also carries a TTL and creation time."""
+
     __slots__ = ("created", "ttl")
 
     def __init__(
@@ -201,10 +203,12 @@ class DNSRecord(DNSEntry):  # noqa: PLW1641
 
     # TODO: Switch to just int here
     def get_remaining_ttl(self, now: _float) -> int | float:
+        """Seconds of TTL left at the given time, never negative."""
         remain = (self.created + (_EXPIRE_FULL_TIME_MS * self.ttl) - now) / 1000.0
         return 0 if remain < 0 else remain
 
     def is_expired(self, now: _float) -> bool:
+        """True once the full TTL has elapsed."""
         return self.created + (_EXPIRE_FULL_TIME_MS * self.ttl) <= now
 
     def is_stale(self, now: _float) -> bool:
@@ -318,10 +322,12 @@ class DNSHinfo(DNSRecord):
         self._hash = hash((self.key, type_, self.class_, cpu, os))
 
     def write(self, out: DNSOutgoing) -> None:
+        """Write the rdata to an outgoing packet."""
         out.write_character_string(self.cpu.encode("utf-8"))
         out.write_character_string(self.os.encode("utf-8"))
 
     def __eq__(self, other: Any) -> bool:
+        """Equal when cpu, os and the entry fields match."""
         return isinstance(other, DNSHinfo) and self._eq(other)
 
     def _eq(self, other: DNSHinfo) -> bool:
@@ -480,6 +486,7 @@ class DNSService(DNSRecord):
         out.write_name(self.server)
 
     def __eq__(self, other: Any) -> bool:
+        """Equal when priority, weight, port, server and the entry fields match."""
         return isinstance(other, DNSService) and self._eq(other)
 
     def _eq(self, other: DNSService) -> bool:
@@ -533,6 +540,7 @@ class DNSNsec(DNSRecord):
         self._hash = hash((self.key, type_, self.class_, next_name, *self.rdtypes))
 
     def write(self, out: DNSOutgoing) -> None:
+        """Write the rdata to an outgoing packet."""
         bitmap = bytearray(b"\0" * 32)
         total_octets = 0
         for rdtype in self.rdtypes:
@@ -604,6 +612,7 @@ class DNSRRSet:
         return self._lookup
 
     def suppresses(self, record: _DNSRecord) -> bool:
+        """True when the set holds a match with over half the record's TTL left."""
         lookup = self._get_lookup()
         other = lookup.get(record)
         if other is None:

--- a/src/zeroconf/_handlers/query_handler.py
+++ b/src/zeroconf/_handlers/query_handler.py
@@ -318,6 +318,7 @@ class QueryHandler:
     def async_response(  # pylint: disable=unused-argument
         self, msgs: list[_DNSIncoming], ucast_source: bool
     ) -> QuestionAnswers | None:
+        """Build the answers for a batch of incoming queries, or None when there are none."""
         strategies: list[_AnswerStrategy] = []
         for msg in msgs:
             for question in msg._questions:

--- a/src/zeroconf/_protocol/incoming.py
+++ b/src/zeroconf/_protocol/incoming.py
@@ -140,9 +140,11 @@ class DNSIncoming:
         raise TypeError(f"cannot pickle {type(self).__name__!r} object")
 
     def is_query(self) -> bool:
+        """True when the QR flag marks the message as a query."""
         return (self.flags & _FLAGS_QR_MASK) == _FLAGS_QR_QUERY
 
     def is_response(self) -> bool:
+        """True when the QR flag marks the message as a response."""
         return (self.flags & _FLAGS_QR_MASK) == _FLAGS_QR_RESPONSE
 
     def has_qu_question(self) -> bool:
@@ -151,6 +153,7 @@ class DNSIncoming:
 
     @property
     def truncated(self) -> bool:
+        """True when the TC bit is set."""
         return (self.flags & _FLAGS_TC) == _FLAGS_TC
 
     @property
@@ -211,6 +214,7 @@ class DNSIncoming:
         return self._answers
 
     def is_probe(self) -> bool:
+        """True when the message carries authority records, marking a probe."""
         return self._num_authorities > 0
 
     def __repr__(self) -> str:
@@ -270,6 +274,7 @@ class DNSIncoming:
             questions.append(question)
 
     def _read_character_string(self) -> str:
+        """Decode a length prefixed character string."""
         if self.offset >= self._data_len:
             raise IncomingDecodeError(
                 f"Character string at offset {self.offset} overruns packet of "
@@ -293,6 +298,7 @@ class DNSIncoming:
         return info
 
     def _read_string(self, length: _int) -> bytes:
+        """Slice the next length bytes out of the buffer."""
         start = self.offset
         end = start + length
         if end > self._data_len:
@@ -481,6 +487,7 @@ class DNSIncoming:
         return rdtypes
 
     def _read_name(self) -> str:
+        """Decode a possibly compressed domain name at the current offset."""
         original_offset = self.offset
         name_str_cache = self._name_str_cache
         is_pure_pointer = False

--- a/src/zeroconf/_protocol/outgoing.py
+++ b/src/zeroconf/_protocol/outgoing.py
@@ -77,6 +77,8 @@ LOGGING_DEBUG = logging.DEBUG
 
 
 class DNSOutgoing:
+    """Builder for outgoing DNS messages."""
+
     __slots__ = (
         "additionals",
         "allow_long",
@@ -115,9 +117,11 @@ class DNSOutgoing:
         self.additionals: list[DNSRecord] = []
 
     def is_query(self) -> bool:
+        """True when the QR flag marks the message as a query."""
         return (self.flags & _FLAGS_QR_MASK) == _FLAGS_QR_QUERY
 
     def is_response(self) -> bool:
+        """True when the QR flag marks the message as a response."""
         return (self.flags & _FLAGS_QR_MASK) == _FLAGS_QR_RESPONSE
 
     def _reset_for_next_packet(self) -> None:
@@ -196,6 +200,7 @@ class DNSOutgoing:
         self.additionals.append(record)
 
     def _write_byte(self, value: int_) -> None:
+        """Append one byte."""
         self.data.append(BYTE_TABLE[value])
         self.size += 1
 
@@ -204,17 +209,20 @@ class DNSOutgoing:
         return SHORT_LOOKUP[value] if value < SHORT_CACHE_MAX else PACK_SHORT(value)
 
     def _insert_short_at_start(self, value: int_) -> None:
-        """Inserts an unsigned short at the start of the packet"""
+        """Prepend an unsigned short as the first chunk."""
         self.data.insert(0, self._get_short(value))
 
     def _replace_short(self, index: int_, value: int_) -> None:
+        """Overwrite the chunk at index with an unsigned short."""
         self.data[index] = self._get_short(value)
 
     def write_short(self, value: int_) -> None:
+        """Append an unsigned short."""
         self.data.append(self._get_short(value))
         self.size += 2
 
     def _write_int(self, value: float | int) -> None:
+        """Append an unsigned 32 bit value."""
         value_as_int = int(value)
         long_bytes = LONG_LOOKUP.get(value_as_int)
         if long_bytes is not None:
@@ -224,6 +232,7 @@ class DNSOutgoing:
         self.size += 4
 
     def write_string(self, value: bytes_) -> None:
+        """Append raw bytes."""
         if TYPE_CHECKING:
             assert isinstance(value, bytes)
         self.data.append(value)
@@ -296,6 +305,7 @@ class DNSOutgoing:
         self._write_byte(index & 0xFF)
 
     def _write_question(self, question: DNSQuestion_) -> bool:
+        """Encode one question, or roll back and return False when it cannot fit."""
         start_data_length = len(self.data)
         start_size = self.size
         self.write_name(question.name)

--- a/src/zeroconf/_services/browser.py
+++ b/src/zeroconf/_services/browser.py
@@ -576,6 +576,12 @@ class _ServiceBrowserBase(RecordUpdateListener):
         delay: int = _BROWSER_TIME,
         question_type: DNSQuestionType | None = None,
     ) -> None:
+        """Start watching one or more fully qualified service types.
+
+        Events are delivered to the given ServiceListener or handler
+        callables; delay sets the interval between the periodic queries
+        and question_type forces QM or QU questions.
+        """
         assert handlers or listener, "You need to specify at least one handler"
         self.types: set[str] = set(type_ if isinstance(type_, list) else [type_])
         for check_type_ in self.types:

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -151,6 +151,15 @@ def instance_name_from_service_info(info: ServiceInfo, strict: bool = True) -> s
 
 
 class ServiceInfo(RecordUpdateListener):
+    """Everything known about a single service instance.
+
+    Holds the instance name, its type, the host server name, port,
+    addresses, priority, weight, and the properties dictionary carried
+    by the TXT record (pass a dict, or bytes to reuse a raw TXT
+    payload). Build one to register a service, or let request or
+    async_request populate one from the network.
+    """
+
     __slots__ = (
         "_decoded_properties",
         "_dns_address_cache",
@@ -324,6 +333,7 @@ class ServiceInfo(RecordUpdateListener):
         self._get_address_and_nsec_records_cache = None
 
     async def async_wait(self, timeout: float, loop: asyncio.AbstractEventLoop | None = None) -> None:
+        """Suspend the calling task for timeout milliseconds, or less when new records arrive."""
         if not self._new_records_futures:
             self._new_records_futures = set()
         await wait_for_future_set_or_timeout(
@@ -540,6 +550,7 @@ class ServiceInfo(RecordUpdateListener):
             self._ipv4_addresses = self._get_ip_addresses_from_cache_lifo(zc, now, _TYPE_A)
 
     def async_update_records(self, zc: Zeroconf, now: float_, records: list[RecordUpdate_]) -> None:
+        """Merge a batch of record updates into this object and wake any waiters."""
         new_records_futures = self._new_records_futures
         updated: bool = False
         nsec_records = None
@@ -931,6 +942,12 @@ class ServiceInfo(RecordUpdateListener):
         addr: str | None = None,
         port: int = _MDNS_PORT,
     ) -> bool:
+        """Populate this object from the network, returning True on success.
+
+        Waits up to timeout milliseconds for the answers to arrive; addr
+        and port direct the queries at a specific responder instead of
+        the multicast group.
+        """
         assert zc.loop is not None, "Zeroconf instance must have a loop, was it not started?"
         assert zc.loop.is_running(), "Zeroconf instance loop must be running, was it already stopped?"
         if zc.loop == get_running_loop():
@@ -957,6 +974,12 @@ class ServiceInfo(RecordUpdateListener):
         addr: str | None = None,
         port: int = _MDNS_PORT,
     ) -> bool:
+        """Populate this object from the network, returning True on success.
+
+        Event loop flavor of request; waits up to timeout milliseconds
+        for the answers to arrive, and addr and port direct the queries
+        at a specific responder instead of the multicast group.
+        """
         if not zc.started:
             await zc.async_wait_for_start()
 

--- a/src/zeroconf/asyncio.py
+++ b/src/zeroconf/asyncio.py
@@ -46,6 +46,9 @@ __all__ = [
 
 
 class AsyncServiceBrowser(_ServiceBrowserBase):
+    """Event loop browser that fires ServiceListener callbacks as services
+    of the requested types appear, change, and disappear."""
+
     def __init__(
         self,
         zeroconf: Zeroconf,
@@ -158,6 +161,11 @@ class AsyncZeroconf:
         cooperating_responders: bool = False,
         strict: bool = True,
     ) -> Awaitable:
+        """Announce a service on the network.
+
+        Returns an awaitable that completes once the announcements have
+        been sent.
+        """
         return await self.zeroconf.async_register_service(
             info, ttl, allow_name_change, cooperating_responders, strict
         )
@@ -180,6 +188,10 @@ class AsyncZeroconf:
         return await self.zeroconf.async_unregister_service(info)
 
     async def async_update_service(self, info: ServiceInfo) -> Awaitable:
+        """Publish updated records for an already registered service.
+
+        Returns an awaitable that completes once the rebroadcasts finish.
+        """
         return await self.zeroconf.async_update_service(info)
 
     async def async_update_interfaces(
@@ -214,18 +226,31 @@ class AsyncZeroconf:
         timeout: int = 3000,
         question_type: DNSQuestionType | None = None,
     ) -> AsyncServiceInfo | None:
+        """Look up details for a service on the network.
+
+        Queries for the given fully qualified type and name, waiting up to
+        timeout milliseconds, and returns a populated AsyncServiceInfo or
+        None when nothing answered in time. question_type forces QM or QU
+        questions instead of the automatic choice.
+        """
         return await self.zeroconf.async_get_service_info(type_, name, timeout, question_type)
 
     async def async_add_service_listener(self, type_: str, listener: ServiceListener) -> None:
+        """Browse a service type, delivering events to the listener.
+
+        Replaces any browser previously registered for the same listener.
+        """
         await self.async_remove_service_listener(listener)
         self.async_browsers[listener] = AsyncServiceBrowser(self.zeroconf, type_, listener)
 
     async def async_remove_service_listener(self, listener: ServiceListener) -> None:
+        """Stop and drop the browser registered for the listener, if any."""
         if listener in self.async_browsers:
             await self.async_browsers[listener].async_cancel()
             del self.async_browsers[listener]
 
     async def async_remove_all_service_listeners(self) -> None:
+        """Stop and drop every browser started through add_service_listener."""
         await asyncio.gather(
             *(self.async_remove_service_listener(listener) for listener in list(self.async_browsers))
         )


### PR DESCRIPTION
## Summary
Follow up to #1847 for #1835. Adds freshly written docstrings for every public member that lost its rendered API documentation in the derivative prose removal, terse one liners for the internal helpers that earn them, and two brand new async example scripts replacing the deleted ones.

## Details
- every docstring here was authored new; a four word n-gram comparison against the deleted text shows no shared prose beyond one generic phrase, and a six word comparison against the 2009 pyzeroconf and 2014 v0.14-wmcbrine trees comes back empty
- the new examples use `asyncio.create_task` and `asyncio.Event` instead of the legacy `ensure_future` and sleep loops

## Test plan
- [x] full suite passes
- [x] both examples run under `--help` and pass ruff
- [x] verified no public member of `zeroconf` or `zeroconf.asyncio` lost documentation relative to master except pre existing gaps
