### PR TITLE
revert: remove short prose found by the character level audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,8 +187,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.ref }}
 
-      - name: Create local branch name
-        env:
+      - env:
           BRANCH: ${{ github.head_ref || github.ref_name }}
         run: git switch -C "$BRANCH"
 
@@ -222,8 +221,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.ref }}
 
-      - name: Create local branch name
-        env:
+      - env:
           BRANCH: ${{ github.ref_name }}
         run: git switch -C "$BRANCH"
 

--- a/src/zeroconf/_dns.py
+++ b/src/zeroconf/_dns.py
@@ -106,8 +106,6 @@ class DNSEntry:  # noqa: PLW1641
 
 
 class DNSQuestion(DNSEntry):
-    """A DNS question entry"""
-
     __slots__ = ("_hash",)
 
     def __init__(self, name: str, type_: int, class_: int) -> None:
@@ -234,8 +232,6 @@ class DNSRecord(DNSEntry):  # noqa: PLW1641
 
 
 class DNSAddress(DNSRecord):
-    """A DNS address record"""
-
     __slots__ = ("_hash", "address", "scope_id")
 
     def __init__(
@@ -342,8 +338,6 @@ class DNSHinfo(DNSRecord):
 
 
 class DNSPointer(DNSRecord):
-    """A DNS pointer record"""
-
     __slots__ = ("_hash", "alias", "alias_key")
 
     def __init__(
@@ -395,8 +389,6 @@ class DNSPointer(DNSRecord):
 
 
 class DNSText(DNSRecord):
-    """A DNS text record"""
-
     __slots__ = ("_hash", "text")
 
     def __init__(
@@ -439,8 +431,6 @@ class DNSText(DNSRecord):
 
 
 class DNSService(DNSRecord):
-    """A DNS service record"""
-
     __slots__ = ("_hash", "port", "priority", "server", "server_key", "weight")
 
     def __init__(

--- a/tests/services/test_browser.py
+++ b/tests/services/test_browser.py
@@ -524,7 +524,6 @@ def test_first_query_delay():
     first_query_time = None
 
     def send(out, addr=const._MDNS_ADDR, port=const._MDNS_PORT):
-        """Sends an outgoing packet."""
         nonlocal first_query_time
         if first_query_time is None:
             first_query_time = current_time_millis()
@@ -578,7 +577,6 @@ async def test_asking_default_is_asking_qm_questions_after_the_first_qu(quick_ti
     questions: list[list[DNSQuestion]] = []
 
     def send(out, addr=const._MDNS_ADDR, port=const._MDNS_PORT, v6_flow_scope=()):
-        """Sends an outgoing packet."""
         pout = r.DNSIncoming(out.packets()[0])
         questions.append(pout.questions)
         got_query.set()
@@ -680,7 +678,6 @@ async def test_ttl_refresh_cancelled_rescue_query(quick_timing: None) -> None:
     packets = []
 
     def send(out, addr=const._MDNS_ADDR, port=const._MDNS_PORT, v6_flow_scope=()):
-        """Sends an outgoing packet."""
         pout = r.DNSIncoming(out.packets()[0])
         packets.append(pout)
         got_query.set()
@@ -773,7 +770,6 @@ async def test_asking_qm_questions():
     first_outgoing = None
 
     def send(out, addr=const._MDNS_ADDR, port=const._MDNS_PORT):
-        """Sends an outgoing packet."""
         nonlocal first_outgoing
         if first_outgoing is None:
             first_outgoing = out
@@ -813,7 +809,6 @@ async def test_asking_qu_questions():
     first_outgoing = None
 
     def send(out, addr=const._MDNS_ADDR, port=const._MDNS_PORT):
-        """Sends an outgoing packet."""
         nonlocal first_outgoing
         if first_outgoing is None:
             first_outgoing = out
@@ -1257,7 +1252,6 @@ async def test_query_scheduler():
     sends: list[r.DNSIncoming] = []
 
     def send(out, addr=const._MDNS_ADDR, port=const._MDNS_PORT, v6_flow_scope=()):
-        """Sends an outgoing packet."""
         pout = r.DNSIncoming(out.packets()[0])
         sends.append(pout)
 
@@ -1350,7 +1344,6 @@ async def test_query_scheduler_rescue_records():
     sends: list[r.DNSIncoming] = []
 
     def send(out, addr=const._MDNS_ADDR, port=const._MDNS_PORT, v6_flow_scope=()):
-        """Sends an outgoing packet."""
         pout = r.DNSIncoming(out.packets()[0])
         sends.append(pout)
 
@@ -1664,7 +1657,6 @@ async def test_close_zeroconf_without_browser_before_start_up_queries(quick_timi
     sends: list[r.DNSIncoming] = []
 
     def send(out, addr=const._MDNS_ADDR, port=const._MDNS_PORT, v6_flow_scope=()):
-        """Sends an outgoing packet."""
         pout = r.DNSIncoming(out.packets()[0])
         sends.append(pout)
 
@@ -1732,7 +1724,6 @@ async def test_close_zeroconf_without_browser_after_start_up_queries(quick_timin
     sends: list[r.DNSIncoming] = []
 
     def send(out, addr=const._MDNS_ADDR, port=const._MDNS_PORT, v6_flow_scope=()):
-        """Sends an outgoing packet."""
         pout = r.DNSIncoming(out.packets()[0])
         sends.append(pout)
 

--- a/tests/services/test_info.py
+++ b/tests/services/test_info.py
@@ -273,7 +273,6 @@ class TestServiceInfo(unittest.TestCase):
         last_sent: r.DNSOutgoing | None = None
 
         def send(out, addr=const._MDNS_ADDR, port=const._MDNS_PORT, v6_flow_scope=()):
-            """Sends an outgoing packet."""
             nonlocal last_sent
 
             last_sent = out
@@ -413,7 +412,6 @@ class TestServiceInfo(unittest.TestCase):
         last_sent: r.DNSOutgoing | None = None
 
         def send(out, addr=const._MDNS_ADDR, port=const._MDNS_PORT, v6_flow_scope=()):
-            """Sends an outgoing packet."""
             nonlocal last_sent
 
             last_sent = out
@@ -1254,7 +1252,6 @@ def test_asking_qu_questions(quick_request_timing):
     first_outgoing = None
 
     def send(out, addr=const._MDNS_ADDR, port=const._MDNS_PORT):
-        """Sends an outgoing packet."""
         nonlocal first_outgoing
         if first_outgoing is None:
             first_outgoing = out
@@ -1280,7 +1277,6 @@ def test_asking_qm_questions(quick_request_timing):
     first_outgoing = None
 
     def send(out, addr=const._MDNS_ADDR, port=const._MDNS_PORT):
-        """Sends an outgoing packet."""
         nonlocal first_outgoing
         if first_outgoing is None:
             first_outgoing = out
@@ -1317,7 +1313,6 @@ async def test_we_try_four_times_with_random_delay():
     request_count = 0
 
     def async_send(out, addr=const._MDNS_ADDR, port=const._MDNS_PORT):
-        """Sends an outgoing packet."""
         nonlocal request_count
         request_count += 1
 
@@ -2161,7 +2156,6 @@ async def test_unicast_flag_if_requested() -> None:
     aiozc = AsyncZeroconf(interfaces=["127.0.0.1"])
 
     def async_send(out: DNSOutgoing, addr: str | None = None, port: int = const._MDNS_PORT) -> None:
-        """Sends an outgoing packet."""
         for question in out.questions:
             assert question.unicast
 

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -1027,7 +1027,6 @@ async def test_integration(quick_timing: None) -> None:
     packets = []
 
     def send(out, addr=const._MDNS_ADDR, port=const._MDNS_PORT, v6_flow_scope=()):
-        """Sends an outgoing packet."""
         pout = DNSIncoming(out.packets()[0])
         packets.append(pout)
         last_answers = pout.answers()
@@ -1191,7 +1190,6 @@ async def test_info_asking_default_is_asking_qm_questions_after_the_first_qu(qui
     second_outgoing = None
 
     def send(out, addr=const._MDNS_ADDR, port=const._MDNS_PORT):
-        """Sends an outgoing packet."""
         nonlocal first_outgoing
         nonlocal second_outgoing
         if out.questions:

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -72,7 +72,6 @@ class TestRegistrar(unittest.TestCase):
             return const._DNS_OTHER_TTL
 
         def _process_outgoing_packet(out):
-            """Sends an outgoing packet."""
             nonlocal nbr_answers, nbr_additionals, nbr_authorities
 
             for answer, _ in out.answers:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -29,16 +29,6 @@ def teardown_module():
 
 
 class Names(unittest.TestCase):
-    def test_long_name(self):
-        generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
-        question = r.DNSQuestion(
-            "this.is.a.very.long.name.with.lots.of.parts.in.it.local.",
-            const._TYPE_SRV,
-            const._CLASS_IN,
-        )
-        generated.add_question(question)
-        r.DNSIncoming(generated.packets()[0])
-
     def test_exceedingly_long_name(self):
         generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
         name = f"{'part.' * 1000}local."


### PR DESCRIPTION
## Summary
Fifth removal pass for #1835. A character level audit at 45 character sensitivity over every pyzeroconf era blob and all tracked files caught prose too short for the word level passes: five four word class docstrings in `_dns.py` verbatim from 2009, the 2009 send docstring copied into eighteen test helpers, the whole `test_long_name` function whose distinctive test string came from zunittest.py, and the two workflow step names authored by eshattow. Deletion only; one test is deleted whole and comes back rewritten in the follow up.

## Test plan
- [x] suite passes (513, one test deleted pending its rewrite)
- [x] every remaining character level match is API compelled code or published mechanical matches