### PR TITLE
chore: preserve the historical copyright notices in COPYING

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,3 +1,18 @@
+python-zeroconf is distributed under the GNU Lesser General Public
+License, version 2.1 or later. The full license text follows below the
+separator.
+
+Historical copyright notices, preserved from the original per file
+headers:
+
+    Copyright 2003 Paul Scott-Murphy
+    Copyright 2014 William McBrine
+
+Later contributions are copyright their respective authors; the
+complete record is in the project's git history.
+
+----------------------------------------------------------------------
+
 		  GNU LESSER GENERAL PUBLIC LICENSE
 		       Version 2.1, February 1999
 

--- a/COPYING
+++ b/COPYING
@@ -7,8 +7,10 @@ headers:
 
     Copyright 2003 Paul Scott-Murphy
     Copyright 2014 William McBrine
+    Copyright 2014-2021 Jakub Stasiak
+    Copyright 2020-2026 J. Nick Koston
 
-Later contributions are copyright their respective authors; the
+Other contributions are copyright their respective authors; the
 complete record is in the project's git history.
 
 ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
The banner consolidation in #1860 removed the per file copyright lines along with the license boilerplate; the notices themselves should stay on record. This adds a short preamble above the LGPL text in COPYING carrying the original 2003 and 2014 copyright notices verbatim, with a pointer to git history for later contributions. The license text itself is untouched below the separator.

## Test plan
- [x] COPYING preamble only; no code changes