### PR TITLE
revert: remove wmcbrine's readme fork note and six short derivative docstrings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,18 +24,6 @@ This is fork of pyzeroconf, Multicast DNS Service Discovery for Python,
 originally by Paul Scott-Murphy (https://github.com/paulsm/pyzeroconf),
 modified by William McBrine (https://github.com/wmcbrine/pyzeroconf).
 
-The original William McBrine's fork note::
-
-    This fork is used in all of my TiVo-related projects: HME for Python
-    (and therefore HME/VLC), Network Remote, Remote Proxy, and pyTivo.
-    Before this, I was tracking the changes for zeroconf.py in three
-    separate repos. I figured I should have an authoritative source.
-
-    Although I make changes based on my experience with TiVos, I expect that
-    they're generally applicable. This version also includes patches found
-    on the now-defunct (?) Launchpad repo of pyzeroconf, and elsewhere
-    around the net -- not always well-documented, sorry.
-
 Compatible with:
 
 * Bonjour

--- a/src/zeroconf/_cache.py
+++ b/src/zeroconf/_cache.py
@@ -66,8 +66,6 @@ def _remove_key(cache: _DNSRecordCacheType, key: _str, record: _DNSRecord) -> No
 
 
 class DNSCache:
-    """A cache of DNS entries."""
-
     def __init__(self) -> None:
         self.cache: _DNSRecordCacheType = {}
         self._expire_heap: list[tuple[float, DNSRecord]] = []

--- a/src/zeroconf/_dns.py
+++ b/src/zeroconf/_dns.py
@@ -296,8 +296,6 @@ class DNSAddress(DNSRecord):
 
 
 class DNSHinfo(DNSRecord):
-    """A DNS host information record"""
-
     __slots__ = ("_hash", "cpu", "os")
 
     def __init__(

--- a/src/zeroconf/_protocol/incoming.py
+++ b/src/zeroconf/_protocol/incoming.py
@@ -235,7 +235,6 @@ class DNSIncoming:
         )
 
     def _read_header(self) -> None:
-        """Reads header portion of packet"""
         offset = self.offset
         if offset + 12 > self._data_len:
             raise IncomingDecodeError(
@@ -252,7 +251,6 @@ class DNSIncoming:
         self._num_additionals = buf[offset + 10] << 8 | buf[offset + 11]
 
     def _read_questions(self) -> None:
-        """Reads questions section of packet"""
         buf = self._buf
         questions = self._questions
         for _ in range(self._num_questions):

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -252,7 +252,6 @@ class ServiceInfo(RecordUpdateListener):
 
     @property
     def name(self) -> str:
-        """The name of the service."""
         return self._name
 
     @name.setter

--- a/src/zeroconf/_utils/ipaddress.py
+++ b/src/zeroconf/_utils/ipaddress.py
@@ -66,7 +66,6 @@ class ZeroconfIPv4Address(IPv4Address):
 
     @property
     def is_loopback(self) -> bool:
-        """Return True if this is a loop back."""
         return self._is_loopback
 
 
@@ -103,7 +102,6 @@ class ZeroconfIPv6Address(IPv6Address):
 
     @property
     def is_loopback(self) -> bool:
-        """Return True if this is a loop back."""
         return self._is_loopback
 
 


### PR DESCRIPTION
## Summary
Third removal pass for #1835, from a deeper audit run at five word sensitivity over every blob of all 53 pyzeroconf era commits, with the readme and docs added to the scanned corpus. Two things the earlier passes could not see: the readme still quoted wmcbrine's original fork note verbatim, and four 2009 docstrings of exactly five words sat under the previous six word threshold. Both are deleted here, along with two generic one liners that echoed the 2009 sentence patterns, deleted out of caution.

Deletion only; the suite stays green since it is prose only. The follow up restores fresh docstrings and a freshly written history paragraph for the readme.

## Test plan
- [x] full suite passes
- [x] the deep audit now reports no shared prose with any pyzeroconf era blob outside the license headers and factual attribution lines
