### PR TITLE
revert: remove a derivative notify docstring

### DIFF
--- a/src/zeroconf/_core.py
+++ b/src/zeroconf/_core.py
@@ -269,7 +269,6 @@ class Zeroconf(QuietLogger):
         await wait_for_future_set_or_timeout(loop, self._notify_futures, timeout)
 
     def notify_all(self) -> None:
-        """Notifies all waiting threads and notify listeners."""
         assert self.loop is not None
         self.loop.call_soon_threadsafe(self.async_notify_all)
 


### PR DESCRIPTION
## Summary
Eleventh pass for #1835. A 30 character shingle audit over every tracked file, including the pxd files and changelog the earlier passes skipped, found one remaining derivative line: the async_notify_all docstring, which is the 2009 notify docstring with three words appended. Everything else the pass surfaced is mechanical (cdef class declarations, the project name phrase, boilerplate seams).

## Test plan
- [x] suite passes; single docstring deletion