### PR TITLE
chore: fresh docstrings for the block audit sites

### DIFF
--- a/src/zeroconf/_cache.py
+++ b/src/zeroconf/_cache.py
@@ -329,6 +329,7 @@ class DNSCache:
                     self._async_set_created_ttl(record, now, 1)
 
     def _async_set_created_ttl(self, record: DNSRecord, now: _float, ttl: _int) -> None:
+        """Stamp a record with a new ttl and creation moment, then cache it."""
         # It would be better if we made a copy instead of mutating the record
         # in place, but records currently don't have a copy method.
         record._set_created_ttl(now, ttl)

--- a/src/zeroconf/_protocol/incoming.py
+++ b/src/zeroconf/_protocol/incoming.py
@@ -148,6 +148,7 @@ class DNSIncoming:
         return (self.flags & _FLAGS_QR_MASK) == _FLAGS_QR_RESPONSE
 
     def has_qu_question(self) -> bool:
+        """True when at least one question requests a unicast response."""
         return self._has_qu_question
 
     @property


### PR DESCRIPTION
## Summary
Follow up to #1856 for #1835. Two freshly written docstrings for the deleted sites. The block level fuzzy audit re-run on this branch no longer reports either site; the remaining low similarity pairs are compelled technical terms (unsigned short, the service record field list) in otherwise unrelated sentences.

## Test plan
- [x] suite passes
- [x] block audit re-run clean on both sites