### PR TITLE
chore: fresh docstrings for the short-prose sites and readme rewords

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -122,7 +122,7 @@ Here's how to discover services:
     If you want to customize that you need to specify ``interfaces`` argument when
     constructing ``Zeroconf`` object (see the code for details).
 
-If you don't know which service type to browse for, try:
+To see which service types are present on the network, try:
 
 .. code-block:: python
 

--- a/README.rst
+++ b/README.rst
@@ -88,6 +88,8 @@ The easiest way to install python-zeroconf is using pip::
 How do I use it?
 ================
 
+Here's how to discover services:
+
 .. code-block:: python
 
     from zeroconf import ServiceBrowser, ServiceListener, Zeroconf
@@ -119,6 +121,8 @@ How do I use it?
     Discovery and service registration use *all* available network interfaces by default.
     If you want to customize that you need to specify ``interfaces`` argument when
     constructing ``Zeroconf`` object (see the code for details).
+
+If you don't know which service type to browse for, try:
 
 .. code-block:: python
 

--- a/src/zeroconf/_cache.py
+++ b/src/zeroconf/_cache.py
@@ -66,6 +66,8 @@ def _remove_key(cache: _DNSRecordCacheType, key: _str, record: _DNSRecord) -> No
 
 
 class DNSCache:
+    """Store of received DNS records, indexed for fast lookup."""
+
     def __init__(self) -> None:
         self.cache: _DNSRecordCacheType = {}
         self._expire_heap: list[tuple[float, DNSRecord]] = []

--- a/src/zeroconf/_dns.py
+++ b/src/zeroconf/_dns.py
@@ -296,6 +296,8 @@ class DNSAddress(DNSRecord):
 
 
 class DNSHinfo(DNSRecord):
+    """HINFO record carrying the host's cpu and os strings."""
+
     __slots__ = ("_hash", "cpu", "os")
 
     def __init__(

--- a/src/zeroconf/_protocol/incoming.py
+++ b/src/zeroconf/_protocol/incoming.py
@@ -235,6 +235,7 @@ class DNSIncoming:
         )
 
     def _read_header(self) -> None:
+        """Unpack the fixed twelve byte message header."""
         offset = self.offset
         if offset + 12 > self._data_len:
             raise IncomingDecodeError(
@@ -251,6 +252,7 @@ class DNSIncoming:
         self._num_additionals = buf[offset + 10] << 8 | buf[offset + 11]
 
     def _read_questions(self) -> None:
+        """Parse the question entries."""
         buf = self._buf
         questions = self._questions
         for _ in range(self._num_questions):

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -252,6 +252,7 @@ class ServiceInfo(RecordUpdateListener):
 
     @property
     def name(self) -> str:
+        """Fully qualified name of this service instance."""
         return self._name
 
     @name.setter

--- a/src/zeroconf/_utils/ipaddress.py
+++ b/src/zeroconf/_utils/ipaddress.py
@@ -56,14 +56,17 @@ class ZeroconfIPv4Address(IPv4Address):
 
     @property
     def is_link_local(self) -> bool:
+        """True for a link-local address."""
         return self._is_link_local
 
     @property
     def is_unspecified(self) -> bool:
+        """True for an unspecified address."""
         return self._is_unspecified
 
     @property
     def is_loopback(self) -> bool:
+        """True for a loopback address."""
         return self._is_loopback
 
 
@@ -90,14 +93,17 @@ class ZeroconfIPv6Address(IPv6Address):
 
     @property
     def is_link_local(self) -> bool:
+        """True for a link-local address."""
         return self._is_link_local
 
     @property
     def is_unspecified(self) -> bool:
+        """True for an unspecified address."""
         return self._is_unspecified
 
     @property
     def is_loopback(self) -> bool:
+        """True for a loopback address."""
         return self._is_loopback
 
 


### PR DESCRIPTION
## Summary
Follow up to #1849 for #1835. Adds freshly written docstrings for the six sites deleted there, and rewords three readme and docstring lines that still shared five word runs with pyzeroconf era sentence patterns.

After this, the deep audit at five word sensitivity over every blob of all 53 pyzeroconf era commits reports exactly two remaining lines in the whole corpus: the factual attribution sentence naming the original authors, and the LGPL license statement in the readme, which the relicense itself replaces.

## Test plan
- [x] full suite passes
- [x] deep audit re-run on this branch confirms the two line residue described above
