### PR TITLE
revert: remove prose echoing pyzeroconf sentence patterns

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,8 +88,6 @@ The easiest way to install python-zeroconf is using pip::
 How do I use it?
 ================
 
-Here's an example of browsing for a service:
-
 .. code-block:: python
 
     from zeroconf import ServiceBrowser, ServiceListener, Zeroconf
@@ -121,8 +119,6 @@ Here's an example of browsing for a service:
     Discovery and service registration use *all* available network interfaces by default.
     If you want to customize that you need to specify ``interfaces`` argument when
     constructing ``Zeroconf`` object (see the code for details).
-
-If you don't know the name of the service you need to browse for, try:
 
 .. code-block:: python
 

--- a/src/zeroconf/_utils/ipaddress.py
+++ b/src/zeroconf/_utils/ipaddress.py
@@ -56,12 +56,10 @@ class ZeroconfIPv4Address(IPv4Address):
 
     @property
     def is_link_local(self) -> bool:
-        """Return True if this is a link-local address."""
         return self._is_link_local
 
     @property
     def is_unspecified(self) -> bool:
-        """Return True if this is an unspecified address."""
         return self._is_unspecified
 
     @property
@@ -92,12 +90,10 @@ class ZeroconfIPv6Address(IPv6Address):
 
     @property
     def is_link_local(self) -> bool:
-        """Return True if this is a link-local address."""
         return self._is_link_local
 
     @property
     def is_unspecified(self) -> bool:
-        """Return True if this is an unspecified address."""
         return self._is_unspecified
 
     @property


### PR DESCRIPTION
## Summary
Fourth removal pass for #1835, splitting out the deletions that #1850 previously mixed with its additions so deletes stay in delete PRs. Removes the four is_link_local and is_unspecified docstrings and two readme sentences that still shared five word runs with pyzeroconf era sentence patterns. Deletion only; #1850 stacks on this with the freshly written replacements.

## Test plan
- [x] suite passes; prose only