### PR TITLE
chore: fresh docstrings, test name string and workflow step names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,8 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.ref }}
 
-      - env:
+      - name: Switch to the head branch
+        env:
           BRANCH: ${{ github.head_ref || github.ref_name }}
         run: git switch -C "$BRANCH"
 
@@ -221,7 +222,8 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.ref }}
 
-      - env:
+      - name: Switch to the head branch
+        env:
           BRANCH: ${{ github.ref_name }}
         run: git switch -C "$BRANCH"
 

--- a/src/zeroconf/_dns.py
+++ b/src/zeroconf/_dns.py
@@ -106,6 +106,8 @@ class DNSEntry:  # noqa: PLW1641
 
 
 class DNSQuestion(DNSEntry):
+    """A question a resolver asks about a name."""
+
     __slots__ = ("_hash",)
 
     def __init__(self, name: str, type_: int, class_: int) -> None:
@@ -232,6 +234,8 @@ class DNSRecord(DNSEntry):  # noqa: PLW1641
 
 
 class DNSAddress(DNSRecord):
+    """Record holding an IPv4 or IPv6 address."""
+
     __slots__ = ("_hash", "address", "scope_id")
 
     def __init__(
@@ -338,6 +342,8 @@ class DNSHinfo(DNSRecord):
 
 
 class DNSPointer(DNSRecord):
+    """PTR record naming a service instance."""
+
     __slots__ = ("_hash", "alias", "alias_key")
 
     def __init__(
@@ -389,6 +395,8 @@ class DNSPointer(DNSRecord):
 
 
 class DNSText(DNSRecord):
+    """TXT record carrying the service properties."""
+
     __slots__ = ("_hash", "text")
 
     def __init__(
@@ -431,6 +439,8 @@ class DNSText(DNSRecord):
 
 
 class DNSService(DNSRecord):
+    """SRV record with the target host, port, priority and weight."""
+
     __slots__ = ("_hash", "port", "priority", "server", "server_key", "weight")
 
     def __init__(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -29,6 +29,16 @@ def teardown_module():
 
 
 class Names(unittest.TestCase):
+    def test_long_name(self):
+        generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
+        question = r.DNSQuestion(
+            "an.excessively.deep.chain.of.dns.labels.used.for.testing.local.",
+            const._TYPE_SRV,
+            const._CLASS_IN,
+        )
+        generated.add_question(question)
+        r.DNSIncoming(generated.packets()[0])
+
     def test_exceedingly_long_name(self):
         generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
         name = f"{'part.' * 1000}local."


### PR DESCRIPTION
## Summary
Follow up to #1852 for #1835. Adds freshly written class docstrings for the five DNS record classes, rewrites `test_long_name` with a new test string, and names the two workflow steps fresh. The eighteen test helper docstrings stay deleted per the terse docstring rule.

A four word n-gram comparison against the deleted text shares only the test's API compelled call lines; the character level audit on this branch reports no remaining prose matches.

## Test plan
- [x] full suite passes, test_long_name restored
- [x] character audit re-run clean on the restored files