### PR TITLE
chore: add a short license header pointing at COPYING

### DIFF
--- a/src/zeroconf/__init__.py
+++ b/src/zeroconf/__init__.py
@@ -1,3 +1,8 @@
+"""A pure python implementation of multicast DNS service discovery.
+
+Licensed under LGPL-2.1-or-later; see COPYING for details.
+"""
+
 from __future__ import annotations
 
 from ._cache import DNSCache  # noqa # import needed for backwards compat

--- a/src/zeroconf/_cache.py
+++ b/src/zeroconf/_cache.py
@@ -1,3 +1,8 @@
+"""A pure python implementation of multicast DNS service discovery.
+
+Licensed under LGPL-2.1-or-later; see COPYING for details.
+"""
+
 from __future__ import annotations
 
 from collections.abc import Iterable

--- a/src/zeroconf/_core.py
+++ b/src/zeroconf/_core.py
@@ -1,3 +1,8 @@
+"""A pure python implementation of multicast DNS service discovery.
+
+Licensed under LGPL-2.1-or-later; see COPYING for details.
+"""
+
 from __future__ import annotations
 
 import asyncio

--- a/src/zeroconf/_dns.py
+++ b/src/zeroconf/_dns.py
@@ -1,3 +1,8 @@
+"""A pure python implementation of multicast DNS service discovery.
+
+Licensed under LGPL-2.1-or-later; see COPYING for details.
+"""
+
 from __future__ import annotations
 
 import enum

--- a/src/zeroconf/_engine.py
+++ b/src/zeroconf/_engine.py
@@ -1,3 +1,8 @@
+"""A pure python implementation of multicast DNS service discovery.
+
+Licensed under LGPL-2.1-or-later; see COPYING for details.
+"""
+
 from __future__ import annotations
 
 import asyncio

--- a/src/zeroconf/_exceptions.py
+++ b/src/zeroconf/_exceptions.py
@@ -1,3 +1,8 @@
+"""A pure python implementation of multicast DNS service discovery.
+
+Licensed under LGPL-2.1-or-later; see COPYING for details.
+"""
+
 from __future__ import annotations
 
 

--- a/src/zeroconf/_handlers/__init__.py
+++ b/src/zeroconf/_handlers/__init__.py
@@ -1,1 +1,6 @@
+"""A pure python implementation of multicast DNS service discovery.
+
+Licensed under LGPL-2.1-or-later; see COPYING for details.
+"""
+
 from __future__ import annotations

--- a/src/zeroconf/_handlers/answers.py
+++ b/src/zeroconf/_handlers/answers.py
@@ -1,3 +1,8 @@
+"""A pure python implementation of multicast DNS service discovery.
+
+Licensed under LGPL-2.1-or-later; see COPYING for details.
+"""
+
 from __future__ import annotations
 
 from operator import attrgetter

--- a/src/zeroconf/_handlers/multicast_outgoing_queue.py
+++ b/src/zeroconf/_handlers/multicast_outgoing_queue.py
@@ -1,3 +1,8 @@
+"""A pure python implementation of multicast DNS service discovery.
+
+Licensed under LGPL-2.1-or-later; see COPYING for details.
+"""
+
 from __future__ import annotations
 
 import random

--- a/src/zeroconf/_handlers/query_handler.py
+++ b/src/zeroconf/_handlers/query_handler.py
@@ -1,3 +1,8 @@
+"""A pure python implementation of multicast DNS service discovery.
+
+Licensed under LGPL-2.1-or-later; see COPYING for details.
+"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast

--- a/src/zeroconf/_handlers/record_manager.py
+++ b/src/zeroconf/_handlers/record_manager.py
@@ -1,3 +1,8 @@
+"""A pure python implementation of multicast DNS service discovery.
+
+Licensed under LGPL-2.1-or-later; see COPYING for details.
+"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast

--- a/src/zeroconf/_history.py
+++ b/src/zeroconf/_history.py
@@ -1,3 +1,8 @@
+"""A pure python implementation of multicast DNS service discovery.
+
+Licensed under LGPL-2.1-or-later; see COPYING for details.
+"""
+
 from __future__ import annotations
 
 from ._dns import DNSQuestion, DNSRecord

--- a/src/zeroconf/_listener.py
+++ b/src/zeroconf/_listener.py
@@ -1,3 +1,8 @@
+"""A pure python implementation of multicast DNS service discovery.
+
+Licensed under LGPL-2.1-or-later; see COPYING for details.
+"""
+
 from __future__ import annotations
 
 import asyncio

--- a/src/zeroconf/_logger.py
+++ b/src/zeroconf/_logger.py
@@ -1,3 +1,8 @@
+"""A pure python implementation of multicast DNS service discovery.
+
+Licensed under LGPL-2.1-or-later; see COPYING for details.
+"""
+
 from __future__ import annotations
 
 import logging

--- a/src/zeroconf/_protocol/__init__.py
+++ b/src/zeroconf/_protocol/__init__.py
@@ -1,1 +1,6 @@
+"""A pure python implementation of multicast DNS service discovery.
+
+Licensed under LGPL-2.1-or-later; see COPYING for details.
+"""
+
 from __future__ import annotations

--- a/src/zeroconf/_protocol/incoming.py
+++ b/src/zeroconf/_protocol/incoming.py
@@ -1,3 +1,8 @@
+"""A pure python implementation of multicast DNS service discovery.
+
+Licensed under LGPL-2.1-or-later; see COPYING for details.
+"""
+
 from __future__ import annotations
 
 import struct

--- a/src/zeroconf/_protocol/outgoing.py
+++ b/src/zeroconf/_protocol/outgoing.py
@@ -1,3 +1,8 @@
+"""A pure python implementation of multicast DNS service discovery.
+
+Licensed under LGPL-2.1-or-later; see COPYING for details.
+"""
+
 from __future__ import annotations
 
 import enum

--- a/src/zeroconf/_record_update.py
+++ b/src/zeroconf/_record_update.py
@@ -1,3 +1,8 @@
+"""A pure python implementation of multicast DNS service discovery.
+
+Licensed under LGPL-2.1-or-later; see COPYING for details.
+"""
+
 from __future__ import annotations
 
 from ._dns import DNSRecord

--- a/src/zeroconf/_services/__init__.py
+++ b/src/zeroconf/_services/__init__.py
@@ -1,3 +1,8 @@
+"""A pure python implementation of multicast DNS service discovery.
+
+Licensed under LGPL-2.1-or-later; see COPYING for details.
+"""
+
 from __future__ import annotations
 
 import enum

--- a/src/zeroconf/_services/browser.py
+++ b/src/zeroconf/_services/browser.py
@@ -1,3 +1,8 @@
+"""A pure python implementation of multicast DNS service discovery.
+
+Licensed under LGPL-2.1-or-later; see COPYING for details.
+"""
+
 from __future__ import annotations
 
 import asyncio

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -1,3 +1,8 @@
+"""A pure python implementation of multicast DNS service discovery.
+
+Licensed under LGPL-2.1-or-later; see COPYING for details.
+"""
+
 from __future__ import annotations
 
 import asyncio

--- a/src/zeroconf/_services/registry.py
+++ b/src/zeroconf/_services/registry.py
@@ -1,3 +1,8 @@
+"""A pure python implementation of multicast DNS service discovery.
+
+Licensed under LGPL-2.1-or-later; see COPYING for details.
+"""
+
 from __future__ import annotations
 
 from .._exceptions import ServiceNameAlreadyRegistered

--- a/src/zeroconf/_services/types.py
+++ b/src/zeroconf/_services/types.py
@@ -1,3 +1,8 @@
+"""A pure python implementation of multicast DNS service discovery.
+
+Licensed under LGPL-2.1-or-later; see COPYING for details.
+"""
+
 from __future__ import annotations
 
 import time

--- a/src/zeroconf/_transport.py
+++ b/src/zeroconf/_transport.py
@@ -1,3 +1,8 @@
+"""A pure python implementation of multicast DNS service discovery.
+
+Licensed under LGPL-2.1-or-later; see COPYING for details.
+"""
+
 from __future__ import annotations
 
 import asyncio

--- a/src/zeroconf/_updates.py
+++ b/src/zeroconf/_updates.py
@@ -1,3 +1,8 @@
+"""A pure python implementation of multicast DNS service discovery.
+
+Licensed under LGPL-2.1-or-later; see COPYING for details.
+"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/src/zeroconf/_utils/__init__.py
+++ b/src/zeroconf/_utils/__init__.py
@@ -1,1 +1,6 @@
+"""A pure python implementation of multicast DNS service discovery.
+
+Licensed under LGPL-2.1-or-later; see COPYING for details.
+"""
+
 from __future__ import annotations

--- a/src/zeroconf/_utils/asyncio.py
+++ b/src/zeroconf/_utils/asyncio.py
@@ -1,3 +1,8 @@
+"""A pure python implementation of multicast DNS service discovery.
+
+Licensed under LGPL-2.1-or-later; see COPYING for details.
+"""
+
 from __future__ import annotations
 
 import asyncio

--- a/src/zeroconf/_utils/ipaddress.py
+++ b/src/zeroconf/_utils/ipaddress.py
@@ -1,3 +1,8 @@
+"""A pure python implementation of multicast DNS service discovery.
+
+Licensed under LGPL-2.1-or-later; see COPYING for details.
+"""
+
 from __future__ import annotations
 
 from functools import lru_cache

--- a/src/zeroconf/_utils/name.py
+++ b/src/zeroconf/_utils/name.py
@@ -1,3 +1,8 @@
+"""A pure python implementation of multicast DNS service discovery.
+
+Licensed under LGPL-2.1-or-later; see COPYING for details.
+"""
+
 from __future__ import annotations
 
 from functools import lru_cache

--- a/src/zeroconf/_utils/net.py
+++ b/src/zeroconf/_utils/net.py
@@ -1,3 +1,8 @@
+"""A pure python implementation of multicast DNS service discovery.
+
+Licensed under LGPL-2.1-or-later; see COPYING for details.
+"""
+
 from __future__ import annotations
 
 import enum

--- a/src/zeroconf/_utils/time.py
+++ b/src/zeroconf/_utils/time.py
@@ -1,3 +1,8 @@
+"""A pure python implementation of multicast DNS service discovery.
+
+Licensed under LGPL-2.1-or-later; see COPYING for details.
+"""
+
 from __future__ import annotations
 
 import time

--- a/src/zeroconf/asyncio.py
+++ b/src/zeroconf/asyncio.py
@@ -1,3 +1,8 @@
+"""A pure python implementation of multicast DNS service discovery.
+
+Licensed under LGPL-2.1-or-later; see COPYING for details.
+"""
+
 from __future__ import annotations
 
 import asyncio

--- a/src/zeroconf/const.py
+++ b/src/zeroconf/const.py
@@ -1,3 +1,8 @@
+"""A pure python implementation of multicast DNS service discovery.
+
+Licensed under LGPL-2.1-or-later; see COPYING for details.
+"""
+
 from __future__ import annotations
 
 import re

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,8 @@
+"""A pure python implementation of multicast DNS service discovery.
+
+Licensed under LGPL-2.1-or-later; see COPYING for details.
+"""
+
 from __future__ import annotations
 
 import asyncio

--- a/tests/services/__init__.py
+++ b/tests/services/__init__.py
@@ -1,1 +1,6 @@
+"""A pure python implementation of multicast DNS service discovery.
+
+Licensed under LGPL-2.1-or-later; see COPYING for details.
+"""
+
 from __future__ import annotations

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,1 +1,6 @@
+"""A pure python implementation of multicast DNS service discovery.
+
+Licensed under LGPL-2.1-or-later; see COPYING for details.
+"""
+
 from __future__ import annotations


### PR DESCRIPTION
## Summary
Follow up to #1860 for #1835. Every module now opens with a five line header naming the package, stating LGPL-2.1-or-later, and pointing at COPYING for the full text. The license does not change.

With the old banner gone the audits can finally run with no exclusions at all: zero shared five word runs remain between the whole tree and any pyzeroconf era blob, and the only exact whole unit matches left are the shebang lines.

## Test plan
- [x] full suite passes
- [x] audits re-run with zero exclusions, results above