### PR TITLE
revert: remove prose found by the fuzzy paraphrase audit

### DIFF
--- a/src/zeroconf/_core.py
+++ b/src/zeroconf/_core.py
@@ -602,12 +602,6 @@ class Zeroconf(QuietLogger):
         return out
 
     async def async_unregister_all_services(self) -> None:
-        """Unregister all registered services.
-
-        Unlike async_register_service and async_unregister_service, this
-        method does not return a future and is always expected to be
-        awaited since its only called at shutdown.
-        """
         # Send Goodbye packets https://datatracker.ietf.org/doc/html/rfc6762#section-10.1
         out = self.generate_unregister_all_services()
         if not out:
@@ -618,12 +612,6 @@ class Zeroconf(QuietLogger):
             self.async_send(out)
 
     def unregister_all_services(self) -> None:
-        """Unregister all registered services.
-
-        While it is not expected during normal operation,
-        this function may raise EventLoopBlocked if the underlying
-        call to `async_unregister_all_services` cannot be completed.
-        """
         assert self.loop is not None
         run_coro_with_timeout(
             self.async_unregister_all_services(),
@@ -712,7 +700,6 @@ class Zeroconf(QuietLogger):
         v6_flow_scope: tuple[()] | tuple[int, int] = (),
         transport: _WrappedTransport | None = None,
     ) -> None:
-        """Sends an outgoing packet threadsafe."""
         assert self.loop is not None
         self.loop.call_soon_threadsafe(self.async_send, out, addr, port, v6_flow_scope, transport)
 
@@ -724,7 +711,6 @@ class Zeroconf(QuietLogger):
         v6_flow_scope: tuple[()] | tuple[int, int] = (),
         transport: _WrappedTransport | None = None,
     ) -> None:
-        """Sends an outgoing packet."""
         if self.done:
             return
 

--- a/src/zeroconf/_dns.py
+++ b/src/zeroconf/_dns.py
@@ -83,7 +83,6 @@ class DNSEntry:  # noqa: PLW1641
         return self.key == other.key and self.type == other.type and self.class_ == other.class_
 
     def __eq__(self, other: Any) -> bool:
-        """Equality test on key (lowercase name), type, and class"""
         return isinstance(other, DNSEntry) and self._dns_entry_matches(other)
 
     @staticmethod
@@ -125,7 +124,6 @@ class DNSQuestion(DNSEntry):
         return self._hash
 
     def __eq__(self, other: Any) -> bool:
-        """Tests equality on dns question."""
         return isinstance(other, DNSQuestion) and self._dns_entry_matches(other)
 
     @property
@@ -379,11 +377,9 @@ class DNSPointer(DNSRecord):
         out.write_name(self.alias)
 
     def __eq__(self, other: Any) -> bool:
-        """Tests equality on alias."""
         return isinstance(other, DNSPointer) and self._eq(other)
 
     def _eq(self, other: DNSPointer) -> bool:
-        """Tests equality on alias."""
         return self.alias_key == other.alias_key and self._dns_entry_matches(other)
 
     def __hash__(self) -> int:
@@ -425,11 +421,9 @@ class DNSText(DNSRecord):
         return self._hash
 
     def __eq__(self, other: Any) -> bool:
-        """Tests equality on text."""
         return isinstance(other, DNSText) and self._eq(other)
 
     def _eq(self, other: DNSText) -> bool:
-        """Tests equality on text."""
         return self.text == other.text and self._dns_entry_matches(other)
 
     def __repr__(self) -> str:
@@ -508,8 +502,6 @@ class DNSService(DNSRecord):
 
 
 class DNSNsec(DNSRecord):
-    """A DNS NSEC record"""
-
     __slots__ = ("_hash", "next_name", "rdtypes")
 
     def __init__(
@@ -560,11 +552,9 @@ class DNSNsec(DNSRecord):
         out.write_string(out_bytes)
 
     def __eq__(self, other: Any) -> bool:
-        """Tests equality on next_name and rdtypes."""
         return isinstance(other, DNSNsec) and self._eq(other)
 
     def _eq(self, other: DNSNsec) -> bool:
-        """Tests equality on next_name and rdtypes."""
         return (
             self.next_name == other.next_name
             and self.rdtypes == other.rdtypes

--- a/src/zeroconf/_protocol/incoming.py
+++ b/src/zeroconf/_protocol/incoming.py
@@ -447,7 +447,6 @@ class DNSIncoming:
         return None
 
     def _read_bitmap(self, end: _int) -> list[int]:
-        """Reads an NSEC bitmap from the packet."""
         rdtypes = []
         if end > self._data_len:
             raise IncomingDecodeError(

--- a/src/zeroconf/_protocol/outgoing.py
+++ b/src/zeroconf/_protocol/outgoing.py
@@ -162,41 +162,6 @@ class DNSOutgoing:
         self.authorities.append(record)
 
     def add_additional_answer(self, record: DNSRecord) -> None:
-        """Adds an additional answer
-
-        From: RFC 6763, DNS-Based Service Discovery, February 2013
-
-        12.  DNS Additional Record Generation
-
-           DNS has an efficiency feature whereby a DNS server may place
-           additional records in the additional section of the DNS message.
-           These additional records are records that the client did not
-           explicitly request, but the server has reasonable grounds to expect
-           that the client might request them shortly, so including them can
-           save the client from having to issue additional queries.
-
-           This section recommends which additional records SHOULD be generated
-           to improve network efficiency, for both Unicast and Multicast DNS-SD
-           responses.
-
-        12.1.  PTR Records
-
-           When including a DNS-SD Service Instance Enumeration or Selective
-           Instance Enumeration (subtype) PTR record in a response packet, the
-           server/responder SHOULD include the following additional records:
-
-           o  The SRV record(s) named in the PTR rdata.
-           o  The TXT record(s) named in the PTR rdata.
-           o  All address records (type "A" and "AAAA") named in the SRV rdata.
-
-        12.2.  SRV Records
-
-           When including an SRV record in a response packet, the
-           server/responder SHOULD include the following additional records:
-
-           o  All address records (type "A" and "AAAA") named in the SRV rdata.
-
-        """
         self.additionals.append(record)
 
     def _write_byte(self, value: int_) -> None:

--- a/src/zeroconf/_utils/name.py
+++ b/src/zeroconf/_utils/name.py
@@ -41,8 +41,6 @@ def service_type_name(type_: str, *, strict: bool = True) -> str:  # pylint: dis
     """
     Validate a fully qualified service name, instance or subtype. [rfc6763]
 
-    Returns fully qualified service name.
-
     Domain names used by mDNS-SD take the following forms:
 
                    <sn> . <_tcp|_udp> . local.

--- a/src/zeroconf/_utils/time.py
+++ b/src/zeroconf/_utils/time.py
@@ -28,13 +28,6 @@ _float = float
 
 
 def current_time_millis() -> _float:
-    """Current time in milliseconds.
-
-    The current implementation uses `time.monotonic`
-    but may change in the future.
-
-    The design requires the time to match asyncio.loop.time()
-    """
     return time.monotonic() * 1000
 
 

--- a/src/zeroconf/asyncio.py
+++ b/src/zeroconf/asyncio.py
@@ -171,12 +171,6 @@ class AsyncZeroconf:
         )
 
     async def async_unregister_all_services(self) -> None:
-        """Unregister all registered services.
-
-        Unlike async_register_service and async_unregister_service, this
-        method does not return a future and is always expected to be
-        awaited since its only called at shutdown.
-        """
         await self.zeroconf.async_unregister_all_services()
 
     async def async_unregister_service(self, info: ServiceInfo) -> Awaitable:


### PR DESCRIPTION
## Summary
Sixth removal pass for #1835. Every earlier audit required exact runs, so a reworded line escaped them; this pass used fuzzy line matching (token overlap plus sequence ratio) between every pyzeroconf era prose line and current master. It caught the production copies of the 2009 send docstring in `_core.py`, the verbatim unregister all services docstrings, the remaining tests equality family in `_dns.py`, the surviving first line of the `add_additional_answer` docstring, and derivative lines in `_utils/time.py` and `_utils/name.py`, plus two modern NSEC docstrings that copied the 2009 sentence templates, deleted for consistency. The RFC 6763 quotation went with its enclosing docstring and returns with the fresh one.

Deletion only, suite stays green. The follow up restores fresh text.

## Test plan
- [x] full suite passes
- [x] fuzzy audit re-run reports only generic scenes a faire lines (unit tests for X, shebangs)