### PR TITLE
chore: fresh docstrings for the fuzzy audit sites

### DIFF
--- a/src/zeroconf/_core.py
+++ b/src/zeroconf/_core.py
@@ -602,6 +602,11 @@ class Zeroconf(QuietLogger):
         return out
 
     async def async_unregister_all_services(self) -> None:
+        """Send goodbye packets for every registered service and drop them all.
+
+        Runs only at shutdown, so unlike the single service calls it
+        returns nothing to await separately.
+        """
         # Send Goodbye packets https://datatracker.ietf.org/doc/html/rfc6762#section-10.1
         out = self.generate_unregister_all_services()
         if not out:
@@ -612,6 +617,11 @@ class Zeroconf(QuietLogger):
             self.async_send(out)
 
     def unregister_all_services(self) -> None:
+        """Send goodbye packets for every registered service and drop them all.
+
+        May raise EventLoopBlocked when the event loop cannot finish the
+        shutdown broadcasts in time.
+        """
         assert self.loop is not None
         run_coro_with_timeout(
             self.async_unregister_all_services(),
@@ -700,6 +710,7 @@ class Zeroconf(QuietLogger):
         v6_flow_scope: tuple[()] | tuple[int, int] = (),
         transport: _WrappedTransport | None = None,
     ) -> None:
+        """Queue a packet for transmission from any thread."""
         assert self.loop is not None
         self.loop.call_soon_threadsafe(self.async_send, out, addr, port, v6_flow_scope, transport)
 
@@ -711,6 +722,7 @@ class Zeroconf(QuietLogger):
         v6_flow_scope: tuple[()] | tuple[int, int] = (),
         transport: _WrappedTransport | None = None,
     ) -> None:
+        """Transmit a packet from the event loop."""
         if self.done:
             return
 

--- a/src/zeroconf/_dns.py
+++ b/src/zeroconf/_dns.py
@@ -83,6 +83,7 @@ class DNSEntry:  # noqa: PLW1641
         return self.key == other.key and self.type == other.type and self.class_ == other.class_
 
     def __eq__(self, other: Any) -> bool:
+        """Equal when key, type and class match."""
         return isinstance(other, DNSEntry) and self._dns_entry_matches(other)
 
     @staticmethod
@@ -124,6 +125,7 @@ class DNSQuestion(DNSEntry):
         return self._hash
 
     def __eq__(self, other: Any) -> bool:
+        """Equal when the entry fields match a question."""
         return isinstance(other, DNSQuestion) and self._dns_entry_matches(other)
 
     @property
@@ -268,6 +270,7 @@ class DNSAddress(DNSRecord):
         out.write_string(self.address)
 
     def __eq__(self, other: Any) -> bool:
+        """Equal when address and the entry fields match."""
         return isinstance(other, DNSAddress) and self._eq(other)
 
     def _eq(self, other: DNSAddress) -> bool:
@@ -377,6 +380,7 @@ class DNSPointer(DNSRecord):
         out.write_name(self.alias)
 
     def __eq__(self, other: Any) -> bool:
+        """Equal when alias and the entry fields match."""
         return isinstance(other, DNSPointer) and self._eq(other)
 
     def _eq(self, other: DNSPointer) -> bool:
@@ -421,6 +425,7 @@ class DNSText(DNSRecord):
         return self._hash
 
     def __eq__(self, other: Any) -> bool:
+        """Equal when text and the entry fields match."""
         return isinstance(other, DNSText) and self._eq(other)
 
     def _eq(self, other: DNSText) -> bool:
@@ -502,6 +507,8 @@ class DNSService(DNSRecord):
 
 
 class DNSNsec(DNSRecord):
+    """NSEC record asserting which record types exist for a name."""
+
     __slots__ = ("_hash", "next_name", "rdtypes")
 
     def __init__(
@@ -552,6 +559,7 @@ class DNSNsec(DNSRecord):
         out.write_string(out_bytes)
 
     def __eq__(self, other: Any) -> bool:
+        """Equal when next_name, rdtypes and the entry fields match."""
         return isinstance(other, DNSNsec) and self._eq(other)
 
     def _eq(self, other: DNSNsec) -> bool:

--- a/src/zeroconf/_protocol/incoming.py
+++ b/src/zeroconf/_protocol/incoming.py
@@ -447,6 +447,7 @@ class DNSIncoming:
         return None
 
     def _read_bitmap(self, end: _int) -> list[int]:
+        """Decode the NSEC type bitmap."""
         rdtypes = []
         if end > self._data_len:
             raise IncomingDecodeError(

--- a/src/zeroconf/_protocol/outgoing.py
+++ b/src/zeroconf/_protocol/outgoing.py
@@ -162,6 +162,41 @@ class DNSOutgoing:
         self.authorities.append(record)
 
     def add_additional_answer(self, record: DNSRecord) -> None:
+        """Append a record to the additional section per DNS-SD guidance.
+
+        From: RFC 6763, DNS-Based Service Discovery, February 2013
+
+        12.  DNS Additional Record Generation
+
+           DNS has an efficiency feature whereby a DNS server may place
+           additional records in the additional section of the DNS message.
+           These additional records are records that the client did not
+           explicitly request, but the server has reasonable grounds to expect
+           that the client might request them shortly, so including them can
+           save the client from having to issue additional queries.
+
+           This section recommends which additional records SHOULD be generated
+           to improve network efficiency, for both Unicast and Multicast DNS-SD
+           responses.
+
+        12.1.  PTR Records
+
+           When including a DNS-SD Service Instance Enumeration or Selective
+           Instance Enumeration (subtype) PTR record in a response packet, the
+           server/responder SHOULD include the following additional records:
+
+           o  The SRV record(s) named in the PTR rdata.
+           o  The TXT record(s) named in the PTR rdata.
+           o  All address records (type "A" and "AAAA") named in the SRV rdata.
+
+        12.2.  SRV Records
+
+           When including an SRV record in a response packet, the
+           server/responder SHOULD include the following additional records:
+
+           o  All address records (type "A" and "AAAA") named in the SRV rdata.
+
+        """
         self.additionals.append(record)
 
     def _write_byte(self, value: int_) -> None:

--- a/src/zeroconf/_utils/name.py
+++ b/src/zeroconf/_utils/name.py
@@ -41,6 +41,8 @@ def service_type_name(type_: str, *, strict: bool = True) -> str:  # pylint: dis
     """
     Validate a fully qualified service name, instance or subtype. [rfc6763]
 
+    Returns the name in its validated, fully qualified form.
+
     Domain names used by mDNS-SD take the following forms:
 
                    <sn> . <_tcp|_udp> . local.

--- a/src/zeroconf/_utils/time.py
+++ b/src/zeroconf/_utils/time.py
@@ -28,6 +28,11 @@ _float = float
 
 
 def current_time_millis() -> _float:
+    """Monotonic clock reading in milliseconds.
+
+    Must stay aligned with asyncio.loop.time(); the backing clock is an
+    implementation detail and may change.
+    """
     return time.monotonic() * 1000
 
 

--- a/src/zeroconf/asyncio.py
+++ b/src/zeroconf/asyncio.py
@@ -171,6 +171,11 @@ class AsyncZeroconf:
         )
 
     async def async_unregister_all_services(self) -> None:
+        """Send goodbye packets for every registered service and drop them all.
+
+        Runs only at shutdown, so unlike the single service calls it
+        returns nothing to await separately.
+        """
         await self.zeroconf.async_unregister_all_services()
 
     async def async_unregister_service(self, info: ServiceInfo) -> Awaitable:


### PR DESCRIPTION
## Summary
Follow up to #1854 for #1835. Freshly written docstrings for every deleted site: the send and unregister all services methods, the whole equality family in `_dns.py` (address, pointer, text and question gained fresh ones for consistency too), the NSEC class and bitmap reader, `current_time_millis`, `add_additional_answer` (the RFC 6763 quotation returns under a fresh first line, cited IETF text), and the service name validator's return line.

Verification: the fuzzy paraphrase audit reports zero similarity between any new line and any pyzeroconf era line, and the four word n-gram comparison against the deleted text shares nothing outside the re-cited RFC quotation.

## Test plan
- [x] full suite passes
- [x] fuzzy audit and 4-gram fresh-vs-deleted check both clean