### PR TITLE
chore: fresh docstring for notify_all

### DIFF
--- a/src/zeroconf/_core.py
+++ b/src/zeroconf/_core.py
@@ -269,6 +269,7 @@ class Zeroconf(QuietLogger):
         await wait_for_future_set_or_timeout(loop, self._notify_futures, timeout)
 
     def notify_all(self) -> None:
+        """Wake every waiter and fire the listeners, from any thread."""
         assert self.loop is not None
         self.loop.call_soon_threadsafe(self.async_notify_all)
 


### PR DESCRIPTION
## Summary
Follow up to #1862 for #1835; one freshly written docstring for notify_all. It shares no word runs with the deleted line beyond the method's own name.

## Test plan
- [x] suite passes