### PR TITLE
revert: remove two docstrings echoing 2009 phrasing

### DIFF
--- a/src/zeroconf/_cache.py
+++ b/src/zeroconf/_cache.py
@@ -329,7 +329,6 @@ class DNSCache:
                     self._async_set_created_ttl(record, now, 1)
 
     def _async_set_created_ttl(self, record: DNSRecord, now: _float, ttl: _int) -> None:
-        """Set the created time and ttl of a record."""
         # It would be better if we made a copy instead of mutating the record
         # in place, but records currently don't have a copy method.
         record._set_created_ttl(now, ttl)

--- a/src/zeroconf/_protocol/incoming.py
+++ b/src/zeroconf/_protocol/incoming.py
@@ -148,7 +148,6 @@ class DNSIncoming:
         return (self.flags & _FLAGS_QR_MASK) == _FLAGS_QR_RESPONSE
 
     def has_qu_question(self) -> bool:
-        """Returns true if any question is a QU question."""
         return self._has_qu_question
 
     @property


### PR DESCRIPTION
## Summary
Seventh removal pass for #1835, from a block level fuzzy audit that unwraps whole docstrings and compares them against every pyzeroconf era block at 0.6 similarity. Two lines scored close to 2009 originals: the record cache set ttl docstring and the QU question predicate docstring. An AST structure audit run alongside it, comparing every current function's node shape against all 155 decliner era functions with identifiers stripped, found zero matches at 0.9, so the rewritten code shares no structural shape with the originals.

Deletion only; the follow up restores fresh lines.

## Test plan
- [x] suite passes; prose only