### PR TITLE
chore: fresh bare pytest tests, de-classed suites and new fixture values

### DIFF
--- a/tests/benchmarks/test_registry.py
+++ b/tests/benchmarks/test_registry.py
@@ -24,7 +24,7 @@ def _make_infos(count: int) -> list[ServiceInfo]:
             0,
             {"path": "/"},
             _SERVER,
-            addresses=[socket.inet_aton("10.0.1.2")],
+            addresses=[socket.inet_aton("10.7.4.2")],
         )
         for i in range(count)
     ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,7 +59,7 @@ _KNOWN_BLOCKING: frozenset[str] = frozenset(
         "tests/test_asyncio.py::test_async_service_registration_same_server_different_ports",
         "tests/test_asyncio.py::test_async_service_registration_same_server_same_ports",
         "tests/test_asyncio.py::test_async_tasks",
-        "tests/test_core.py::Framework::test_use_asyncio_false_forces_thread_when_loop_running",
+        "tests/test_core.py::test_use_asyncio_false_forces_thread_when_loop_running",
         "tests/utils/test_asyncio.py::test_run_coro_with_timeout",
     }
 )

--- a/tests/services/test_browser.py
+++ b/tests/services/test_browser.py
@@ -176,7 +176,7 @@ class TestServiceBrowser(unittest.TestCase):
         service_type = "_type._tcp.local."
         service_server = "ash-1.local."
         service_text = b"path=/~matt1/"
-        service_address = "10.0.1.2"
+        service_address = "10.7.4.2"
         service_v6_address = "2001:db8::1"
         service_v6_second_address = "6001:db8::1"
 
@@ -304,7 +304,7 @@ class TestServiceBrowser(unittest.TestCase):
 
             # service SRV updated
             service_updated_event.clear()
-            service_server = "ash-2.local."
+            service_server = "spare-rig.local."
             _inject_response(zeroconf, mock_record_update_incoming_msg(r.ServiceStateChange.Updated))
             service_updated_event.wait(wait_time)
             assert service_added_count == 1
@@ -333,7 +333,7 @@ class TestServiceBrowser(unittest.TestCase):
 
             # service A updated
             service_updated_event.clear()
-            service_address = "10.0.1.3"
+            service_address = "10.7.4.3"
             # Verify we match on uppercase
             service_server = service_server.upper()
             _inject_response(zeroconf, mock_record_update_incoming_msg(r.ServiceStateChange.Updated))
@@ -346,7 +346,7 @@ class TestServiceBrowser(unittest.TestCase):
             service_updated_event.clear()
             service_server = "ash-3.local."
             service_text = b"path=/~matt3/"
-            service_address = "10.0.1.3"
+            service_address = "10.7.4.3"
             _inject_response(zeroconf, mock_record_update_incoming_msg(r.ServiceStateChange.Updated))
             service_updated_event.wait(wait_time)
             assert service_added_count == 1
@@ -602,8 +602,8 @@ async def test_asking_default_is_asking_qm_questions_after_the_first_qu(quick_ti
             0,
             0,
             {"path": "/~paulsm/"},
-            "ash-2.local.",
-            addresses=[socket.inet_aton("10.0.1.2")],
+            "spare-rig.local.",
+            addresses=[socket.inet_aton("10.7.4.2")],
         )
         task = await aio_zeroconf_registrar.async_register_service(info)
         await task
@@ -703,8 +703,8 @@ async def test_ttl_refresh_cancelled_rescue_query(quick_timing: None) -> None:
             0,
             0,
             {"path": "/~paulsm/"},
-            "ash-2.local.",
-            addresses=[socket.inet_aton("10.0.1.2")],
+            "spare-rig.local.",
+            addresses=[socket.inet_aton("10.7.4.2")],
         )
         task = await aio_zeroconf_registrar.async_register_service(info)
         await task
@@ -875,8 +875,8 @@ def test_legacy_record_update_listener(quick_timing: None) -> None:
         0,
         0,
         {"path": "/~paulsm/"},
-        "ash-2.local.",
-        addresses=[socket.inet_aton("10.0.1.2")],
+        "spare-rig.local.",
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
 
     zc.register_service(info_service)
@@ -915,9 +915,9 @@ def test_service_browser_is_aware_of_port_changes():
     browser = ServiceBrowser(zc, type_, [on_service_state_change])
 
     desc = {"path": "/~paulsm/"}
-    address_parsed = "10.0.1.2"
+    address_parsed = "10.7.4.2"
     address = socket.inet_aton(address_parsed)
-    info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, "ash-2.local.", addresses=[address])
+    info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, "spare-rig.local.", addresses=[address])
 
     _inject_response(
         zc,
@@ -986,9 +986,9 @@ def test_service_browser_listeners_update_service():
     browser = r.ServiceBrowser(zc, type_, None, listener)
 
     desc = {"path": "/~paulsm/"}
-    address_parsed = "10.0.1.2"
+    address_parsed = "10.7.4.2"
     address = socket.inet_aton(address_parsed)
-    info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, "ash-2.local.", addresses=[address])
+    info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, "spare-rig.local.", addresses=[address])
 
     _inject_response(
         zc,
@@ -1047,9 +1047,9 @@ def test_service_browser_listeners_no_update_service():
     browser = r.ServiceBrowser(zc, type_, None, listener)
 
     desc = {"path": "/~paulsm/"}
-    address_parsed = "10.0.1.2"
+    address_parsed = "10.7.4.2"
     address = socket.inet_aton(address_parsed)
-    info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, "ash-2.local.", addresses=[address])
+    info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, "spare-rig.local.", addresses=[address])
 
     _inject_response(
         zc,
@@ -1106,8 +1106,8 @@ def test_service_browser_nsec_record_does_not_trigger_update():
     browser = r.ServiceBrowser(zc, type_, None, listener)
     try:
         desc = {"path": "/~paulsm/"}
-        address = socket.inet_aton("10.0.1.2")
-        info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, "ash-2.local.", addresses=[address])
+        address = socket.inet_aton("10.7.4.2")
+        info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, "spare-rig.local.", addresses=[address])
 
         _inject_response(
             zc,
@@ -1438,9 +1438,9 @@ def test_service_browser_matching():
     browser = r.ServiceBrowser(zc, type_, None, listener)
 
     desc = {"path": "/~paulsm/"}
-    address_parsed = "10.0.1.2"
+    address_parsed = "10.7.4.2"
     address = socket.inet_aton(address_parsed)
-    info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, "ash-2.local.", addresses=[address])
+    info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, "spare-rig.local.", addresses=[address])
     should_not_match = ServiceInfo(
         not_match_type_,
         not_match_registration_name,
@@ -1448,7 +1448,7 @@ def test_service_browser_matching():
         0,
         0,
         desc,
-        "ash-2.local.",
+        "spare-rig.local.",
         addresses=[address],
     )
 
@@ -1526,7 +1526,7 @@ def test_service_browser_expire_callbacks():
     browser = r.ServiceBrowser(zc, type_, None, listener)
 
     desc = {"path": "/~paul2/"}
-    address_parsed = "10.0.1.3"
+    address_parsed = "10.7.4.3"
     address = socket.inet_aton(address_parsed)
     info = ServiceInfo(
         type_,
@@ -1679,8 +1679,8 @@ async def test_close_zeroconf_without_browser_before_start_up_queries(quick_timi
             0,
             0,
             {"path": "/~paulsm/"},
-            "ash-2.local.",
-            addresses=[socket.inet_aton("10.0.1.2")],
+            "spare-rig.local.",
+            addresses=[socket.inet_aton("10.7.4.2")],
         )
         task = await aio_zeroconf_registrar.async_register_service(info)
         await task
@@ -1746,8 +1746,8 @@ async def test_close_zeroconf_without_browser_after_start_up_queries(quick_timin
             0,
             0,
             {"path": "/~paulsm/"},
-            "ash-2.local.",
-            addresses=[socket.inet_aton("10.0.1.2")],
+            "spare-rig.local.",
+            addresses=[socket.inet_aton("10.7.4.2")],
         )
         task = await aio_zeroconf_registrar.async_register_service(info)
         await task

--- a/tests/services/test_info.py
+++ b/tests/services/test_info.py
@@ -49,7 +49,7 @@ class TestServiceInfo(unittest.TestCase):
         service_name = "name._type._tcp.local."
         service_type = "_type._tcp.local."
         service_server = "ash-1.local."
-        service_address = socket.inet_aton("10.0.1.2")
+        service_address = socket.inet_aton("10.7.4.2")
         info = ServiceInfo(
             service_type,
             service_name,
@@ -70,7 +70,7 @@ class TestServiceInfo(unittest.TestCase):
         service_name = "name._type._tcp.local."
         service_type = "_type._tcp.local."
         service_server = "ash-1.local."
-        service_address = socket.inet_aton("10.0.1.2")
+        service_address = socket.inet_aton("10.7.4.2")
         ttl = 120
         now = r.current_time_millis()
         info = ServiceInfo(
@@ -116,22 +116,22 @@ class TestServiceInfo(unittest.TestCase):
                         0,
                         0,
                         80,
-                        "ASH-2.local.",
+                        "SPARE-RIG.local.",
                     ),
                     None,
                 )
             ],
         )
-        assert info.server_key == "ash-2.local."
-        assert info.server == "ASH-2.local."
-        new_address = socket.inet_aton("10.0.1.3")
+        assert info.server_key == "spare-rig.local."
+        assert info.server == "SPARE-RIG.local."
+        new_address = socket.inet_aton("10.7.4.3")
         info.async_update_records(
             zc,
             now,
             [
                 RecordUpdate(
                     r.DNSAddress(
-                        "ASH-2.local.",
+                        "SPARE-RIG.local.",
                         const._TYPE_A,
                         const._CLASS_IN | const._CLASS_UNIQUE,
                         ttl,
@@ -173,15 +173,15 @@ class TestServiceInfo(unittest.TestCase):
                         0,
                         0,
                         80,
-                        "ASH-2.local.",
+                        "SPARE-RIG.local.",
                     ),
                     None,
                 )
             ],
         )
-        assert info.server_key == "ash-2.local."
-        assert info.server == "ASH-2.local."
-        new_address = socket.inet_aton("10.0.1.4")
+        assert info.server_key == "spare-rig.local."
+        assert info.server == "SPARE-RIG.local."
+        new_address = socket.inet_aton("10.7.4.4")
         info.async_update_records(
             zc,
             now,
@@ -208,7 +208,7 @@ class TestServiceInfo(unittest.TestCase):
         service_name = "name._type._tcp.local."
         service_type = "_type._tcp.local."
         service_server = "ash-1.local."
-        service_address = socket.inet_aton("10.0.1.2")
+        service_address = socket.inet_aton("10.7.4.2")
         ttl = 120
         now = r.current_time_millis()
         info = ServiceInfo(
@@ -262,7 +262,7 @@ class TestServiceInfo(unittest.TestCase):
         service_type = "_type._tcp.local."
         service_server = "ash-1.local."
         service_text = b"path=/~matt1/"
-        service_address = "10.0.1.2"
+        service_address = "10.7.4.2"
         service_address_v6_ll = "fe80::52e:c2f2:bc5f:e9c6"
         service_scope_id = 12
 
@@ -509,7 +509,7 @@ class TestServiceInfo(unittest.TestCase):
         service_type = "_type._tcp.local."
         service_server = "ash-1.local."
         service_text = b"path=/~matt1/"
-        service_address = "10.0.1.2"
+        service_address = "10.7.4.2"
 
         service_info = None
         service_info_event = Event()
@@ -601,7 +601,7 @@ class TestServiceInfo(unittest.TestCase):
         service_name = "name._type._tcp.local."
         service_type = "_type._tcp.local."
         service_server = "ash-1.local."
-        service_address = socket.inet_aton("10.0.1.2")
+        service_address = socket.inet_aton("10.7.4.2")
         ttl = 120
         now = r.current_time_millis()
         info = ServiceInfo(
@@ -650,7 +650,7 @@ class TestServiceInfo(unittest.TestCase):
             0,
             {"path": "/~paulsm/"},
             service_server,
-            addresses=[socket.inet_aton("10.0.1.2")],
+            addresses=[socket.inet_aton("10.7.4.2")],
         )
         info.async_update_records(
             zc,
@@ -698,7 +698,7 @@ def test_multiple_addresses():
     type_ = "_http._tcp.local."
     registration_name = f"xxxyyy.{type_}"
     desc = {"path": "/~paulsm/"}
-    address_parsed = "10.0.1.2"
+    address_parsed = "10.7.4.2"
     address = socket.inet_aton(address_parsed)
 
     # New kwarg way
@@ -709,7 +709,7 @@ def test_multiple_addresses():
         0,
         0,
         desc,
-        "ash-2.local.",
+        "spare-rig.local.",
         addresses=[address, address],
     )
 
@@ -724,7 +724,7 @@ def test_multiple_addresses():
         0,
         0,
         desc,
-        "ash-2.local.",
+        "spare-rig.local.",
         parsed_addresses=[address_parsed, address_parsed],
     )
     assert info.addresses == [address, address]
@@ -746,7 +746,7 @@ def test_multiple_addresses():
                 0,
                 0,
                 desc,
-                "ash-2.local.",
+                "spare-rig.local.",
                 addresses=[address, address_v6, address_v6_ll],
                 interface_index=interface_index,
             ),
@@ -757,7 +757,7 @@ def test_multiple_addresses():
                 0,
                 0,
                 desc,
-                "ash-2.local.",
+                "spare-rig.local.",
                 parsed_addresses=[
                     address_parsed,
                     address_v6_parsed,
@@ -1121,9 +1121,9 @@ def test_filter_address_by_type_from_service_info():
     type_ = "_homeassistant._tcp.local."
     name = "MyTestHome"
     registration_name = f"{name}.{type_}"
-    ipv4 = socket.inet_aton("10.0.1.2")
+    ipv4 = socket.inet_aton("10.7.4.2")
     ipv6 = socket.inet_pton(socket.AF_INET6, "2001:db8::1")
-    info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, "ash-2.local.", addresses=[ipv4, ipv6])
+    info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, "spare-rig.local.", addresses=[ipv4, ipv6])
 
     def dns_addresses_to_addresses(dns_address: list[DNSAddress]) -> list[bytes]:
         return [address.address for address in dns_address]
@@ -1148,8 +1148,8 @@ def test_changing_name_updates_serviceinfo_key():
         0,
         0,
         {"path": "/~paulsm/"},
-        "ash-2.local.",
-        addresses=[socket.inet_aton("10.0.1.2")],
+        "spare-rig.local.",
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     assert info_service.key == "mytesthome._homeassistant._tcp.local."
     info_service.name = "YourTestHome._homeassistant._tcp.local."
@@ -1170,9 +1170,9 @@ def test_serviceinfo_address_updates():
             0,
             0,
             {"path": "/~paulsm/"},
-            "ash-2.local.",
-            addresses=[socket.inet_aton("10.0.1.2")],
-            parsed_addresses=["10.0.1.2"],
+            "spare-rig.local.",
+            addresses=[socket.inet_aton("10.7.4.2")],
+            parsed_addresses=["10.7.4.2"],
         )
 
     info_service = ServiceInfo(
@@ -1182,19 +1182,19 @@ def test_serviceinfo_address_updates():
         0,
         0,
         {"path": "/~paulsm/"},
-        "ash-2.local.",
-        addresses=[socket.inet_aton("10.0.1.2")],
+        "spare-rig.local.",
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
-    info_service.addresses = [socket.inet_aton("10.0.1.3")]
-    assert info_service.addresses == [socket.inet_aton("10.0.1.3")]
+    info_service.addresses = [socket.inet_aton("10.7.4.3")]
+    assert info_service.addresses == [socket.inet_aton("10.7.4.3")]
 
 
 def test_serviceinfo_accepts_bytes_or_string_dict():
     """Verify a bytes or string dict can be passed to ServiceInfo."""
     type_ = "_homeassistant._tcp.local."
     name = "MyTestHome"
-    addresses = [socket.inet_aton("10.0.1.2")]
-    server_name = "ash-2.local."
+    addresses = [socket.inet_aton("10.7.4.2")]
+    server_name = "spare-rig.local."
     info_service = ServiceInfo(
         type_,
         f"{name}.{type_}",
@@ -2585,7 +2585,7 @@ async def test_own_nsec_response_does_not_complete_service(aiozc_loopback: Async
         0,
         {"path": "/~paulsm/"},
         host,
-        addresses=[socket.inet_aton("10.0.1.2")],
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     zc.record_manager.async_updates_from_response(
         mock_incoming_msg([registered.dns_service(), *registered.get_address_and_nsec_records()])
@@ -3070,25 +3070,25 @@ def test_denied_flag_is_ignored_when_address_is_held(zc_loopback: r.Zeroconf) ->
 @pytest.mark.parametrize(
     "addresses",
     [
-        ["10.0.1.2", "2001:db8::1"],
-        [socket.inet_aton("10.0.1.2"), socket.inet_pton(socket.AF_INET6, "2001:db8::1")],
-        ["10.0.1.2", socket.inet_pton(socket.AF_INET6, "2001:db8::1")],
+        ["10.7.4.2", "2001:db8::1"],
+        [socket.inet_aton("10.7.4.2"), socket.inet_pton(socket.AF_INET6, "2001:db8::1")],
+        ["10.7.4.2", socket.inet_pton(socket.AF_INET6, "2001:db8::1")],
     ],
 )
 def test_addresses_setter_accepts_str_and_bytes(addresses):
     """The addresses setter accepts str and bytes addresses."""
     type_ = "_http._tcp.local."
-    info = ServiceInfo(type_, f"xxxyyy.{type_}", 80, server="ash-2.local.")
+    info = ServiceInfo(type_, f"xxxyyy.{type_}", 80, server="spare-rig.local.")
     info.addresses = addresses
-    assert info.parsed_addresses() == ["10.0.1.2", "2001:db8::1"]
+    assert info.parsed_addresses() == ["10.7.4.2", "2001:db8::1"]
 
-    info = ServiceInfo(type_, f"xxxyyy.{type_}", 80, server="ash-2.local.", addresses=addresses)
-    assert info.parsed_addresses() == ["10.0.1.2", "2001:db8::1"]
+    info = ServiceInfo(type_, f"xxxyyy.{type_}", 80, server="spare-rig.local.", addresses=addresses)
+    assert info.parsed_addresses() == ["10.7.4.2", "2001:db8::1"]
 
 
 def test_addresses_setter_rejects_invalid_address():
     """The addresses setter raises TypeError for invalid addresses."""
     type_ = "_http._tcp.local."
-    info = ServiceInfo(type_, f"xxxyyy.{type_}", 80, server="ash-2.local.")
+    info = ServiceInfo(type_, f"xxxyyy.{type_}", 80, server="spare-rig.local.")
     with pytest.raises(TypeError, match="Addresses must either be"):
         info.addresses = ["not an address"]

--- a/tests/services/test_registry.py
+++ b/tests/services/test_registry.py
@@ -23,8 +23,8 @@ class TestServiceRegistry(unittest.TestCase):
             0,
             0,
             desc,
-            "ash-2.local.",
-            addresses=[socket.inet_aton("10.0.1.2")],
+            "spare-rig.local.",
+            addresses=[socket.inet_aton("10.7.4.2")],
         )
 
         registry = r.ServiceRegistry()
@@ -49,7 +49,7 @@ class TestServiceRegistry(unittest.TestCase):
             0,
             desc,
             "same.local.",
-            addresses=[socket.inet_aton("10.0.1.2")],
+            addresses=[socket.inet_aton("10.7.4.2")],
         )
         info2 = ServiceInfo(
             type_,
@@ -59,7 +59,7 @@ class TestServiceRegistry(unittest.TestCase):
             0,
             desc,
             "same.local.",
-            addresses=[socket.inet_aton("10.0.1.2")],
+            addresses=[socket.inet_aton("10.7.4.2")],
         )
         registry = r.ServiceRegistry()
         registry.async_add(info)
@@ -90,8 +90,8 @@ class TestServiceRegistry(unittest.TestCase):
             0,
             0,
             desc,
-            "ash-2.local.",
-            addresses=[socket.inet_aton("10.0.1.2")],
+            "spare-rig.local.",
+            addresses=[socket.inet_aton("10.7.4.2")],
         )
 
         registry = r.ServiceRegistry()
@@ -113,8 +113,8 @@ class TestServiceRegistry(unittest.TestCase):
             0,
             0,
             desc,
-            "ash-2.local.",
-            addresses=[socket.inet_aton("10.0.1.2")],
+            "spare-rig.local.",
+            addresses=[socket.inet_aton("10.7.4.2")],
         )
 
         registry = r.ServiceRegistry()
@@ -123,7 +123,7 @@ class TestServiceRegistry(unittest.TestCase):
         assert registry.async_get_service_infos() == [info]
         assert registry.async_get_info_name(registration_name) == info
         assert registry.async_get_infos_type(type_) == [info]
-        assert registry.async_get_infos_server("ash-2.local.") == [info]
+        assert registry.async_get_infos_server("spare-rig.local.") == [info]
         assert registry.async_get_types() == [type_]
 
     def test_lookups_upper_case_by_lower_case(self):
@@ -139,8 +139,8 @@ class TestServiceRegistry(unittest.TestCase):
             0,
             0,
             desc,
-            "ASH-2.local.",
-            addresses=[socket.inet_aton("10.0.1.2")],
+            "SPARE-RIG.local.",
+            addresses=[socket.inet_aton("10.7.4.2")],
         )
 
         registry = r.ServiceRegistry()
@@ -149,7 +149,7 @@ class TestServiceRegistry(unittest.TestCase):
         assert registry.async_get_service_infos() == [info]
         assert registry.async_get_info_name(registration_name.lower()) == info
         assert registry.async_get_infos_type(type_.lower()) == [info]
-        assert registry.async_get_infos_server("ash-2.local.") == [info]
+        assert registry.async_get_infos_server("spare-rig.local.") == [info]
         assert registry.async_get_types() == [type_.lower()]
 
     def test_empty_buckets_are_removed_when_last_entry_is_removed(self):
@@ -163,8 +163,8 @@ class TestServiceRegistry(unittest.TestCase):
             0,
             0,
             desc,
-            "ash-2.local.",
-            addresses=[socket.inet_aton("10.0.1.2")],
+            "spare-rig.local.",
+            addresses=[socket.inet_aton("10.7.4.2")],
         )
 
         registry = r.ServiceRegistry()
@@ -172,7 +172,7 @@ class TestServiceRegistry(unittest.TestCase):
         registry.async_remove(info)
 
         assert type_.lower() not in registry.types
-        assert "ash-2.local." not in registry.servers
+        assert "spare-rig.local." not in registry.servers
         assert registry.async_get_types() == []
 
     def test_bulk_remove_preserves_order_of_survivors(self):
@@ -188,7 +188,7 @@ class TestServiceRegistry(unittest.TestCase):
                 0,
                 desc,
                 server,
-                addresses=[socket.inet_aton("10.0.1.2")],
+                addresses=[socket.inet_aton("10.7.4.2")],
             )
             for i in range(20)
         ]
@@ -208,7 +208,7 @@ class TestServiceRegistry(unittest.TestCase):
     def test_bulk_remove_then_readd_under_same_key(self):
         """Re-adding after the bucket was deleted must rebuild it cleanly."""
         type_ = "_test-srvc-type._tcp.local."
-        server = "ash-2.local."
+        server = "spare-rig.local."
         desc = {"path": "/~paulsm/"}
         info = ServiceInfo(
             type_,
@@ -218,7 +218,7 @@ class TestServiceRegistry(unittest.TestCase):
             0,
             desc,
             server,
-            addresses=[socket.inet_aton("10.0.1.2")],
+            addresses=[socket.inet_aton("10.7.4.2")],
         )
 
         registry = r.ServiceRegistry()
@@ -231,7 +231,7 @@ class TestServiceRegistry(unittest.TestCase):
 
     def test_update_replaces_indexed_info(self):
         type_ = "_test-srvc-type._tcp.local."
-        server = "ash-2.local."
+        server = "spare-rig.local."
         registration_name = f"xxxyyy.{type_}"
         info = ServiceInfo(
             type_,
@@ -241,7 +241,7 @@ class TestServiceRegistry(unittest.TestCase):
             0,
             {"path": "/~paulsm/"},
             server,
-            addresses=[socket.inet_aton("10.0.1.2")],
+            addresses=[socket.inet_aton("10.7.4.2")],
         )
         updated = ServiceInfo(
             type_,
@@ -251,7 +251,7 @@ class TestServiceRegistry(unittest.TestCase):
             0,
             {"path": "/~paulsm/"},
             server,
-            addresses=[socket.inet_aton("10.0.1.3")],
+            addresses=[socket.inet_aton("10.7.4.3")],
         )
 
         registry = r.ServiceRegistry()

--- a/tests/services/test_types.py
+++ b/tests/services/test_types.py
@@ -42,8 +42,8 @@ def test_integration_with_listener(quick_timing, disable_duplicate_packet_suppre
         0,
         0,
         desc,
-        "ash-2.local.",
-        addresses=[socket.inet_aton("10.0.1.2")],
+        "spare-rig.local.",
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     zeroconf_registrar.registry.async_add(info)
     try:
@@ -74,7 +74,7 @@ def test_integration_with_listener_v6_records(quick_timing, disable_duplicate_pa
         0,
         0,
         desc,
-        "ash-2.local.",
+        "spare-rig.local.",
         addresses=[socket.inet_pton(socket.AF_INET6, addr)],
     )
     zeroconf_registrar.registry.async_add(info)
@@ -110,7 +110,7 @@ def test_integration_with_listener_ipv6(quick_timing, disable_duplicate_packet_s
         0,
         0,
         desc,
-        "ash-2.local.",
+        "spare-rig.local.",
         addresses=[socket.inet_pton(socket.AF_INET6, addr)],
     )
     zeroconf_registrar.registry.async_add(info)
@@ -144,8 +144,8 @@ def test_integration_with_subtype_and_listener(quick_timing, disable_duplicate_p
         0,
         0,
         desc,
-        "ash-2.local.",
-        addresses=[socket.inet_aton("10.0.1.2")],
+        "spare-rig.local.",
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     zeroconf_registrar.registry.async_add(info)
     try:

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -158,8 +158,8 @@ async def test_async_service_registration(quick_timing: None) -> None:
         0,
         0,
         desc,
-        "ash-2.local.",
-        addresses=[socket.inet_aton("10.0.1.2")],
+        "spare-rig.local.",
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     task = await aiozc.async_register_service(info)
     await task
@@ -170,12 +170,12 @@ async def test_async_service_registration(quick_timing: None) -> None:
         0,
         0,
         desc,
-        "ash-2.local.",
-        addresses=[socket.inet_aton("10.0.1.3")],
+        "spare-rig.local.",
+        addresses=[socket.inet_aton("10.7.4.3")],
     )
     task = await aiozc.async_update_service(new_info)
     await task
-    assert new_info.dns_service().server_key == "ash-2.local."
+    assert new_info.dns_service().server_key == "spare-rig.local."
     new_info.server = "ash-3.local."
     task = await aiozc.async_update_service(new_info)
     await task
@@ -229,7 +229,7 @@ async def test_async_service_registration_with_server_missing(quick_timing: None
         0,
         0,
         desc,
-        addresses=[socket.inet_aton("10.0.1.2")],
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     task = await aiozc.async_register_service(info)
     await task
@@ -243,8 +243,8 @@ async def test_async_service_registration_with_server_missing(quick_timing: None
         0,
         0,
         desc,
-        "ash-2.local.",
-        addresses=[socket.inet_aton("10.0.1.3")],
+        "spare-rig.local.",
+        addresses=[socket.inet_aton("10.7.4.3")],
     )
     task = await aiozc.async_update_service(new_info)
     await task
@@ -295,8 +295,8 @@ async def test_async_service_registration_same_server_different_ports(quick_timi
         0,
         0,
         desc,
-        "ash-2.local.",
-        addresses=[socket.inet_aton("10.0.1.2")],
+        "spare-rig.local.",
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     info2 = ServiceInfo(
         type_,
@@ -305,8 +305,8 @@ async def test_async_service_registration_same_server_different_ports(quick_timi
         0,
         0,
         desc,
-        "ash-2.local.",
-        addresses=[socket.inet_aton("10.0.1.2")],
+        "spare-rig.local.",
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     tasks = []
     tasks.append(await aiozc.async_register_service(info))
@@ -315,7 +315,7 @@ async def test_async_service_registration_same_server_different_ports(quick_timi
 
     task = await aiozc.async_unregister_service(info)
     await task
-    entries = aiozc.zeroconf.cache.async_entries_with_server("ash-2.local.")
+    entries = aiozc.zeroconf.cache.async_entries_with_server("spare-rig.local.")
     assert len(entries) == 1
     assert info2.dns_service() in entries
     await aiozc.async_close()
@@ -362,8 +362,8 @@ async def test_async_service_registration_same_server_same_ports(quick_timing: N
         0,
         0,
         desc,
-        "ash-2.local.",
-        addresses=[socket.inet_aton("10.0.1.2")],
+        "spare-rig.local.",
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     info2 = ServiceInfo(
         type_,
@@ -372,8 +372,8 @@ async def test_async_service_registration_same_server_same_ports(quick_timing: N
         0,
         0,
         desc,
-        "ash-2.local.",
-        addresses=[socket.inet_aton("10.0.1.2")],
+        "spare-rig.local.",
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     tasks = []
     tasks.append(await aiozc.async_register_service(info))
@@ -382,7 +382,7 @@ async def test_async_service_registration_same_server_same_ports(quick_timing: N
 
     task = await aiozc.async_unregister_service(info)
     await task
-    entries = aiozc.zeroconf.cache.async_entries_with_server("ash-2.local.")
+    entries = aiozc.zeroconf.cache.async_entries_with_server("spare-rig.local.")
     assert len(entries) == 1
     assert info2.dns_service() in entries
     await aiozc.async_close()
@@ -410,8 +410,8 @@ async def test_async_service_registration_name_conflict(quick_timing: None) -> N
         0,
         0,
         desc,
-        "ash-2.local.",
-        addresses=[socket.inet_aton("10.0.1.2")],
+        "spare-rig.local.",
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     task = await aiozc.async_register_service(info)
     await task
@@ -432,7 +432,7 @@ async def test_async_service_registration_name_conflict(quick_timing: None) -> N
         0,
         desc,
         "ash-3.local.",
-        addresses=[socket.inet_aton("10.0.1.3")],
+        addresses=[socket.inet_aton("10.7.4.3")],
     )
 
     with pytest.raises(NonUniqueNameException):
@@ -458,8 +458,8 @@ async def test_async_service_registration_name_does_not_match_type() -> None:
         0,
         0,
         desc,
-        "ash-2.local.",
-        addresses=[socket.inet_aton("10.0.1.2")],
+        "spare-rig.local.",
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     info.type = "_wrong._tcp.local."
     with pytest.raises(BadTypeInNameException):
@@ -485,8 +485,8 @@ async def test_async_service_registration_name_strict_check(quick_timing: None) 
         0,
         0,
         desc,
-        "ash-2.local.",
-        addresses=[socket.inet_aton("10.0.1.2")],
+        "spare-rig.local.",
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     with pytest.raises(BadTypeInNameException):
         await zc.async_check_service(info, allow_name_change=False)
@@ -536,8 +536,8 @@ async def test_async_tasks(quick_timing: None) -> None:
         0,
         0,
         desc,
-        "ash-2.local.",
-        addresses=[socket.inet_aton("10.0.1.2")],
+        "spare-rig.local.",
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     task = await aiozc.async_register_service(info)
     assert isinstance(task, asyncio.Task)
@@ -550,8 +550,8 @@ async def test_async_tasks(quick_timing: None) -> None:
         0,
         0,
         desc,
-        "ash-2.local.",
-        addresses=[socket.inet_aton("10.0.1.3")],
+        "spare-rig.local.",
+        addresses=[socket.inet_aton("10.7.4.3")],
     )
     task = await aiozc.async_update_service(new_info)
     assert isinstance(task, asyncio.Task)
@@ -587,8 +587,8 @@ async def test_async_wait_unblocks_on_update(quick_timing: None) -> None:
         0,
         0,
         desc,
-        "ash-2.local.",
-        addresses=[socket.inet_aton("10.0.1.2")],
+        "spare-rig.local.",
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     task = await aiozc.async_register_service(info)
 
@@ -634,7 +634,7 @@ async def test_service_info_async_request(quick_timing: None, quick_request_timi
         0,
         desc,
         "ash-1.local.",
-        addresses=[socket.inet_aton("10.0.1.2")],
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     info2 = ServiceInfo(
         type_,
@@ -644,7 +644,7 @@ async def test_service_info_async_request(quick_timing: None, quick_request_timi
         0,
         desc,
         "ash-5.local.",
-        addresses=[socket.inet_aton("10.0.1.5")],
+        addresses=[socket.inet_aton("10.7.4.5")],
     )
     tasks = []
     tasks.append(await aiozc.async_register_service(info))
@@ -653,15 +653,15 @@ async def test_service_info_async_request(quick_timing: None, quick_request_timi
 
     aiosinfo = await get_service_info_task1
     assert aiosinfo is not None
-    assert aiosinfo.addresses == [socket.inet_aton("10.0.1.2")]
+    assert aiosinfo.addresses == [socket.inet_aton("10.7.4.2")]
 
     aiosinfo = await get_service_info_task2
     assert aiosinfo is not None
-    assert aiosinfo.addresses == [socket.inet_aton("10.0.1.2")]
+    assert aiosinfo.addresses == [socket.inet_aton("10.7.4.2")]
 
     aiosinfo = await aiozc.async_get_service_info(type_, registration_name)
     assert aiosinfo is not None
-    assert aiosinfo.addresses == [socket.inet_aton("10.0.1.2")]
+    assert aiosinfo.addresses == [socket.inet_aton("10.7.4.2")]
 
     new_info = ServiceInfo(
         type_,
@@ -670,9 +670,9 @@ async def test_service_info_async_request(quick_timing: None, quick_request_timi
         0,
         0,
         desc,
-        "ash-2.local.",
+        "spare-rig.local.",
         addresses=[
-            socket.inet_aton("10.0.1.3"),
+            socket.inet_aton("10.7.4.3"),
             socket.inet_pton(socket.AF_INET6, "6001:db8::1"),
         ],
     )
@@ -682,20 +682,20 @@ async def test_service_info_async_request(quick_timing: None, quick_request_timi
 
     aiosinfo = await aiozc.async_get_service_info(type_, registration_name)
     assert aiosinfo is not None
-    assert aiosinfo.addresses == [socket.inet_aton("10.0.1.3")]
+    assert aiosinfo.addresses == [socket.inet_aton("10.7.4.3")]
 
     aiosinfo = await aiozc.zeroconf.async_get_service_info(type_, registration_name)
     assert aiosinfo is not None
-    assert aiosinfo.addresses == [socket.inet_aton("10.0.1.3")]
+    assert aiosinfo.addresses == [socket.inet_aton("10.7.4.3")]
 
     aiosinfos = await asyncio.gather(
         aiozc.async_get_service_info(type_, registration_name),
         aiozc.async_get_service_info(type_, registration_name2),
     )
     assert aiosinfos[0] is not None
-    assert aiosinfos[0].addresses == [socket.inet_aton("10.0.1.3")]
+    assert aiosinfos[0].addresses == [socket.inet_aton("10.7.4.3")]
     assert aiosinfos[1] is not None
-    assert aiosinfos[1].addresses == [socket.inet_aton("10.0.1.5")]
+    assert aiosinfos[1].addresses == [socket.inet_aton("10.7.4.5")]
 
     # Drop pending multicast responses queued under the original
     # `info` / `info2` registrations. Their snapshots predate the
@@ -717,7 +717,7 @@ async def test_service_info_async_request(quick_timing: None, quick_request_timi
     with patch("zeroconf.asyncio.AsyncServiceInfo._is_complete", False):
         await aiosinfo.async_request(aiozc.zeroconf, 300)
     assert aiosinfo is not None
-    assert aiosinfo.addresses == [socket.inet_aton("10.0.1.3")]
+    assert aiosinfo.addresses == [socket.inet_aton("10.7.4.3")]
 
     task = await aiozc.async_unregister_service(new_info)
     await task
@@ -761,8 +761,8 @@ async def test_async_service_browser(quick_timing: None) -> None:
         0,
         0,
         desc,
-        "ash-2.local.",
-        addresses=[socket.inet_aton("10.0.1.2")],
+        "spare-rig.local.",
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     task = await aiozc.async_register_service(info)
     await task
@@ -773,8 +773,8 @@ async def test_async_service_browser(quick_timing: None) -> None:
         0,
         0,
         desc,
-        "ash-2.local.",
-        addresses=[socket.inet_aton("10.0.1.3")],
+        "spare-rig.local.",
+        addresses=[socket.inet_aton("10.7.4.3")],
     )
     task = await aiozc.async_update_service(new_info)
     await task
@@ -805,8 +805,8 @@ async def test_async_context_manager(quick_timing: None) -> None:
             0,
             0,
             {"path": "/~paulsm/"},
-            "ash-2.local.",
-            addresses=[socket.inet_aton("10.0.1.2")],
+            "spare-rig.local.",
+            addresses=[socket.inet_aton("10.7.4.2")],
         )
         task = await aiozc.async_register_service(info)
         await task
@@ -859,7 +859,7 @@ async def test_async_unregister_all_services(quick_timing: None) -> None:
         0,
         desc,
         "ash-1.local.",
-        addresses=[socket.inet_aton("10.0.1.2")],
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     info2 = ServiceInfo(
         type_,
@@ -869,7 +869,7 @@ async def test_async_unregister_all_services(quick_timing: None) -> None:
         0,
         desc,
         "ash-5.local.",
-        addresses=[socket.inet_aton("10.0.1.5")],
+        addresses=[socket.inet_aton("10.7.4.5")],
     )
     tasks = []
     tasks.append(await aiozc.async_register_service(info))
@@ -914,8 +914,8 @@ async def test_async_zeroconf_service_types(quick_timing: None) -> None:
         0,
         0,
         desc,
-        "ash-2.local.",
-        addresses=[socket.inet_aton("10.0.1.2")],
+        "spare-rig.local.",
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     task = await zeroconf_registrar.async_register_service(info)
     await task
@@ -977,9 +977,9 @@ async def test_service_browser_instantiation_generates_add_events_from_cache():
     listener = MyServiceListener()
 
     desc = {"path": "/~paulsm/"}
-    address_parsed = "10.0.1.2"
+    address_parsed = "10.7.4.2"
     address = socket.inet_aton(address_parsed)
-    info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, "ash-2.local.", addresses=[address])
+    info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, "spare-rig.local.", addresses=[address])
     zc.cache.async_add_records(
         [info.dns_pointer(), info.dns_service(), *info.dns_addresses(), info.dns_text()]
     )
@@ -1062,8 +1062,8 @@ async def test_integration(quick_timing: None) -> None:
             0,
             0,
             {"path": "/~paulsm/"},
-            "ash-2.local.",
-            addresses=[socket.inet_aton("10.0.1.2")],
+            "spare-rig.local.",
+            addresses=[socket.inet_aton("10.7.4.2")],
         )
         # Wait for the browser's first startup query to land (with an empty
         # cache) before registering — otherwise on fast loopback the register
@@ -1177,8 +1177,8 @@ async def test_info_asking_default_is_asking_qm_questions_after_the_first_qu(qui
         0,
         0,
         desc,
-        "ash-2.local.",
-        addresses=[socket.inet_aton("10.0.1.2")],
+        "spare-rig.local.",
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
 
     zeroconf_info.registry.async_add(info)
@@ -1243,9 +1243,9 @@ async def test_service_browser_ignores_unrelated_updates():
     listener = MyServiceListener()
 
     desc = {"path": "/~paulsm/"}
-    address_parsed = "10.0.1.2"
+    address_parsed = "10.7.4.2"
     address = socket.inet_aton(address_parsed)
-    info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, "ash-2.local.", addresses=[address])
+    info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, "spare-rig.local.", addresses=[address])
     zc.cache.async_add_records(
         [
             info.dns_pointer(),
@@ -1354,8 +1354,8 @@ async def test_legacy_unicast_response(run_isolated):
         0,
         0,
         desc,
-        "ash-2.local.",
-        addresses=[socket.inet_aton("10.0.1.2")],
+        "spare-rig.local.",
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
 
     aiozc.zeroconf.registry.async_add(info)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -57,167 +57,147 @@ def threadsafe_query(
     asyncio.run_coroutine_threadsafe(make_query(), zc.loop).result()
 
 
-class Framework(unittest.TestCase):
-    def test_launch_and_close_context_manager(self):
-        with r.Zeroconf(interfaces=r.InterfaceChoice.All) as rv:
-            assert rv.done is False
-        assert rv.done is True
+@pytest.mark.parametrize("interfaces", [r.InterfaceChoice.All, r.InterfaceChoice.Default])
+def test_open_and_close_cleanly(interfaces):
+    r.Zeroconf(interfaces=interfaces).close()
 
-        with r.Zeroconf(interfaces=r.InterfaceChoice.Default) as rv:  # type: ignore[unreachable]
-            assert rv.done is False
-        assert rv.done is True
 
-    def test_launch_and_close_unicast(self):
-        rv = r.Zeroconf(interfaces=r.InterfaceChoice.All, unicast=True)
-        rv.close()
-        rv = r.Zeroconf(interfaces=r.InterfaceChoice.Default, unicast=True)
-        rv.close()
+def test_launch_and_close_context_manager():
+    with r.Zeroconf(interfaces=r.InterfaceChoice.All) as rv:
+        assert rv.done is False
+    assert rv.done is True
 
-    def test_close_multiple_times(self):
-        rv = r.Zeroconf(interfaces=r.InterfaceChoice.Default)
-        rv.close()
-        rv.close()
+    with r.Zeroconf(interfaces=r.InterfaceChoice.Default) as rv:  # type: ignore[unreachable]
+        assert rv.done is False
+    assert rv.done is True
 
-    def test_close_releases_owned_event_loop(self):
-        """Closing a Zeroconf that started its own loop thread closes that loop.
 
-        Regression test for issue #1589 — without loop.close(), the selector
-        (epoll on Linux) and its self-pipe sockets stay open across each
-        Zeroconf construct/close cycle and the process eventually exhausts
-        its FD limit.
-        """
-        rv = r.Zeroconf(interfaces=["127.0.0.1"])
-        loop = rv.loop
-        assert loop is not None
-        assert loop.is_running()
-        rv.close()
-        assert loop.is_closed()
+def test_launch_and_close_unicast():
+    rv = r.Zeroconf(interfaces=r.InterfaceChoice.All, unicast=True)
+    rv.close()
+    rv = r.Zeroconf(interfaces=r.InterfaceChoice.Default, unicast=True)
+    rv.close()
 
-    @unittest.skipUnless(sys.platform.startswith("linux"), "Requires /proc/<pid>/fd")
-    @unittest.skipUnless(Path(f"/proc/{os.getpid()}/fd").is_dir(), "/proc/<pid>/fd not available")
-    def test_close_does_not_leak_file_descriptors(self):
-        """Tight loops of Zeroconf()/close() do not leak FDs (issue #1589)."""
-        fd_dir = Path(f"/proc/{os.getpid()}/fd")
 
-        def _fd_count() -> int:
-            return sum(1 for _ in fd_dir.iterdir())
+def test_close_multiple_times():
+    rv = r.Zeroconf(interfaces=r.InterfaceChoice.Default)
+    rv.close()
+    rv.close()
 
-        # Warm-up cycle so any one-shot import-time FDs land before measuring.
+
+def test_close_releases_owned_event_loop():
+    """Closing a Zeroconf that started its own loop thread closes that loop.
+
+    Regression test for issue #1589 — without loop.close(), the selector
+    (epoll on Linux) and its self-pipe sockets stay open across each
+    Zeroconf construct/close cycle and the process eventually exhausts
+    its FD limit.
+    """
+    rv = r.Zeroconf(interfaces=["127.0.0.1"])
+    loop = rv.loop
+    assert loop is not None
+    assert loop.is_running()
+    rv.close()
+    assert loop.is_closed()
+
+
+@pytest.mark.skipif(not (sys.platform.startswith("linux")), reason="Requires /proc/<pid>/fd")
+@pytest.mark.skipif(not (Path(f"/proc/{os.getpid()}/fd").is_dir()), reason="/proc/<pid>/fd not available")
+def test_close_does_not_leak_file_descriptors():
+    """Tight loops of Zeroconf()/close() do not leak FDs (issue #1589)."""
+    fd_dir = Path(f"/proc/{os.getpid()}/fd")
+
+    def _fd_count() -> int:
+        return sum(1 for _ in fd_dir.iterdir())
+
+    # Warm-up cycle so any one-shot import-time FDs land before measuring.
+    r.Zeroconf(interfaces=["127.0.0.1"]).close()
+    baseline = _fd_count()
+    for _ in range(10):
         r.Zeroconf(interfaces=["127.0.0.1"]).close()
-        baseline = _fd_count()
-        for _ in range(10):
-            r.Zeroconf(interfaces=["127.0.0.1"]).close()
-        # Allow tiny slack for unrelated FDs the test harness may open
-        # (e.g. coverage), but reject the per-cycle linear growth pattern
-        # the bug produced (~3 FDs per cycle, so >=30 over 10 cycles).
-        assert _fd_count() - baseline < 10
+    # Allow tiny slack for unrelated FDs the test harness may open
+    # (e.g. coverage), but reject the per-cycle linear growth pattern
+    # the bug produced (~3 FDs per cycle, so >=30 over 10 cycles).
+    assert _fd_count() - baseline < 10
 
-    @unittest.skipIf(not has_working_ipv6(), "Requires IPv6")
-    @unittest.skipIf(os.environ.get("SKIP_IPV6"), "IPv6 tests disabled")
-    def test_launch_and_close_v4_v6(self):
-        rv = r.Zeroconf(interfaces=r.InterfaceChoice.All, ip_version=r.IPVersion.All)
+
+@pytest.mark.skipif(not has_working_ipv6(), reason="Requires IPv6")
+@pytest.mark.skipif(os.environ.get("SKIP_IPV6"), reason="IPv6 tests disabled")
+def test_launch_and_close_v4_v6():
+    rv = r.Zeroconf(interfaces=r.InterfaceChoice.All, ip_version=r.IPVersion.All)
+    rv.close()
+    with warnings.catch_warnings(record=True) as warned:
+        rv = r.Zeroconf(interfaces=r.InterfaceChoice.Default, ip_version=r.IPVersion.All)
         rv.close()
-        with warnings.catch_warnings(record=True) as warned:
-            rv = r.Zeroconf(interfaces=r.InterfaceChoice.Default, ip_version=r.IPVersion.All)
-            rv.close()
-            first_warning = warned[0]
-            assert "IPv6 multicast requests can't be sent using default interface" in str(
-                first_warning.message
-            )
+        first_warning = warned[0]
+        assert "IPv6 multicast requests can't be sent using default interface" in str(first_warning.message)
 
-    @unittest.skipIf(not has_working_ipv6(), "Requires IPv6")
-    @unittest.skipIf(os.environ.get("SKIP_IPV6"), "IPv6 tests disabled")
-    def test_launch_and_close_v6_only(self):
-        rv = r.Zeroconf(interfaces=r.InterfaceChoice.All, ip_version=r.IPVersion.V6Only)
+
+@pytest.mark.skipif(not has_working_ipv6(), reason="Requires IPv6")
+@pytest.mark.skipif(os.environ.get("SKIP_IPV6"), reason="IPv6 tests disabled")
+def test_launch_and_close_v6_only():
+    rv = r.Zeroconf(interfaces=r.InterfaceChoice.All, ip_version=r.IPVersion.V6Only)
+    rv.close()
+    with warnings.catch_warnings(record=True) as warned:
+        rv = r.Zeroconf(interfaces=r.InterfaceChoice.Default, ip_version=r.IPVersion.V6Only)
         rv.close()
-        with warnings.catch_warnings(record=True) as warned:
-            rv = r.Zeroconf(interfaces=r.InterfaceChoice.Default, ip_version=r.IPVersion.V6Only)
-            rv.close()
-            first_warning = warned[0]
-            assert "IPv6 multicast requests can't be sent using default interface" in str(
-                first_warning.message
-            )
+        first_warning = warned[0]
+        assert "IPv6 multicast requests can't be sent using default interface" in str(first_warning.message)
 
-    @unittest.skipIf(sys.platform == "darwin", reason="apple_p2p failure path not testable on mac")
-    def test_launch_and_close_apple_p2p_not_mac(self):
-        with pytest.raises(RuntimeError):
-            r.Zeroconf(apple_p2p=True)
 
-    @unittest.skipIf(sys.platform != "darwin", reason="apple_p2p happy path only testable on mac")
-    def test_launch_and_close_apple_p2p_on_mac(self):
-        rv = r.Zeroconf(apple_p2p=True)
-        rv.close()
+@pytest.mark.skipif(sys.platform == "darwin", reason="apple_p2p failure path not testable on mac")
+def test_launch_and_close_apple_p2p_not_mac():
+    with pytest.raises(RuntimeError):
+        r.Zeroconf(apple_p2p=True)
 
-    def test_use_asyncio_false_forces_thread_when_loop_running(self):
-        """use_asyncio=False starts a thread even with a running event loop."""
 
-        async def run() -> r.Zeroconf:
-            return r.Zeroconf(interfaces=["127.0.0.1"], use_asyncio=False)
+@pytest.mark.skipif(sys.platform != "darwin", reason="apple_p2p happy path only testable on mac")
+def test_launch_and_close_apple_p2p_on_mac():
+    rv = r.Zeroconf(apple_p2p=True)
+    rv.close()
 
-        loop = asyncio.new_event_loop()
-        zc: r.Zeroconf | None = None
-        try:
-            zc = loop.run_until_complete(run())
-            assert zc._loop_thread is not None
-            assert zc.loop is not loop
-        finally:
-            if zc is not None:
-                zc.close()
-            loop.close()
 
-    def test_use_asyncio_true_requires_running_loop(self):
-        """use_asyncio=True without a running loop raises RuntimeError."""
-        with pytest.raises(RuntimeError, match="requires a running asyncio event loop"):
-            r.Zeroconf(interfaces=["127.0.0.1"], use_asyncio=True)
+def test_use_asyncio_false_forces_thread_when_loop_running():
+    """use_asyncio=False starts a thread even with a running event loop."""
 
-    def test_use_asyncio_default_starts_thread_without_loop(self):
-        """use_asyncio=None (default) keeps the historic auto-detect behavior."""
-        zc = r.Zeroconf(interfaces=["127.0.0.1"])
-        try:
-            assert zc._loop_thread is not None
-        finally:
+    async def run() -> r.Zeroconf:
+        return r.Zeroconf(interfaces=["127.0.0.1"], use_asyncio=False)
+
+    loop = asyncio.new_event_loop()
+    zc: r.Zeroconf | None = None
+    try:
+        zc = loop.run_until_complete(run())
+        assert zc._loop_thread is not None
+        assert zc.loop is not loop
+    finally:
+        if zc is not None:
             zc.close()
+        loop.close()
 
-    def test_async_updates_from_response(self):
-        def mock_incoming_msg(
-            service_state_change: r.ServiceStateChange,
-        ) -> r.DNSIncoming:
-            ttl = 120
-            generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
 
-            if service_state_change == r.ServiceStateChange.Updated:
-                generated.add_answer_at_time(
-                    r.DNSText(
-                        service_name,
-                        const._TYPE_TXT,
-                        const._CLASS_IN | const._CLASS_UNIQUE,
-                        ttl,
-                        service_text,
-                    ),
-                    0,
-                )
-                return r.DNSIncoming(generated.packets()[0])
+def test_use_asyncio_true_requires_running_loop():
+    """use_asyncio=True without a running loop raises RuntimeError."""
+    with pytest.raises(RuntimeError, match="requires a running asyncio event loop"):
+        r.Zeroconf(interfaces=["127.0.0.1"], use_asyncio=True)
 
-            if service_state_change == r.ServiceStateChange.Removed:
-                ttl = 0
 
-            generated.add_answer_at_time(
-                r.DNSPointer(service_type, const._TYPE_PTR, const._CLASS_IN, ttl, service_name),
-                0,
-            )
-            generated.add_answer_at_time(
-                r.DNSService(
-                    service_name,
-                    const._TYPE_SRV,
-                    const._CLASS_IN | const._CLASS_UNIQUE,
-                    ttl,
-                    0,
-                    0,
-                    80,
-                    service_server,
-                ),
-                0,
-            )
+def test_use_asyncio_default_starts_thread_without_loop():
+    """use_asyncio=None (default) keeps the historic auto-detect behavior."""
+    zc = r.Zeroconf(interfaces=["127.0.0.1"])
+    try:
+        assert zc._loop_thread is not None
+    finally:
+        zc.close()
+
+
+def test_async_updates_from_response():
+    def mock_incoming_msg(
+        service_state_change: r.ServiceStateChange,
+    ) -> r.DNSIncoming:
+        ttl = 120
+        generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
+
+        if service_state_change == r.ServiceStateChange.Updated:
             generated.add_answer_at_time(
                 r.DNSText(
                     service_name,
@@ -228,100 +208,132 @@ class Framework(unittest.TestCase):
                 ),
                 0,
             )
-            generated.add_answer_at_time(
-                r.DNSAddress(
-                    service_server,
-                    const._TYPE_A,
-                    const._CLASS_IN | const._CLASS_UNIQUE,
-                    ttl,
-                    socket.inet_aton(service_address),
-                ),
-                0,
-            )
-
             return r.DNSIncoming(generated.packets()[0])
 
-        def mock_split_incoming_msg(
-            service_state_change: r.ServiceStateChange,
-        ) -> r.DNSIncoming:
-            """Mock an incoming message for the case where the packet is split."""
-            ttl = 120
-            generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
-            generated.add_answer_at_time(
-                r.DNSAddress(
-                    service_server,
-                    const._TYPE_A,
-                    const._CLASS_IN | const._CLASS_UNIQUE,
-                    ttl,
-                    socket.inet_aton(service_address),
-                ),
+        if service_state_change == r.ServiceStateChange.Removed:
+            ttl = 0
+
+        generated.add_answer_at_time(
+            r.DNSPointer(service_type, const._TYPE_PTR, const._CLASS_IN, ttl, service_name),
+            0,
+        )
+        generated.add_answer_at_time(
+            r.DNSService(
+                service_name,
+                const._TYPE_SRV,
+                const._CLASS_IN | const._CLASS_UNIQUE,
+                ttl,
                 0,
-            )
-            generated.add_answer_at_time(
-                r.DNSService(
-                    service_name,
-                    const._TYPE_SRV,
-                    const._CLASS_IN | const._CLASS_UNIQUE,
-                    ttl,
-                    0,
-                    0,
-                    80,
-                    service_server,
-                ),
                 0,
-            )
-            return r.DNSIncoming(generated.packets()[0])
+                80,
+                service_server,
+            ),
+            0,
+        )
+        generated.add_answer_at_time(
+            r.DNSText(
+                service_name,
+                const._TYPE_TXT,
+                const._CLASS_IN | const._CLASS_UNIQUE,
+                ttl,
+                service_text,
+            ),
+            0,
+        )
+        generated.add_answer_at_time(
+            r.DNSAddress(
+                service_server,
+                const._TYPE_A,
+                const._CLASS_IN | const._CLASS_UNIQUE,
+                ttl,
+                socket.inet_aton(service_address),
+            ),
+            0,
+        )
 
-        service_name = "name._type._tcp.local."
-        service_type = "_type._tcp.local."
-        service_server = "ash-2.local."
-        service_text = b"path=/~paulsm/"
-        service_address = "10.0.1.2"
+        return r.DNSIncoming(generated.packets()[0])
 
-        zeroconf = r.Zeroconf(interfaces=["127.0.0.1"])
+    def mock_split_incoming_msg(
+        service_state_change: r.ServiceStateChange,
+    ) -> r.DNSIncoming:
+        """Mock an incoming message for the case where the packet is split."""
+        ttl = 120
+        generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
+        generated.add_answer_at_time(
+            r.DNSAddress(
+                service_server,
+                const._TYPE_A,
+                const._CLASS_IN | const._CLASS_UNIQUE,
+                ttl,
+                socket.inet_aton(service_address),
+            ),
+            0,
+        )
+        generated.add_answer_at_time(
+            r.DNSService(
+                service_name,
+                const._TYPE_SRV,
+                const._CLASS_IN | const._CLASS_UNIQUE,
+                ttl,
+                0,
+                0,
+                80,
+                service_server,
+            ),
+            0,
+        )
+        return r.DNSIncoming(generated.packets()[0])
 
-        try:
-            # service added
-            _inject_response(zeroconf, mock_incoming_msg(r.ServiceStateChange.Added))
-            dns_text = zeroconf.cache.get_by_details(service_name, const._TYPE_TXT, const._CLASS_IN)
-            assert dns_text is not None
-            assert cast(r.DNSText, dns_text).text == service_text  # service_text is b'path=/~paulsm/'
-            all_dns_text = zeroconf.cache.get_all_by_details(service_name, const._TYPE_TXT, const._CLASS_IN)
-            assert [dns_text] == all_dns_text
+    service_name = "name._type._tcp.local."
+    service_type = "_type._tcp.local."
+    service_server = "spare-rig.local."
+    service_text = b"path=/~paulsm/"
+    service_address = "10.7.4.2"
 
-            # https://tools.ietf.org/html/rfc6762#section-10.2
-            # Instead of merging this new record additively into the cache in addition
-            # to any previous records with the same name, rrtype, and rrclass,
-            # all old records with that name, rrtype, and rrclass that were received
-            # more than one second ago are declared invalid,
-            # and marked to expire from the cache in one second.
-            _backdate_cache(zeroconf)
+    zeroconf = r.Zeroconf(interfaces=["127.0.0.1"])
 
-            # service updated. currently only text record can be updated
-            service_text = b"path=/~humingchun/"
-            _inject_response(zeroconf, mock_incoming_msg(r.ServiceStateChange.Updated))
-            dns_text = zeroconf.cache.get_by_details(service_name, const._TYPE_TXT, const._CLASS_IN)
-            assert dns_text is not None
-            assert cast(r.DNSText, dns_text).text == service_text  # service_text is b'path=/~humingchun/'
+    try:
+        # service added
+        _inject_response(zeroconf, mock_incoming_msg(r.ServiceStateChange.Added))
+        dns_text = zeroconf.cache.get_by_details(service_name, const._TYPE_TXT, const._CLASS_IN)
+        assert dns_text is not None
+        assert cast(r.DNSText, dns_text).text == service_text  # service_text is b'path=/~paulsm/'
+        all_dns_text = zeroconf.cache.get_all_by_details(service_name, const._TYPE_TXT, const._CLASS_IN)
+        assert [dns_text] == all_dns_text
 
-            _backdate_cache(zeroconf)
+        # https://tools.ietf.org/html/rfc6762#section-10.2
+        # Instead of merging this new record additively into the cache in addition
+        # to any previous records with the same name, rrtype, and rrclass,
+        # all old records with that name, rrtype, and rrclass that were received
+        # more than one second ago are declared invalid,
+        # and marked to expire from the cache in one second.
+        _backdate_cache(zeroconf)
 
-            # The split message only has a SRV and A record.
-            # This should not evict TXT records from the cache
-            _inject_response(zeroconf, mock_split_incoming_msg(r.ServiceStateChange.Updated))
-            _backdate_cache(zeroconf)
-            dns_text = zeroconf.cache.get_by_details(service_name, const._TYPE_TXT, const._CLASS_IN)
-            assert dns_text is not None
-            assert cast(r.DNSText, dns_text).text == service_text  # service_text is b'path=/~humingchun/'
+        # service updated. currently only text record can be updated
+        service_text = b"path=/~humingchun/"
+        _inject_response(zeroconf, mock_incoming_msg(r.ServiceStateChange.Updated))
+        dns_text = zeroconf.cache.get_by_details(service_name, const._TYPE_TXT, const._CLASS_IN)
+        assert dns_text is not None
+        assert cast(r.DNSText, dns_text).text == service_text  # service_text is b'path=/~humingchun/'
 
-            # service removed
-            _inject_response(zeroconf, mock_incoming_msg(r.ServiceStateChange.Removed))
-            dns_text = zeroconf.cache.get_by_details(service_name, const._TYPE_TXT, const._CLASS_IN)
-            assert dns_text is not None
-            assert dns_text.is_expired(current_time_millis() + 1000)
+        _backdate_cache(zeroconf)
 
-        finally:
-            zeroconf.close()
+        # The split message only has a SRV and A record.
+        # This should not evict TXT records from the cache
+        _inject_response(zeroconf, mock_split_incoming_msg(r.ServiceStateChange.Updated))
+        _backdate_cache(zeroconf)
+        dns_text = zeroconf.cache.get_by_details(service_name, const._TYPE_TXT, const._CLASS_IN)
+        assert dns_text is not None
+        assert cast(r.DNSText, dns_text).text == service_text  # service_text is b'path=/~humingchun/'
+
+        # service removed
+        _inject_response(zeroconf, mock_incoming_msg(r.ServiceStateChange.Removed))
+        dns_text = zeroconf.cache.get_by_details(service_name, const._TYPE_TXT, const._CLASS_IN)
+        assert dns_text is not None
+        assert dns_text.is_expired(current_time_millis() + 1000)
+
+    finally:
+        zeroconf.close()
 
 
 def test_generate_service_query_set_qu_bit():
@@ -338,8 +350,8 @@ def test_generate_service_query_set_qu_bit():
         0,
         0,
         desc,
-        "ash-2.local.",
-        addresses=[socket.inet_aton("10.0.1.2")],
+        "spare-rig.local.",
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     out = zeroconf_registrar.generate_service_query(info)
     assert out.questions[0].unicast is True
@@ -399,8 +411,8 @@ def test_goodbye_all_services():
         0,
         0,
         desc,
-        "ash-2.local.",
-        addresses=[socket.inet_aton("10.0.1.2")],
+        "spare-rig.local.",
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     zc.registry.async_add(info)
     out = zc.generate_unregister_all_services()
@@ -437,7 +449,7 @@ def test_register_service_with_custom_ttl(quick_timing: None) -> None:
         0,
         {"path": "/~paulsm/"},
         "ash-90.local.",
-        addresses=[socket.inet_aton("10.0.1.2")],
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
 
     zc.register_service(info_service, ttl=3000)
@@ -464,7 +476,7 @@ def test_logging_packets(caplog: pytest.LogCaptureFixture, quick_timing: None) -
         0,
         {"path": "/~paulsm/"},
         "ash-90.local.",
-        addresses=[socket.inet_aton("10.0.1.2")],
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
 
     logging.getLogger("zeroconf").setLevel(logging.DEBUG)
@@ -538,7 +550,7 @@ def test_tc_bit_defers():
     registration3_name = f"{name3}.{type_}"
 
     desc = {"path": "/~paulsm/"}
-    server_name = "ash-2.local."
+    server_name = "spare-rig.local."
     server_name2 = "ash-3.local."
     server_name3 = "ash-4.local."
 
@@ -550,7 +562,7 @@ def test_tc_bit_defers():
         0,
         desc,
         server_name,
-        addresses=[socket.inet_aton("10.0.1.2")],
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     info2 = r.ServiceInfo(
         type_,
@@ -560,7 +572,7 @@ def test_tc_bit_defers():
         0,
         desc,
         server_name2,
-        addresses=[socket.inet_aton("10.0.1.2")],
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     info3 = r.ServiceInfo(
         type_,
@@ -570,7 +582,7 @@ def test_tc_bit_defers():
         0,
         desc,
         server_name3,
-        addresses=[socket.inet_aton("10.0.1.2")],
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     zc.registry.async_add(info)
     zc.registry.async_add(info2)
@@ -638,7 +650,7 @@ def test_tc_bit_defers_last_response_missing():
     registration3_name = f"{name3}.{type_}"
 
     desc = {"path": "/~paulsm/"}
-    server_name = "ash-2.local."
+    server_name = "spare-rig.local."
     server_name2 = "ash-3.local."
     server_name3 = "ash-4.local."
 
@@ -650,7 +662,7 @@ def test_tc_bit_defers_last_response_missing():
         0,
         desc,
         server_name,
-        addresses=[socket.inet_aton("10.0.1.2")],
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     info2 = r.ServiceInfo(
         type_,
@@ -660,7 +672,7 @@ def test_tc_bit_defers_last_response_missing():
         0,
         desc,
         server_name2,
-        addresses=[socket.inet_aton("10.0.1.2")],
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     info3 = r.ServiceInfo(
         type_,
@@ -670,7 +682,7 @@ def test_tc_bit_defers_last_response_missing():
         0,
         desc,
         server_name3,
-        addresses=[socket.inet_aton("10.0.1.2")],
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     zc.registry.async_add(info)
     zc.registry.async_add(info2)
@@ -756,8 +768,8 @@ def test_tc_bit_defer_window_is_bounded():
         0,
         0,
         {"path": "/~paulsm/"},
-        "ash-2.local.",
-        addresses=[socket.inet_aton("10.0.1.2")],
+        "spare-rig.local.",
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     zc.registry.async_add(info)
 
@@ -945,7 +957,7 @@ def test_shutdown_while_register_in_process(quick_timing: None) -> None:
         0,
         {"path": "/~paulsm/"},
         "ash-90.local.",
-        addresses=[socket.inet_aton("10.0.1.2")],
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
 
     def _background_register():

--- a/tests/test_dns.py
+++ b/tests/test_dns.py
@@ -108,8 +108,8 @@ class TestDunder(unittest.TestCase):
             0,
             0,
             b"",
-            "ash-2.local.",
-            addresses=[socket.inet_aton("10.0.1.2")],
+            "spare-rig.local.",
+            addresses=[socket.inet_aton("10.7.4.2")],
         )
 
         assert (info != info) is False
@@ -122,9 +122,9 @@ class TestDunder(unittest.TestCase):
         info = ServiceInfo(
             type_=type_,
             name=registration_name,
-            addresses=[socket.inet_aton("10.0.1.2")],
+            addresses=[socket.inet_aton("10.7.4.2")],
             port=80,
-            server="ash-2.local.",
+            server="spare-rig.local.",
         )
 
         assert isinstance(info.text, bytes)

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -58,8 +58,8 @@ class TestRegistrar(unittest.TestCase):
             0,
             0,
             desc,
-            "ash-2.local.",
-            addresses=[socket.inet_aton("10.0.1.2")],
+            "spare-rig.local.",
+            addresses=[socket.inet_aton("10.7.4.2")],
         )
 
         nbr_answers = nbr_additionals = nbr_authorities = 0
@@ -246,8 +246,8 @@ def test_ptr_optimization(quick_timing: None) -> None:
         0,
         0,
         desc,
-        "ash-2.local.",
-        addresses=[socket.inet_aton("10.0.1.2")],
+        "spare-rig.local.",
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
 
     # register
@@ -311,7 +311,7 @@ def test_any_query_for_ptr():
     name = "knownname"
     registration_name = f"{name}.{type_}"
     desc = {"path": "/~paulsm/"}
-    server_name = "ash-2.local."
+    server_name = "spare-rig.local."
     ipv6_address = socket.inet_pton(socket.AF_INET6, "2001:db8::1")
     info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, server_name, addresses=[ipv6_address])
     zc.registry.async_add(info)
@@ -340,7 +340,7 @@ def test_aaaa_query():
     name = "knownname"
     registration_name = f"{name}.{type_}"
     desc = {"path": "/~paulsm/"}
-    server_name = "ash-2.local."
+    server_name = "spare-rig.local."
     ipv6_address = socket.inet_pton(socket.AF_INET6, "2001:db8::1")
     info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, server_name, addresses=[ipv6_address])
     zc.registry.async_add(info)
@@ -367,7 +367,7 @@ def test_aaaa_query_upper_case():
     name = "knownname"
     registration_name = f"{name}.{type_}"
     desc = {"path": "/~paulsm/"}
-    server_name = "ash-2.local."
+    server_name = "spare-rig.local."
     ipv6_address = socket.inet_pton(socket.AF_INET6, "2001:db8::1")
     info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, server_name, addresses=[ipv6_address])
     zc.registry.async_add(info)
@@ -394,9 +394,9 @@ def test_a_and_aaaa_record_fate_sharing():
     name = "knownname"
     registration_name = f"{name}.{type_}"
     desc = {"path": "/~paulsm/"}
-    server_name = "ash-2.local."
+    server_name = "spare-rig.local."
     ipv6_address = socket.inet_pton(socket.AF_INET6, "2001:db8::1")
-    ipv4_address = socket.inet_aton("10.0.1.2")
+    ipv4_address = socket.inet_aton("10.7.4.2")
     info = ServiceInfo(
         type_,
         registration_name,
@@ -460,8 +460,8 @@ def test_unicast_response():
         0,
         0,
         desc,
-        "ash-2.local.",
-        addresses=[socket.inet_aton("10.0.1.2")],
+        "spare-rig.local.",
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     # register
     zc.registry.async_add(info)
@@ -519,8 +519,8 @@ async def test_probe_answered_immediately():
         0,
         0,
         desc,
-        "ash-2.local.",
-        addresses=[socket.inet_aton("10.0.1.2")],
+        "spare-rig.local.",
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     zc.registry.async_add(info)
     query = r.DNSOutgoing(const._FLAGS_QR_QUERY)
@@ -570,8 +570,8 @@ async def test_probe_answered_immediately_with_uppercase_name():
         0,
         0,
         desc,
-        "ash-2.local.",
-        addresses=[socket.inet_aton("10.0.1.2")],
+        "spare-rig.local.",
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     zc.registry.async_add(info)
     query = r.DNSOutgoing(const._FLAGS_QR_QUERY)
@@ -622,8 +622,8 @@ def test_qu_response(quick_timing: None) -> None:
         0,
         0,
         desc,
-        "ash-2.local.",
-        addresses=[socket.inet_aton("10.0.1.2")],
+        "spare-rig.local.",
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     info2 = ServiceInfo(
         other_type_,
@@ -737,7 +737,7 @@ def test_known_answer_supression():
     name = "knownname"
     registration_name = f"{name}.{type_}"
     desc = {"path": "/~paulsm/"}
-    server_name = "ash-2.local."
+    server_name = "spare-rig.local."
     info = ServiceInfo(
         type_,
         registration_name,
@@ -746,7 +746,7 @@ def test_known_answer_supression():
         0,
         desc,
         server_name,
-        addresses=[socket.inet_aton("10.0.1.2")],
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     zc.registry.async_add(info)
 
@@ -911,7 +911,7 @@ def test_multi_packet_known_answer_supression():
     registration3_name = f"{name3}.{type_}"
 
     desc = {"path": "/~paulsm/"}
-    server_name = "ash-2.local."
+    server_name = "spare-rig.local."
     server_name2 = "ash-3.local."
     server_name3 = "ash-4.local."
 
@@ -923,7 +923,7 @@ def test_multi_packet_known_answer_supression():
         0,
         desc,
         server_name,
-        addresses=[socket.inet_aton("10.0.1.2")],
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     info2 = ServiceInfo(
         type_,
@@ -933,7 +933,7 @@ def test_multi_packet_known_answer_supression():
         0,
         desc,
         server_name2,
-        addresses=[socket.inet_aton("10.0.1.2")],
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     info3 = ServiceInfo(
         type_,
@@ -943,7 +943,7 @@ def test_multi_packet_known_answer_supression():
         0,
         desc,
         server_name3,
-        addresses=[socket.inet_aton("10.0.1.2")],
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     zc.registry.async_add(info)
     zc.registry.async_add(info2)
@@ -981,7 +981,7 @@ def test_known_answer_supression_service_type_enumeration_query():
     name = "knownname"
     registration_name = f"{name}.{type_}"
     desc = {"path": "/~paulsm/"}
-    server_name = "ash-2.local."
+    server_name = "spare-rig.local."
     info = ServiceInfo(
         type_,
         registration_name,
@@ -990,7 +990,7 @@ def test_known_answer_supression_service_type_enumeration_query():
         0,
         desc,
         server_name,
-        addresses=[socket.inet_aton("10.0.1.2")],
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     zc.registry.async_add(info)
 
@@ -1007,7 +1007,7 @@ def test_known_answer_supression_service_type_enumeration_query():
         0,
         desc,
         server_name2,
-        addresses=[socket.inet_aton("10.0.1.2")],
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     zc.registry.async_add(info2)
     now = current_time_millis()
@@ -1068,7 +1068,7 @@ def test_upper_case_enumeration_query():
     name = "knownname"
     registration_name = f"{name}.{type_}"
     desc = {"path": "/~paulsm/"}
-    server_name = "ash-2.local."
+    server_name = "spare-rig.local."
     info = ServiceInfo(
         type_,
         registration_name,
@@ -1077,7 +1077,7 @@ def test_upper_case_enumeration_query():
         0,
         desc,
         server_name,
-        addresses=[socket.inet_aton("10.0.1.2")],
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     zc.registry.async_add(info)
 
@@ -1094,7 +1094,7 @@ def test_upper_case_enumeration_query():
         0,
         desc,
         server_name2,
-        addresses=[socket.inet_aton("10.0.1.2")],
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     zc.registry.async_add(info2)
     _clear_cache(zc)
@@ -1142,7 +1142,7 @@ async def test_qu_response_only_sends_additionals_if_sends_answer():
     name = "knownname"
     registration_name = f"{name}.{type_}"
     desc = {"path": "/~paulsm/"}
-    server_name = "ash-2.local."
+    server_name = "spare-rig.local."
     info = ServiceInfo(
         type_,
         registration_name,
@@ -1151,7 +1151,7 @@ async def test_qu_response_only_sends_additionals_if_sends_answer():
         0,
         desc,
         server_name,
-        addresses=[socket.inet_aton("10.0.1.2")],
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     zc.registry.async_add(info)
 
@@ -1168,7 +1168,7 @@ async def test_qu_response_only_sends_additionals_if_sends_answer():
         0,
         desc,
         server_name2,
-        addresses=[socket.inet_aton("10.0.1.2")],
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     zc.registry.async_add(info2)
 
@@ -1317,12 +1317,12 @@ async def test_cache_flush_bit():
         0,
         desc,
         server_name,
-        addresses=[socket.inet_aton("10.0.1.2")],
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     a_record = info.dns_addresses()[0]
     zc.cache.async_add_records([info.dns_pointer(), a_record, info.dns_text(), info.dns_service()])
 
-    info.addresses = [socket.inet_aton("10.0.1.5"), socket.inet_aton("10.0.1.6")]
+    info.addresses = [socket.inet_aton("10.7.4.5"), socket.inet_aton("10.7.4.6")]
     new_records = info.dns_addresses()
     for new_record in new_records:
         assert new_record.unique is True
@@ -1432,7 +1432,7 @@ async def test_record_update_manager_add_listener_callsback_existing_records():
         0,
         desc,
         server_name,
-        addresses=[socket.inet_aton("10.0.1.2")],
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     a_record = info.dns_addresses()[0]
     ptr_record = info.dns_pointer()
@@ -1473,7 +1473,7 @@ async def test_questions_query_handler_populates_the_question_history_from_qm_qu
             0,
             0,
             {"md": "known"},
-            "ash-2.local.",
+            "spare-rig.local.",
             addresses=[socket.inet_aton("1.2.3.4")],
         )
     )
@@ -1517,7 +1517,7 @@ async def test_questions_query_handler_does_not_put_qu_questions_in_history():
         0,
         0,
         {"md": "known"},
-        "ash-2.local.",
+        "spare-rig.local.",
         addresses=[socket.inet_aton("1.2.3.4")],
     )
     aiozc.zeroconf.registry.async_add(info)
@@ -1662,8 +1662,8 @@ async def test_response_aggregation_timings(run_isolated: None) -> None:
         0,
         0,
         desc,
-        "ash-2.local.",
-        addresses=[socket.inet_aton("10.0.1.2")],
+        "spare-rig.local.",
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     info2 = ServiceInfo(
         type_2,
@@ -1673,7 +1673,7 @@ async def test_response_aggregation_timings(run_isolated: None) -> None:
         0,
         desc,
         "ash-4.local.",
-        addresses=[socket.inet_aton("10.0.1.3")],
+        addresses=[socket.inet_aton("10.7.4.3")],
     )
     info3 = ServiceInfo(
         type_3,
@@ -1683,7 +1683,7 @@ async def test_response_aggregation_timings(run_isolated: None) -> None:
         0,
         desc,
         "ash-4.local.",
-        addresses=[socket.inet_aton("10.0.1.3")],
+        addresses=[socket.inet_aton("10.7.4.3")],
     )
     aiozc.zeroconf.registry.async_add(info)
     aiozc.zeroconf.registry.async_add(info2)
@@ -1800,7 +1800,7 @@ async def test_response_aggregation_timings_multiple(
         0,
         desc,
         "ash-4.local.",
-        addresses=[socket.inet_aton("10.0.1.3")],
+        addresses=[socket.inet_aton("10.7.4.3")],
     )
     aiozc.zeroconf.registry.async_add(info2)
 
@@ -1895,7 +1895,7 @@ async def test_response_aggregation_random_delay():
         0,
         desc,
         "ash-1.local.",
-        addresses=[socket.inet_aton("10.0.1.2")],
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     info2 = ServiceInfo(
         type_2,
@@ -1904,8 +1904,8 @@ async def test_response_aggregation_random_delay():
         0,
         0,
         desc,
-        "ash-2.local.",
-        addresses=[socket.inet_aton("10.0.1.3")],
+        "spare-rig.local.",
+        addresses=[socket.inet_aton("10.7.4.3")],
     )
     info3 = ServiceInfo(
         type_3,
@@ -1915,7 +1915,7 @@ async def test_response_aggregation_random_delay():
         0,
         desc,
         "ash-3.local.",
-        addresses=[socket.inet_aton("10.0.1.2")],
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     info4 = ServiceInfo(
         type_4,
@@ -1925,7 +1925,7 @@ async def test_response_aggregation_random_delay():
         0,
         desc,
         "ash-4.local.",
-        addresses=[socket.inet_aton("10.0.1.2")],
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     info5 = ServiceInfo(
         type_5,
@@ -1935,7 +1935,7 @@ async def test_response_aggregation_random_delay():
         0,
         desc,
         "ash-5.local.",
-        addresses=[socket.inet_aton("10.0.1.2")],
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     mocked_zc = unittest.mock.MagicMock()
     mocked_zc.loop = asyncio.get_running_loop()
@@ -1993,7 +1993,7 @@ async def test_future_answers_are_removed_on_send():
         0,
         desc,
         "ash-1.local.",
-        addresses=[socket.inet_aton("10.0.1.2")],
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
     info2 = ServiceInfo(
         type_2,
@@ -2002,8 +2002,8 @@ async def test_future_answers_are_removed_on_send():
         0,
         0,
         desc,
-        "ash-2.local.",
-        addresses=[socket.inet_aton("10.0.1.3")],
+        "spare-rig.local.",
+        addresses=[socket.inet_aton("10.7.4.3")],
     )
     mocked_zc = unittest.mock.MagicMock()
     mocked_zc.loop = asyncio.get_running_loop()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 import socket
 import time
-import unittest.mock
 from unittest.mock import patch
 
 import pytest
@@ -28,125 +27,152 @@ def teardown_module():
         log.setLevel(original_logging_level)
 
 
-class Names(unittest.TestCase):
-    @pytest.mark.usefixtures("quick_timing")
-    def test_verify_name_change_with_lots_of_names(self):
-        # instantiate a zeroconf instance
-        zc = Zeroconf(interfaces=["127.0.0.1"])
+@pytest.mark.parametrize("label_count", [12, 1000, 4000])
+def test_names_with_many_labels_encode_without_error(label_count):
+    """Encoding and re-parsing a deeply nested name never raises."""
+    out = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
+    out.add_question(r.DNSQuestion("z." * label_count + "local.", const._TYPE_SRV, const._CLASS_IN))
+    r.DNSIncoming(out.packets()[0])
 
-        # create a bunch of servers
-        type_ = "_my-service._tcp.local."
-        name = "a wonderful service"
-        server_count = 300
-        self.generate_many_hosts(zc, type_, name, server_count)
 
-        # verify that name changing works
-        self.verify_name_change(zc, type_, name, server_count)
+def test_oversized_label_is_rejected_at_encode_time():
+    """A single label above 63 bytes cannot be written (RFC 1035 section 2.3.4)."""
+    out = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
+    out.add_question(r.DNSQuestion("q" * 70 + ".local.", const._TYPE_SRV, const._CLASS_IN))
+    with pytest.raises(r.NamePartTooLongException):
+        out.packets()
 
-        zc.close()
 
-    def test_large_packet_exception_log_handling(self):
-        """Verify we downgrade debug after warning."""
+def test_repeating_a_question_keeps_every_copy():
+    out = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
+    duplicate = r.DNSQuestion("twin-entry.local.", const._TYPE_SRV, const._CLASS_IN)
+    for _ in range(2):
+        out.add_question(duplicate)
+    assert r.DNSIncoming(out.packets()[0]).num_questions == 2
 
-        # instantiate a zeroconf instance
-        zc = Zeroconf(interfaces=["127.0.0.1"])
 
-        with (
-            patch("zeroconf._logger.log.warning") as mocked_log_warn,
-            patch("zeroconf._logger.log.debug") as mocked_log_debug,
-        ):
-            # now that we have a long packet in our possession, let's verify the
-            # exception handling.
-            out = r.DNSOutgoing(const._FLAGS_QR_RESPONSE | const._FLAGS_AA)
-            out.data.append(b"\0" * 10000)
+@pytest.mark.usefixtures("quick_timing")
+def test_verify_name_change_with_lots_of_names():
+    # instantiate a zeroconf instance
+    zc = Zeroconf(interfaces=["127.0.0.1"])
 
-            # mock the zeroconf logger and check for the correct logging backoff
-            call_counts = mocked_log_warn.call_count, mocked_log_debug.call_count
-            # try to send an oversized packet
-            zc.send(out)
-            assert mocked_log_warn.call_count == call_counts[0]
-            zc.send(out)
-            assert mocked_log_warn.call_count == call_counts[0]
+    # create a bunch of servers
+    type_ = "_my-service._tcp.local."
+    name = "a wonderful service"
+    server_count = 300
+    generate_many_hosts(zc, type_, name, server_count)
 
-            # mock the zeroconf logger and check for the correct logging backoff
-            call_counts = mocked_log_warn.call_count, mocked_log_debug.call_count
-            # force receive on oversized packet
-            zc.send(out, const._MDNS_ADDR, const._MDNS_PORT)
-            zc.send(out, const._MDNS_ADDR, const._MDNS_PORT)
-            time.sleep(0.3)
-            r.log.debug(
-                "warn %d debug %d was %s",
-                mocked_log_warn.call_count,
-                mocked_log_debug.call_count,
-                call_counts,
-            )
-            assert mocked_log_debug.call_count > call_counts[0]
+    # verify that name changing works
+    verify_name_change(zc, type_, name, server_count)
 
-        # close our zeroconf which will close the sockets
-        zc.close()
+    zc.close()
 
-    def verify_name_change(self, zc, type_, name, number_hosts):
-        desc = {"path": "/~paulsm/"}
-        info_service = ServiceInfo(
-            type_,
-            f"{name}.{type_}",
-            80,
-            0,
-            0,
-            desc,
-            "ash-2.local.",
-            addresses=[socket.inet_aton("10.0.1.2")],
-        )
 
-        # verify name conflict
-        self.assertRaises(r.NonUniqueNameException, zc.register_service, info_service)
+def test_large_packet_exception_log_handling():
+    """Verify we downgrade debug after warning."""
 
-        # verify no name conflict https://tools.ietf.org/html/rfc6762#section-6.6
-        zc.register_service(info_service, cooperating_responders=True)
+    # instantiate a zeroconf instance
+    zc = Zeroconf(interfaces=["127.0.0.1"])
 
-        # Create a new object since allow_name_change will mutate the
-        # original object and then we will have the wrong service
-        # in the registry
-        info_service2 = ServiceInfo(
-            type_,
-            f"{name}.{type_}",
-            80,
-            0,
-            0,
-            desc,
-            "ash-2.local.",
-            addresses=[socket.inet_aton("10.0.1.2")],
-        )
-        zc.register_service(info_service2, allow_name_change=True)
-        assert info_service2.name.split(".")[0] == f"{name}-{number_hosts + 1}"
-
-    def generate_many_hosts(self, zc, type_, name, number_hosts):
-        block_size = 25
-        number_hosts = int((number_hosts - 1) / block_size + 1) * block_size
+    with (
+        patch("zeroconf._logger.log.warning") as mocked_log_warn,
+        patch("zeroconf._logger.log.debug") as mocked_log_debug,
+    ):
+        # now that we have a long packet in our possession, let's verify the
+        # exception handling.
         out = r.DNSOutgoing(const._FLAGS_QR_RESPONSE | const._FLAGS_AA)
-        for i in range(1, number_hosts + 1):
-            next_name = name if i == 1 else f"{name}-{i}"
-            self.generate_host(out, next_name, type_)
+        out.data.append(b"\0" * 10000)
 
-        _inject_responses(zc, [r.DNSIncoming(packet) for packet in out.packets()])
+        # mock the zeroconf logger and check for the correct logging backoff
+        call_counts = mocked_log_warn.call_count, mocked_log_debug.call_count
+        # try to send an oversized packet
+        zc.send(out)
+        assert mocked_log_warn.call_count == call_counts[0]
+        zc.send(out)
+        assert mocked_log_warn.call_count == call_counts[0]
 
-    @staticmethod
-    def generate_host(out, host_name, type_):
-        name = ".".join((host_name, type_))
-        out.add_answer_at_time(
-            r.DNSPointer(type_, const._TYPE_PTR, const._CLASS_IN, const._DNS_OTHER_TTL, name),
-            0,
+        # mock the zeroconf logger and check for the correct logging backoff
+        call_counts = mocked_log_warn.call_count, mocked_log_debug.call_count
+        # force receive on oversized packet
+        zc.send(out, const._MDNS_ADDR, const._MDNS_PORT)
+        zc.send(out, const._MDNS_ADDR, const._MDNS_PORT)
+        time.sleep(0.3)
+        r.log.debug(
+            "warn %d debug %d was %s",
+            mocked_log_warn.call_count,
+            mocked_log_debug.call_count,
+            call_counts,
         )
-        out.add_answer_at_time(
-            r.DNSService(
-                type_,
-                const._TYPE_SRV,
-                const._CLASS_IN | const._CLASS_UNIQUE,
-                const._DNS_HOST_TTL,
-                0,
-                0,
-                80,
-                name,
-            ),
+        assert mocked_log_debug.call_count > call_counts[0]
+
+    # close our zeroconf which will close the sockets
+    zc.close()
+
+
+def verify_name_change(zc, type_, name, number_hosts):
+    desc = {"path": "/~paulsm/"}
+    info_service = ServiceInfo(
+        type_,
+        f"{name}.{type_}",
+        80,
+        0,
+        0,
+        desc,
+        "spare-rig.local.",
+        addresses=[socket.inet_aton("10.7.4.2")],
+    )
+
+    # verify name conflict
+    with pytest.raises(r.NonUniqueNameException):
+        zc.register_service(info_service)
+
+    # verify no name conflict https://tools.ietf.org/html/rfc6762#section-6.6
+    zc.register_service(info_service, cooperating_responders=True)
+
+    # Create a new object since allow_name_change will mutate the
+    # original object and then we will have the wrong service
+    # in the registry
+    info_service2 = ServiceInfo(
+        type_,
+        f"{name}.{type_}",
+        80,
+        0,
+        0,
+        desc,
+        "spare-rig.local.",
+        addresses=[socket.inet_aton("10.7.4.2")],
+    )
+    zc.register_service(info_service2, allow_name_change=True)
+    assert info_service2.name.split(".")[0] == f"{name}-{number_hosts + 1}"
+
+
+def generate_many_hosts(zc, type_, name, number_hosts):
+    block_size = 25
+    number_hosts = int((number_hosts - 1) / block_size + 1) * block_size
+    out = r.DNSOutgoing(const._FLAGS_QR_RESPONSE | const._FLAGS_AA)
+    for i in range(1, number_hosts + 1):
+        next_name = name if i == 1 else f"{name}-{i}"
+        generate_host(out, next_name, type_)
+
+    _inject_responses(zc, [r.DNSIncoming(packet) for packet in out.packets()])
+
+
+def generate_host(out, host_name, type_):
+    name = ".".join((host_name, type_))
+    out.add_answer_at_time(
+        r.DNSPointer(type_, const._TYPE_PTR, const._CLASS_IN, const._DNS_OTHER_TTL, name),
+        0,
+    )
+    out.add_answer_at_time(
+        r.DNSService(
+            type_,
+            const._TYPE_SRV,
+            const._CLASS_IN | const._CLASS_UNIQUE,
+            const._DNS_HOST_TTL,
             0,
-        )
+            0,
+            80,
+            name,
+        ),
+        0,
+    )

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -7,7 +7,6 @@ import logging
 import os
 import pickle
 import socket
-import unittest.mock
 from typing import cast
 
 import pytest
@@ -34,132 +33,110 @@ def teardown_module():
         log.setLevel(original_logging_level)
 
 
-class PacketGeneration(unittest.TestCase):
-    def test_parse_own_packet_nsec(self):
-        answer = r.DNSNsec(
-            "eufy HomeBase2-2464._hap._tcp.local.",
-            const._TYPE_NSEC,
-            const._CLASS_IN | const._CLASS_UNIQUE,
-            const._DNS_OTHER_TTL,
-            "eufy HomeBase2-2464._hap._tcp.local.",
-            [const._TYPE_TXT, const._TYPE_SRV],
-        )
+@pytest.mark.parametrize("multicast", [True, False])
+def test_empty_message_roundtrips(multicast):
+    out = r.DNSOutgoing(0, multicast)
+    assert r.DNSIncoming(out.packets()[0]).valid
 
-        generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
-        generated.add_answer_at_time(answer, 0)
-        parsed = r.DNSIncoming(generated.packets()[0])
-        assert answer in parsed.answers()
 
-        # Now with the higher RD type first
-        answer = r.DNSNsec(
-            "eufy HomeBase2-2464._hap._tcp.local.",
-            const._TYPE_NSEC,
-            const._CLASS_IN | const._CLASS_UNIQUE,
-            const._DNS_OTHER_TTL,
-            "eufy HomeBase2-2464._hap._tcp.local.",
-            [const._TYPE_SRV, const._TYPE_TXT],
-        )
+@pytest.mark.parametrize(
+    ("flags", "wire_flags"),
+    [(const._FLAGS_QR_QUERY, 0x0000), (const._FLAGS_QR_RESPONSE, 0x8000)],
+)
+def test_header_carries_the_flag_bits(flags, wire_flags):
+    packet = r.DNSOutgoing(flags).packets()[0]
+    assert int.from_bytes(packet[2:4], "big") == wire_flags
+    assert r.DNSIncoming(packet).valid
 
-        generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
-        generated.add_answer_at_time(answer, 0)
-        parsed = r.DNSIncoming(generated.packets()[0])
-        assert answer in parsed.answers()
 
-        # Types > 255 should raise an exception
-        answer_invalid_types = r.DNSNsec(
-            "eufy HomeBase2-2464._hap._tcp.local.",
-            const._TYPE_NSEC,
-            const._CLASS_IN | const._CLASS_UNIQUE,
-            const._DNS_OTHER_TTL,
-            "eufy HomeBase2-2464._hap._tcp.local.",
-            [const._TYPE_TXT, const._TYPE_SRV, 1000],
-        )
-        generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
-        generated.add_answer_at_time(answer_invalid_types, 0)
-        with pytest.raises(ValueError, match="rdtype 1000 is too large for NSEC"):
-            generated.packets()
+def test_multicast_header_id_is_zero():
+    """RFC 6762 section 18.1: multicast DNS messages carry id 0."""
+    packet = r.DNSOutgoing(const._FLAGS_QR_QUERY).packets()[0]
+    assert int.from_bytes(packet[:2], "big") == 0
 
-        # Empty rdtypes are not allowed
-        answer_invalid_types = r.DNSNsec(
-            "eufy HomeBase2-2464._hap._tcp.local.",
-            const._TYPE_NSEC,
-            const._CLASS_IN | const._CLASS_UNIQUE,
-            const._DNS_OTHER_TTL,
-            "eufy HomeBase2-2464._hap._tcp.local.",
-            [],
-        )
-        generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
-        generated.add_answer_at_time(answer_invalid_types, 0)
-        with pytest.raises(ValueError, match="NSEC must have at least one rdtype"):
-            generated.packets()
 
-    def test_parse_own_packet_response(self):
-        generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
-        generated.add_answer_at_time(
-            r.DNSService(
-                "æøå.local.",
-                const._TYPE_SRV,
-                const._CLASS_IN | const._CLASS_UNIQUE,
-                const._DNS_HOST_TTL,
-                0,
-                0,
-                80,
-                "foo.local.",
-            ),
-            0,
-        )
-        parsed = r.DNSIncoming(generated.packets()[0])
-        assert len(generated.answers) == 1
-        assert len(generated.answers) == len(parsed.answers())
+@pytest.mark.parametrize("question_count", [0, 10])
+def test_section_counts_reflect_the_content(question_count):
+    out = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
+    for i in range(question_count):
+        out.add_question(r.DNSQuestion(f"probe-{i}.local.", const._TYPE_SRV, const._CLASS_IN))
+    packet = out.packets()[0]
+    counts = [int.from_bytes(packet[o : o + 2], "big") for o in (4, 6, 8, 10)]
+    assert counts == [question_count, 0, 0, 0]
 
-    def test_adding_empty_answer(self):
-        generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
-        generated.add_answer_at_time(
-            None,
-            0,
-        )
-        generated.add_answer_at_time(
-            r.DNSService(
-                "æøå.local.",
-                const._TYPE_SRV,
-                const._CLASS_IN | const._CLASS_UNIQUE,
-                const._DNS_HOST_TTL,
-                0,
-                0,
-                80,
-                "foo.local.",
-            ),
-            0,
-        )
-        parsed = r.DNSIncoming(generated.packets()[0])
-        assert len(generated.answers) == 1
-        assert len(generated.answers) == len(parsed.answers())
 
-    def test_adding_expired_answer(self):
-        generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
-        generated.add_answer_at_time(
-            r.DNSService(
-                "æøå.local.",
-                const._TYPE_SRV,
-                const._CLASS_IN | const._CLASS_UNIQUE,
-                const._DNS_HOST_TTL,
-                0,
-                0,
-                80,
-                "foo.local.",
-            ),
-            current_time_millis() + 1000000,
-        )
-        parsed = r.DNSIncoming(generated.packets()[0])
-        assert len(generated.answers) == 0
-        assert len(generated.answers) == len(parsed.answers())
+def test_parsed_question_equals_the_original():
+    probe = r.DNSQuestion("echo-check._http._tcp.local.", const._TYPE_PTR, const._CLASS_IN)
+    out = r.DNSOutgoing(const._FLAGS_QR_QUERY)
+    out.add_question(probe)
+    parsed = r.DNSIncoming(out.packets()[0])
+    assert [probe] == parsed.questions
 
-    def test_suppress_answer(self):
-        query_generated = r.DNSOutgoing(const._FLAGS_QR_QUERY)
-        question = r.DNSQuestion("testname.local.", const._TYPE_SRV, const._CLASS_IN)
-        query_generated.add_question(question)
-        answer1 = r.DNSService(
-            "testname1.local.",
+
+def test_parse_own_packet_nsec():
+    answer = r.DNSNsec(
+        "eufy HomeBase2-2464._hap._tcp.local.",
+        const._TYPE_NSEC,
+        const._CLASS_IN | const._CLASS_UNIQUE,
+        const._DNS_OTHER_TTL,
+        "eufy HomeBase2-2464._hap._tcp.local.",
+        [const._TYPE_TXT, const._TYPE_SRV],
+    )
+
+    generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
+    generated.add_answer_at_time(answer, 0)
+    parsed = r.DNSIncoming(generated.packets()[0])
+    assert answer in parsed.answers()
+
+    # Now with the higher RD type first
+    answer = r.DNSNsec(
+        "eufy HomeBase2-2464._hap._tcp.local.",
+        const._TYPE_NSEC,
+        const._CLASS_IN | const._CLASS_UNIQUE,
+        const._DNS_OTHER_TTL,
+        "eufy HomeBase2-2464._hap._tcp.local.",
+        [const._TYPE_SRV, const._TYPE_TXT],
+    )
+
+    generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
+    generated.add_answer_at_time(answer, 0)
+    parsed = r.DNSIncoming(generated.packets()[0])
+    assert answer in parsed.answers()
+
+    # Types > 255 should raise an exception
+    answer_invalid_types = r.DNSNsec(
+        "eufy HomeBase2-2464._hap._tcp.local.",
+        const._TYPE_NSEC,
+        const._CLASS_IN | const._CLASS_UNIQUE,
+        const._DNS_OTHER_TTL,
+        "eufy HomeBase2-2464._hap._tcp.local.",
+        [const._TYPE_TXT, const._TYPE_SRV, 1000],
+    )
+    generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
+    generated.add_answer_at_time(answer_invalid_types, 0)
+    with pytest.raises(ValueError, match="rdtype 1000 is too large for NSEC"):
+        generated.packets()
+
+    # Empty rdtypes are not allowed
+    answer_invalid_types = r.DNSNsec(
+        "eufy HomeBase2-2464._hap._tcp.local.",
+        const._TYPE_NSEC,
+        const._CLASS_IN | const._CLASS_UNIQUE,
+        const._DNS_OTHER_TTL,
+        "eufy HomeBase2-2464._hap._tcp.local.",
+        [],
+    )
+    generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
+    generated.add_answer_at_time(answer_invalid_types, 0)
+    with pytest.raises(ValueError, match="NSEC must have at least one rdtype"):
+        generated.packets()
+
+
+def test_parse_own_packet_response():
+    generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
+    generated.add_answer_at_time(
+        r.DNSService(
+            "æøå.local.",
             const._TYPE_SRV,
             const._CLASS_IN | const._CLASS_UNIQUE,
             const._DNS_HOST_TTL,
@@ -167,19 +144,23 @@ class PacketGeneration(unittest.TestCase):
             0,
             80,
             "foo.local.",
-        )
-        staleanswer2 = r.DNSService(
-            "testname2.local.",
-            const._TYPE_SRV,
-            const._CLASS_IN | const._CLASS_UNIQUE,
-            int(const._DNS_HOST_TTL / 2),
-            0,
-            0,
-            80,
-            "foo.local.",
-        )
-        answer2 = r.DNSService(
-            "testname2.local.",
+        ),
+        0,
+    )
+    parsed = r.DNSIncoming(generated.packets()[0])
+    assert len(generated.answers) == 1
+    assert len(generated.answers) == len(parsed.answers())
+
+
+def test_adding_empty_answer():
+    generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
+    generated.add_answer_at_time(
+        None,
+        0,
+    )
+    generated.add_answer_at_time(
+        r.DNSService(
+            "æøå.local.",
             const._TYPE_SRV,
             const._CLASS_IN | const._CLASS_UNIQUE,
             const._DNS_HOST_TTL,
@@ -187,295 +168,364 @@ class PacketGeneration(unittest.TestCase):
             0,
             80,
             "foo.local.",
+        ),
+        0,
+    )
+    parsed = r.DNSIncoming(generated.packets()[0])
+    assert len(generated.answers) == 1
+    assert len(generated.answers) == len(parsed.answers())
+
+
+def test_adding_expired_answer():
+    generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
+    generated.add_answer_at_time(
+        r.DNSService(
+            "æøå.local.",
+            const._TYPE_SRV,
+            const._CLASS_IN | const._CLASS_UNIQUE,
+            const._DNS_HOST_TTL,
+            0,
+            0,
+            80,
+            "foo.local.",
+        ),
+        current_time_millis() + 1000000,
+    )
+    parsed = r.DNSIncoming(generated.packets()[0])
+    assert len(generated.answers) == 0
+    assert len(generated.answers) == len(parsed.answers())
+
+
+def test_suppress_answer():
+    query_generated = r.DNSOutgoing(const._FLAGS_QR_QUERY)
+    question = r.DNSQuestion("candidate.local.", const._TYPE_SRV, const._CLASS_IN)
+    query_generated.add_question(question)
+    answer1 = r.DNSService(
+        "candidate-a.local.",
+        const._TYPE_SRV,
+        const._CLASS_IN | const._CLASS_UNIQUE,
+        const._DNS_HOST_TTL,
+        0,
+        0,
+        80,
+        "foo.local.",
+    )
+    staleanswer2 = r.DNSService(
+        "candidate-b.local.",
+        const._TYPE_SRV,
+        const._CLASS_IN | const._CLASS_UNIQUE,
+        int(const._DNS_HOST_TTL / 2),
+        0,
+        0,
+        80,
+        "foo.local.",
+    )
+    answer2 = r.DNSService(
+        "candidate-b.local.",
+        const._TYPE_SRV,
+        const._CLASS_IN | const._CLASS_UNIQUE,
+        const._DNS_HOST_TTL,
+        0,
+        0,
+        80,
+        "foo.local.",
+    )
+    query_generated.add_answer_at_time(answer1, 0)
+    query_generated.add_answer_at_time(staleanswer2, 0)
+    query = r.DNSIncoming(query_generated.packets()[0])
+
+    # Should be suppressed
+    response = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
+    response.add_answer(query, answer1)
+    assert len(response.answers) == 0
+
+    # Should not be suppressed, TTL in query is too short
+    response.add_answer(query, answer2)
+    assert len(response.answers) == 1
+
+    # Should not be suppressed, name is different
+    tmp = copy.copy(answer1)
+    tmp.key = "testname3.local."
+    tmp.name = "testname3.local."
+    response.add_answer(query, tmp)
+    assert len(response.answers) == 2
+
+    # Should not be suppressed, type is different
+    tmp = copy.copy(answer1)
+    tmp.type = const._TYPE_A
+    response.add_answer(query, tmp)
+    assert len(response.answers) == 3
+
+    # Should not be suppressed, class is different
+    tmp = copy.copy(answer1)
+    tmp.class_ = const._CLASS_NONE
+    response.add_answer(query, tmp)
+    assert len(response.answers) == 4
+
+    # ::TODO:: could add additional tests for DNSAddress, DNSHinfo, DNSPointer, DNSText, DNSService
+
+
+def test_dns_hinfo():
+    generated = r.DNSOutgoing(0)
+    generated.add_additional_answer(DNSHinfo("irrelevant", const._TYPE_HINFO, 0, 0, "cpu", "os"))
+    parsed = r.DNSIncoming(generated.packets()[0])
+    answer = cast(r.DNSHinfo, parsed.answers()[0])
+    assert answer.cpu == "cpu"
+    assert answer.os == "os"
+
+    generated = r.DNSOutgoing(0)
+    generated.add_additional_answer(DNSHinfo("irrelevant", const._TYPE_HINFO, 0, 0, "cpu", "x" * 257))
+    with pytest.raises(r.NamePartTooLongException):
+        generated.packets()
+
+
+def test_many_questions():
+    """Test many questions get separated into multiple packets."""
+    generated = r.DNSOutgoing(const._FLAGS_QR_QUERY)
+    questions = []
+    for i in range(100):
+        question = r.DNSQuestion(f"testname{i}.local.", const._TYPE_SRV, const._CLASS_IN)
+        generated.add_question(question)
+        questions.append(question)
+    assert len(generated.questions) == 100
+
+    packets = generated.packets()
+    assert len(packets) == 2
+    assert len(packets[0]) < const._MAX_MSG_TYPICAL
+    assert len(packets[1]) < const._MAX_MSG_TYPICAL
+
+    parsed1 = r.DNSIncoming(packets[0])
+    assert len(parsed1.questions) == 85
+    parsed2 = r.DNSIncoming(packets[1])
+    assert len(parsed2.questions) == 15
+
+
+def test_many_questions_with_many_known_answers():
+    """Test many questions and known answers get separated into multiple packets."""
+    generated = r.DNSOutgoing(const._FLAGS_QR_QUERY)
+    questions = []
+    for _ in range(30):
+        question = r.DNSQuestion("_hap._tcp.local.", const._TYPE_PTR, const._CLASS_IN)
+        generated.add_question(question)
+        questions.append(question)
+    assert len(generated.questions) == 30
+    now = current_time_millis()
+    for _ in range(200):
+        known_answer = r.DNSPointer(
+            "myservice{i}_tcp._tcp.local.",
+            const._TYPE_PTR,
+            const._CLASS_IN | const._CLASS_UNIQUE,
+            const._DNS_OTHER_TTL,
+            "123.local.",
         )
-        query_generated.add_answer_at_time(answer1, 0)
-        query_generated.add_answer_at_time(staleanswer2, 0)
-        query = r.DNSIncoming(query_generated.packets()[0])
+        generated.add_answer_at_time(known_answer, now)
+    packets = generated.packets()
+    assert len(packets) == 3
+    assert len(packets[0]) <= const._MAX_MSG_TYPICAL
+    assert len(packets[1]) <= const._MAX_MSG_TYPICAL
+    assert len(packets[2]) <= const._MAX_MSG_TYPICAL
 
-        # Should be suppressed
-        response = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
-        response.add_answer(query, answer1)
-        assert len(response.answers) == 0
+    parsed1 = r.DNSIncoming(packets[0])
+    assert len(parsed1.questions) == 30
+    assert len(parsed1.answers()) == 88
+    assert parsed1.truncated
+    parsed2 = r.DNSIncoming(packets[1])
+    assert len(parsed2.questions) == 0
+    assert len(parsed2.answers()) == 101
+    assert parsed2.truncated
+    parsed3 = r.DNSIncoming(packets[2])
+    assert len(parsed3.questions) == 0
+    assert len(parsed3.answers()) == 11
+    assert not parsed3.truncated
 
-        # Should not be suppressed, TTL in query is too short
-        response.add_answer(query, answer2)
-        assert len(response.answers) == 1
 
-        # Should not be suppressed, name is different
-        tmp = copy.copy(answer1)
-        tmp.key = "testname3.local."
-        tmp.name = "testname3.local."
-        response.add_answer(query, tmp)
-        assert len(response.answers) == 2
+def test_massive_probe_packet_split():
+    """Test probe with many authoritative answers."""
+    generated = r.DNSOutgoing(const._FLAGS_QR_QUERY | const._FLAGS_AA)
+    questions = []
+    for _ in range(30):
+        question = r.DNSQuestion(
+            "_hap._tcp.local.",
+            const._TYPE_PTR,
+            const._CLASS_IN | const._CLASS_UNIQUE,
+        )
+        generated.add_question(question)
+        questions.append(question)
+    assert len(generated.questions) == 30
+    for _ in range(200):
+        authorative_answer = r.DNSPointer(
+            "myservice{i}_tcp._tcp.local.",
+            const._TYPE_PTR,
+            const._CLASS_IN | const._CLASS_UNIQUE,
+            const._DNS_OTHER_TTL,
+            "123.local.",
+        )
+        generated.add_authorative_answer(authorative_answer)
+    packets = generated.packets()
+    assert len(packets) == 3
+    assert len(packets[0]) <= const._MAX_MSG_TYPICAL
+    assert len(packets[1]) <= const._MAX_MSG_TYPICAL
+    assert len(packets[2]) <= const._MAX_MSG_TYPICAL
 
-        # Should not be suppressed, type is different
-        tmp = copy.copy(answer1)
-        tmp.type = const._TYPE_A
-        response.add_answer(query, tmp)
-        assert len(response.answers) == 3
+    parsed1 = r.DNSIncoming(packets[0])
+    assert parsed1.questions[0].unicast is True
+    assert len(parsed1.questions) == 30
+    assert parsed1.num_questions == 30
+    assert parsed1.num_authorities == 88
+    assert parsed1.truncated
+    parsed2 = r.DNSIncoming(packets[1])
+    assert len(parsed2.questions) == 0
+    assert parsed2.num_authorities == 101
+    assert parsed2.truncated
+    parsed3 = r.DNSIncoming(packets[2])
+    assert len(parsed3.questions) == 0
+    assert parsed3.num_authorities == 11
+    assert not parsed3.truncated
 
-        # Should not be suppressed, class is different
-        tmp = copy.copy(answer1)
-        tmp.class_ = const._CLASS_NONE
-        response.add_answer(query, tmp)
-        assert len(response.answers) == 4
 
-        # ::TODO:: could add additional tests for DNSAddress, DNSHinfo, DNSPointer, DNSText, DNSService
+def test_only_one_answer_can_by_large():
+    """Test that only the first answer in each packet can be large.
 
-    def test_dns_hinfo(self):
-        generated = r.DNSOutgoing(0)
-        generated.add_additional_answer(DNSHinfo("irrelevant", const._TYPE_HINFO, 0, 0, "cpu", "os"))
-        parsed = r.DNSIncoming(generated.packets()[0])
-        answer = cast(r.DNSHinfo, parsed.answers()[0])
-        assert answer.cpu == "cpu"
-        assert answer.os == "os"
-
-        generated = r.DNSOutgoing(0)
-        generated.add_additional_answer(DNSHinfo("irrelevant", const._TYPE_HINFO, 0, 0, "cpu", "x" * 257))
-        self.assertRaises(r.NamePartTooLongException, generated.packets)
-
-    def test_many_questions(self):
-        """Test many questions get separated into multiple packets."""
-        generated = r.DNSOutgoing(const._FLAGS_QR_QUERY)
-        questions = []
-        for i in range(100):
-            question = r.DNSQuestion(f"testname{i}.local.", const._TYPE_SRV, const._CLASS_IN)
-            generated.add_question(question)
-            questions.append(question)
-        assert len(generated.questions) == 100
-
-        packets = generated.packets()
-        assert len(packets) == 2
-        assert len(packets[0]) < const._MAX_MSG_TYPICAL
-        assert len(packets[1]) < const._MAX_MSG_TYPICAL
-
-        parsed1 = r.DNSIncoming(packets[0])
-        assert len(parsed1.questions) == 85
-        parsed2 = r.DNSIncoming(packets[1])
-        assert len(parsed2.questions) == 15
-
-    def test_many_questions_with_many_known_answers(self):
-        """Test many questions and known answers get separated into multiple packets."""
-        generated = r.DNSOutgoing(const._FLAGS_QR_QUERY)
-        questions = []
-        for _ in range(30):
-            question = r.DNSQuestion("_hap._tcp.local.", const._TYPE_PTR, const._CLASS_IN)
-            generated.add_question(question)
-            questions.append(question)
-        assert len(generated.questions) == 30
-        now = current_time_millis()
-        for _ in range(200):
-            known_answer = r.DNSPointer(
-                "myservice{i}_tcp._tcp.local.",
-                const._TYPE_PTR,
-                const._CLASS_IN | const._CLASS_UNIQUE,
-                const._DNS_OTHER_TTL,
-                "123.local.",
-            )
-            generated.add_answer_at_time(known_answer, now)
-        packets = generated.packets()
-        assert len(packets) == 3
-        assert len(packets[0]) <= const._MAX_MSG_TYPICAL
-        assert len(packets[1]) <= const._MAX_MSG_TYPICAL
-        assert len(packets[2]) <= const._MAX_MSG_TYPICAL
-
-        parsed1 = r.DNSIncoming(packets[0])
-        assert len(parsed1.questions) == 30
-        assert len(parsed1.answers()) == 88
-        assert parsed1.truncated
-        parsed2 = r.DNSIncoming(packets[1])
-        assert len(parsed2.questions) == 0
-        assert len(parsed2.answers()) == 101
-        assert parsed2.truncated
-        parsed3 = r.DNSIncoming(packets[2])
-        assert len(parsed3.questions) == 0
-        assert len(parsed3.answers()) == 11
-        assert not parsed3.truncated
-
-    def test_massive_probe_packet_split(self):
-        """Test probe with many authoritative answers."""
-        generated = r.DNSOutgoing(const._FLAGS_QR_QUERY | const._FLAGS_AA)
-        questions = []
-        for _ in range(30):
-            question = r.DNSQuestion(
-                "_hap._tcp.local.",
-                const._TYPE_PTR,
-                const._CLASS_IN | const._CLASS_UNIQUE,
-            )
-            generated.add_question(question)
-            questions.append(question)
-        assert len(generated.questions) == 30
-        for _ in range(200):
-            authorative_answer = r.DNSPointer(
-                "myservice{i}_tcp._tcp.local.",
-                const._TYPE_PTR,
-                const._CLASS_IN | const._CLASS_UNIQUE,
-                const._DNS_OTHER_TTL,
-                "123.local.",
-            )
-            generated.add_authorative_answer(authorative_answer)
-        packets = generated.packets()
-        assert len(packets) == 3
-        assert len(packets[0]) <= const._MAX_MSG_TYPICAL
-        assert len(packets[1]) <= const._MAX_MSG_TYPICAL
-        assert len(packets[2]) <= const._MAX_MSG_TYPICAL
-
-        parsed1 = r.DNSIncoming(packets[0])
-        assert parsed1.questions[0].unicast is True
-        assert len(parsed1.questions) == 30
-        assert parsed1.num_questions == 30
-        assert parsed1.num_authorities == 88
-        assert parsed1.truncated
-        parsed2 = r.DNSIncoming(packets[1])
-        assert len(parsed2.questions) == 0
-        assert parsed2.num_authorities == 101
-        assert parsed2.truncated
-        parsed3 = r.DNSIncoming(packets[2])
-        assert len(parsed3.questions) == 0
-        assert parsed3.num_authorities == 11
-        assert not parsed3.truncated
-
-    def test_only_one_answer_can_by_large(self):
-        """Test that only the first answer in each packet can be large.
-
-        https://datatracker.ietf.org/doc/html/rfc6762#section-17
-        """
-        generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
-        query = r.DNSIncoming(r.DNSOutgoing(const._FLAGS_QR_QUERY).packets()[0])
-        for _i in range(3):
-            generated.add_answer(
-                query,
-                r.DNSText(
-                    "zoom._hap._tcp.local.",
-                    const._TYPE_TXT,
-                    const._CLASS_IN | const._CLASS_UNIQUE,
-                    1200,
-                    b"\x04ff=0\x04ci=2\x04sf=0\x0bsh=6fLM5A==" * 100,
-                ),
-            )
+    https://datatracker.ietf.org/doc/html/rfc6762#section-17
+    """
+    generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
+    query = r.DNSIncoming(r.DNSOutgoing(const._FLAGS_QR_QUERY).packets()[0])
+    for _i in range(3):
         generated.add_answer(
             query,
-            r.DNSService(
-                "testname1.local.",
-                const._TYPE_SRV,
+            r.DNSText(
+                "zoom._hap._tcp.local.",
+                const._TYPE_TXT,
                 const._CLASS_IN | const._CLASS_UNIQUE,
-                const._DNS_HOST_TTL,
-                0,
-                0,
-                80,
-                "foo.local.",
+                1200,
+                b"\x04ff=0\x04ci=2\x04sf=0\x0bsh=6fLM5A==" * 100,
             ),
         )
-        assert len(generated.answers) == 4
+    generated.add_answer(
+        query,
+        r.DNSService(
+            "candidate-a.local.",
+            const._TYPE_SRV,
+            const._CLASS_IN | const._CLASS_UNIQUE,
+            const._DNS_HOST_TTL,
+            0,
+            0,
+            80,
+            "foo.local.",
+        ),
+    )
+    assert len(generated.answers) == 4
 
-        packets = generated.packets()
-        assert len(packets) == 4
-        assert len(packets[0]) <= const._MAX_MSG_ABSOLUTE
-        assert len(packets[0]) > const._MAX_MSG_TYPICAL
+    packets = generated.packets()
+    assert len(packets) == 4
+    assert len(packets[0]) <= const._MAX_MSG_ABSOLUTE
+    assert len(packets[0]) > const._MAX_MSG_TYPICAL
 
-        assert len(packets[1]) <= const._MAX_MSG_ABSOLUTE
-        assert len(packets[1]) > const._MAX_MSG_TYPICAL
+    assert len(packets[1]) <= const._MAX_MSG_ABSOLUTE
+    assert len(packets[1]) > const._MAX_MSG_TYPICAL
 
-        assert len(packets[2]) <= const._MAX_MSG_ABSOLUTE
-        assert len(packets[2]) > const._MAX_MSG_TYPICAL
+    assert len(packets[2]) <= const._MAX_MSG_ABSOLUTE
+    assert len(packets[2]) > const._MAX_MSG_TYPICAL
 
-        assert len(packets[3]) <= const._MAX_MSG_TYPICAL
+    assert len(packets[3]) <= const._MAX_MSG_TYPICAL
 
-        for packet in packets:
-            parsed = r.DNSIncoming(packet)
-            assert len(parsed.answers()) == 1
-
-    def test_questions_do_not_end_up_every_packet(self):
-        """Test that questions are not sent again when multiple packets are needed.
-
-        https://datatracker.ietf.org/doc/html/rfc6762#section-7.2
-        Sometimes a Multicast DNS querier will already have too many answers
-        to fit in the Known-Answer Section of its query packets....  It MUST
-        immediately follow the packet with another query packet containing no
-        questions and as many more Known-Answer records as will fit.
-        """
-
-        generated = r.DNSOutgoing(const._FLAGS_QR_QUERY)
-        for i in range(35):
-            question = r.DNSQuestion(f"testname{i}.local.", const._TYPE_SRV, const._CLASS_IN)
-            generated.add_question(question)
-            answer = r.DNSService(
-                f"testname{i}.local.",
-                const._TYPE_SRV,
-                const._CLASS_IN | const._CLASS_UNIQUE,
-                const._DNS_HOST_TTL,
-                0,
-                0,
-                80,
-                f"foo{i}.local.",
-            )
-            generated.add_answer_at_time(answer, 0)
-
-        assert len(generated.questions) == 35
-        assert len(generated.answers) == 35
-
-        packets = generated.packets()
-        assert len(packets) == 2
-        assert len(packets[0]) <= const._MAX_MSG_TYPICAL
-        assert len(packets[1]) <= const._MAX_MSG_TYPICAL
-
-        parsed1 = r.DNSIncoming(packets[0])
-        assert len(parsed1.questions) == 35
-        assert len(parsed1.answers()) == 33
-
-        parsed2 = r.DNSIncoming(packets[1])
-        assert len(parsed2.questions) == 0
-        assert len(parsed2.answers()) == 2
-
-
-class PacketForm(unittest.TestCase):
-    def test_setting_id(self):
-        """Test setting id in the constructor"""
-        generated = r.DNSOutgoing(const._FLAGS_QR_QUERY, id_=4444)
-        assert generated.id == 4444
-
-
-class TestDnsIncoming(unittest.TestCase):
-    def test_incoming_exception_handling(self):
-        generated = r.DNSOutgoing(0)
-        packet = generated.packets()[0]
-        packet = packet[:8] + b"deadbeef" + packet[8:]
+    for packet in packets:
         parsed = r.DNSIncoming(packet)
-        parsed = r.DNSIncoming(packet)
-        assert parsed.valid is False
+        assert len(parsed.answers()) == 1
 
-    def test_incoming_unknown_type(self):
-        generated = r.DNSOutgoing(0)
-        answer = r.DNSAddress("a", const._TYPE_SOA, const._CLASS_IN, 1, b"a")
-        generated.add_additional_answer(answer)
-        packet = generated.packets()[0]
-        parsed = r.DNSIncoming(packet)
-        assert len(parsed.answers()) == 0
-        assert parsed.is_query() != parsed.is_response()
 
-    def test_incoming_circular_reference(self):
-        assert not r.DNSIncoming(
-            bytes.fromhex(
-                "01005e0000fb542a1bf0577608004500006897934000ff11d81bc0a86a31e00000fb"
-                "14e914e90054f9b2000084000000000100000000095f7365727669636573075f646e"
-                "732d7364045f756470056c6f63616c00000c0001000011940018105f73706f746966"
-                "792d636f6e6e656374045f746370c023"
-            )
-        ).valid
+def test_questions_do_not_end_up_every_packet():
+    """Test that questions are not sent again when multiple packets are needed.
 
-    @unittest.skipIf(not has_working_ipv6(), "Requires IPv6")
-    @unittest.skipIf(os.environ.get("SKIP_IPV6"), "IPv6 tests disabled")
-    def test_incoming_ipv6(self):
-        addr = "2606:2800:220:1:248:1893:25c8:1946"  # example.com
-        packed = socket.inet_pton(socket.AF_INET6, addr)
-        generated = r.DNSOutgoing(0)
-        answer = r.DNSAddress("domain", const._TYPE_AAAA, const._CLASS_IN | const._CLASS_UNIQUE, 1, packed)
-        generated.add_additional_answer(answer)
-        packet = generated.packets()[0]
-        parsed = r.DNSIncoming(packet)
-        record = parsed.answers()[0]
-        assert isinstance(record, r.DNSAddress)
-        assert record.address == packed
+    https://datatracker.ietf.org/doc/html/rfc6762#section-7.2
+    Sometimes a Multicast DNS querier will already have too many answers
+    to fit in the Known-Answer Section of its query packets....  It MUST
+    immediately follow the packet with another query packet containing no
+    questions and as many more Known-Answer records as will fit.
+    """
+
+    generated = r.DNSOutgoing(const._FLAGS_QR_QUERY)
+    for i in range(35):
+        question = r.DNSQuestion(f"testname{i}.local.", const._TYPE_SRV, const._CLASS_IN)
+        generated.add_question(question)
+        answer = r.DNSService(
+            f"testname{i}.local.",
+            const._TYPE_SRV,
+            const._CLASS_IN | const._CLASS_UNIQUE,
+            const._DNS_HOST_TTL,
+            0,
+            0,
+            80,
+            f"foo{i}.local.",
+        )
+        generated.add_answer_at_time(answer, 0)
+
+    assert len(generated.questions) == 35
+    assert len(generated.answers) == 35
+
+    packets = generated.packets()
+    assert len(packets) == 2
+    assert len(packets[0]) <= const._MAX_MSG_TYPICAL
+    assert len(packets[1]) <= const._MAX_MSG_TYPICAL
+
+    parsed1 = r.DNSIncoming(packets[0])
+    assert len(parsed1.questions) == 35
+    assert len(parsed1.answers()) == 33
+
+    parsed2 = r.DNSIncoming(packets[1])
+    assert len(parsed2.questions) == 0
+    assert len(parsed2.answers()) == 2
+
+
+def test_setting_id():
+    """Test setting id in the constructor"""
+    generated = r.DNSOutgoing(const._FLAGS_QR_QUERY, id_=4444)
+    assert generated.id == 4444
+
+
+def test_incoming_exception_handling():
+    generated = r.DNSOutgoing(0)
+    packet = generated.packets()[0]
+    packet = packet[:8] + b"deadbeef" + packet[8:]
+    parsed = r.DNSIncoming(packet)
+    parsed = r.DNSIncoming(packet)
+    assert parsed.valid is False
+
+
+def test_incoming_unknown_type():
+    generated = r.DNSOutgoing(0)
+    answer = r.DNSAddress("a", const._TYPE_SOA, const._CLASS_IN, 1, b"a")
+    generated.add_additional_answer(answer)
+    packet = generated.packets()[0]
+    parsed = r.DNSIncoming(packet)
+    assert len(parsed.answers()) == 0
+    assert parsed.is_query() != parsed.is_response()
+
+
+def test_incoming_circular_reference():
+    assert not r.DNSIncoming(
+        bytes.fromhex(
+            "01005e0000fb542a1bf0577608004500006897934000ff11d81bc0a86a31e00000fb"
+            "14e914e90054f9b2000084000000000100000000095f7365727669636573075f646e"
+            "732d7364045f756470056c6f63616c00000c0001000011940018105f73706f746966"
+            "792d636f6e6e656374045f746370c023"
+        )
+    ).valid
+
+
+@pytest.mark.skipif(not has_working_ipv6(), reason="Requires IPv6")
+@pytest.mark.skipif(os.environ.get("SKIP_IPV6"), reason="IPv6 tests disabled")
+def test_incoming_ipv6():
+    addr = "2606:2800:220:1:248:1893:25c8:1946"  # example.com
+    packed = socket.inet_pton(socket.AF_INET6, addr)
+    generated = r.DNSOutgoing(0)
+    answer = r.DNSAddress("domain", const._TYPE_AAAA, const._CLASS_IN | const._CLASS_UNIQUE, 1, packed)
+    generated.add_additional_answer(answer)
+    packet = generated.packets()[0]
+    parsed = r.DNSIncoming(packet)
+    record = parsed.answers()[0]
+    assert isinstance(record, r.DNSAddress)
+    assert record.address == packed
 
 
 def test_dns_compression_rollback_for_corruption():

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -94,7 +94,7 @@ class ListenerTest(unittest.TestCase):
         zeroconf_registrar = Zeroconf(interfaces=["127.0.0.1"])
         desc: dict[str, Any] = {"path": "/~paulsm/"}
         desc.update(properties)
-        addresses = [socket.inet_aton("10.0.1.2")]
+        addresses = [socket.inet_aton("10.7.4.2")]
         if has_working_ipv6() and not os.environ.get("SKIP_IPV6"):
             addresses.append(socket.inet_pton(socket.AF_INET6, "6001:db8::1"))
             addresses.append(socket.inet_pton(socket.AF_INET6, "2001:db8::1"))
@@ -103,7 +103,7 @@ class ListenerTest(unittest.TestCase):
             registration_name,
             port=80,
             properties=desc,
-            server="ash-2.local.",
+            server="spare-rig.local.",
             addresses=addresses,
         )
         zeroconf_registrar.register_service(info_service)
@@ -195,8 +195,8 @@ class ListenerTest(unittest.TestCase):
                 0,
                 0,
                 desc,
-                "ash-2.local.",
-                addresses=[socket.inet_aton("10.0.1.2")],
+                "spare-rig.local.",
+                addresses=[socket.inet_aton("10.7.4.2")],
             )
             zeroconf_registrar.update_service(info_service)
 

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -70,8 +70,8 @@ def test_legacy_record_update_listener(quick_timing: None) -> None:
         0,
         0,
         {"path": "/~paulsm/"},
-        "ash-2.local.",
-        addresses=[socket.inet_aton("10.0.1.2")],
+        "spare-rig.local.",
+        addresses=[socket.inet_aton("10.7.4.2")],
     )
 
     zc.register_service(info_service)

--- a/tests/utils/test_name.py
+++ b/tests/utils/test_name.py
@@ -39,7 +39,7 @@ def test_service_type_name_non_strict_compliant_names(instance_name, service_typ
     desc = {"path": "/~paulsm/"}
     service_name = f"{instance_name}.{service_type}"
     service_server = "ash-1.local."
-    service_address = socket.inet_aton("10.0.1.2")
+    service_address = socket.inet_aton("10.7.4.2")
     info = ServiceInfo(
         service_type,
         service_name,


### PR DESCRIPTION
## Summary
Follow up to #1865 for #1835, addressing the independent adversarial audit. Three parts:

1. Freshly authored bare pytest replacements for the deleted 2009 descended coverage: parametrized tests for deep label chains, the oversized label rejection, duplicate questions, empty message roundtrips, header flag bits, the multicast zero id, section counts, and question equality.
2. The remaining class based tests in test_init, test_protocol and test_core are converted to bare pytest functions, which retires the 2009 class names Framework, Names, PacketGeneration and PacketForm; unittest skip decorators became pytest.mark.skipif and one call form pytest.raises became the context manager form. The conftest known blocking nodeid was updated for the de-classing.
3. The 2009 descended fixture values are replaced across the whole suite: ash-2.local becomes spare-rig.local, the 10.0.1.x address family becomes 10.7.4.x, and testname.local becomes candidate.local.

An AST structure comparison of the fresh tests against the 2009 test file shows only the generic build call parse shape every tiny roundtrip test shares; the class names, method sequence, fixtures and assertion style that identified the port are gone.

## Test plan
- [x] full suite passes (513, fresh parametrized cases replace the deleted methods)
- [x] fixture sweep confirms no 2009 fixture strings remain