### PR TITLE
revert: remove short verbatim prose caught by the whole unit audit

### DIFF
--- a/src/zeroconf/_cache.py
+++ b/src/zeroconf/_cache.py
@@ -79,12 +79,6 @@ class DNSCache:
     # be run in the event loop.
 
     def _async_add(self, record: _DNSRecord) -> bool:
-        """Adds an entry.
-
-        Returns true if the entry was not already in the cache.
-
-        This function must be run in from event loop.
-        """
         # Previously storage of records was implemented as a list
         # instead a dict. Since DNSRecords are now hashable, the implementation
         # uses a dict to ensure that adding a new record to the cache
@@ -163,10 +157,6 @@ class DNSCache:
         return new
 
     def _async_remove(self, record: _DNSRecord) -> None:
-        """Removes an entry.
-
-        This function must be run in from event loop.
-        """
         if isinstance(record, DNSService):
             service_record = record
             _remove_key(self.service_cache, service_record.server_key, service_record)

--- a/src/zeroconf/_core.py
+++ b/src/zeroconf/_core.py
@@ -563,12 +563,6 @@ class Zeroconf(QuietLogger):
                 out.add_answer_at_time(record, 0)
 
     def unregister_service(self, info: ServiceInfo) -> None:
-        """Unregister a service.
-
-        While it is not expected during normal operation,
-        this function may raise EventLoopBlocked if the underlying
-        call to `async_unregister_service` cannot be completed.
-        """
         assert self.loop is not None
         run_coro_with_timeout(
             self.async_unregister_service(info),
@@ -577,7 +571,6 @@ class Zeroconf(QuietLogger):
         )
 
     async def async_unregister_service(self, info: ServiceInfo) -> Awaitable:
-        """Unregister a service."""
         info.set_server_if_missing()
         self.registry.async_remove(info)
         # If another server uses the same addresses, we do not want to send
@@ -680,10 +673,6 @@ class Zeroconf(QuietLogger):
         self.loop.call_soon_threadsafe(self.record_manager.async_add_listener, listener, question)
 
     def remove_listener(self, listener: RecordUpdateListener) -> None:
-        """Removes a listener.
-
-        This function is threadsafe
-        """
         assert self.loop is not None
         self.loop.call_soon_threadsafe(self.record_manager.async_remove_listener, listener)
 
@@ -696,10 +685,6 @@ class Zeroconf(QuietLogger):
         self.record_manager.async_add_listener(listener, question)
 
     def async_remove_listener(self, listener: RecordUpdateListener) -> None:
-        """Removes a listener.
-
-        This function is not threadsafe and must be called in the eventloop.
-        """
         self.record_manager.async_remove_listener(listener)
 
     def send(

--- a/src/zeroconf/_dns.py
+++ b/src/zeroconf/_dns.py
@@ -64,8 +64,6 @@ class DNSQuestionType(enum.Enum):
 
 
 class DNSEntry:  # noqa: PLW1641
-    """A DNS entry"""
-
     __slots__ = ("class_", "key", "name", "type", "unique")
 
     def __init__(self, name: str, type_: int, class_: int) -> None:
@@ -148,7 +146,6 @@ class DNSQuestion(DNSEntry):
         self.unique = value
 
     def __repr__(self) -> str:
-        """String representation"""
         return "{}[question,{},{},{}]".format(
             self.get_type(self.type),
             "QU" if self.unicast else "QM",
@@ -502,7 +499,6 @@ class DNSService(DNSRecord):
         return self._hash
 
     def __repr__(self) -> str:
-        """String representation"""
         return self.to_string(f"{self.server}:{self.port}")
 
 
@@ -574,7 +570,6 @@ class DNSNsec(DNSRecord):
         return self._hash
 
     def __repr__(self) -> str:
-        """String representation"""
         return self.to_string(
             self.next_name + "," + "|".join([self.get_type(type_) for type_ in self.rdtypes])
         )

--- a/src/zeroconf/_handlers/record_manager.py
+++ b/src/zeroconf/_handlers/record_manager.py
@@ -195,10 +195,6 @@ class RecordManager:
         self.zc.async_notify_all()
 
     def async_remove_listener(self, listener: RecordUpdateListener) -> None:
-        """Removes a listener.
-
-        This function is not threadsafe and must be called in the eventloop.
-        """
         try:
             self.listeners.remove(listener)
             self.zc.async_notify_all()

--- a/src/zeroconf/_protocol/outgoing.py
+++ b/src/zeroconf/_protocol/outgoing.py
@@ -403,13 +403,6 @@ class DNSOutgoing:
         )
 
     def packets(self) -> list[bytes]:
-        """Returns a list of bytestrings containing the packets' bytes
-
-        is done.  The packets are each restricted to _MAX_MSG_TYPICAL
-        or less in length, except for the case of a single answer which
-        will be written out to a single oversized packet no more than
-        _MAX_MSG_ABSOLUTE in length (and hence will be subject to IP
-        fragmentation potentially)."""
         packets_data = self.packets_data
 
         if self.state == STATE_FINISHED:

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -474,7 +474,6 @@ class ServiceInfo(RecordUpdateListener):
         self._properties = properties
 
     def get_name(self) -> str:
-        """Name accessor"""
         return self._name[: len(self._name) - len(self.type) - 1]
 
     def _get_ip_addresses_from_cache_lifo(
@@ -1086,7 +1085,6 @@ class ServiceInfo(RecordUpdateListener):
         return out
 
     def __repr__(self) -> str:
-        """String representation"""
         return "{}({})".format(
             type(self).__name__,
             ", ".join(

--- a/src/zeroconf/asyncio.py
+++ b/src/zeroconf/asyncio.py
@@ -179,11 +179,6 @@ class AsyncZeroconf:
         await self.zeroconf.async_unregister_all_services()
 
     async def async_unregister_service(self, info: ServiceInfo) -> Awaitable:
-        """Unregister a service.
-
-        The service will be broadcast in a task. This task is returned
-        and therefore can be awaited if necessary.
-        """
         return await self.zeroconf.async_unregister_service(info)
 
     async def async_update_service(self, info: ServiceInfo) -> Awaitable:

--- a/src/zeroconf/const.py
+++ b/src/zeroconf/const.py
@@ -25,8 +25,6 @@ from __future__ import annotations
 import re
 import socket
 
-# Some timing constants
-
 _UNREGISTER_TIME = 125  # ms
 _CHECK_TIME = 500  # ms
 _REGISTER_TIME = 225  # ms
@@ -51,7 +49,6 @@ _ONE_SECOND = 1000  # ms
 # a buffer timeout to ensure a coroutine can finish before
 # the future times out
 
-# Some DNS constants
 
 _MDNS_ADDR = "224.0.0.251"
 _MDNS_ADDR6 = "ff02::fb"


### PR DESCRIPTION
## Summary
Eighth removal pass for #1835. An exact whole unit comparison with no length floor caught the two to four word docstrings every earlier threshold sat above: A DNS entry, String representation (four copies), Name accessor, Adds an entry, Removes an entry, Unregister a service, Removes a listener, the Some timing constants and Some DNS constants comments, and the packets docstring whose first line edits the 2009 original and still carried an orphaned fragment of it. Multi line docstrings whose first line was 2009 text are deleted whole.

Run alongside it, an arrangement audit compared class order and per class method order against the 2009 and 2014 monoliths and found no ordering with even 0.6 similarity, so the arrangement concern noted in the original audit no longer applies to the current tree.

Deletion only, suite green; the follow up restores fresh text.

## Test plan
- [x] full suite passes
- [x] whole unit audit re-run reports only license header lines and shebangs