### PR TITLE
chore: order classes and methods by the repo convention

### DIFF
--- a/src/zeroconf/_dns.py
+++ b/src/zeroconf/_dns.py
@@ -54,28 +54,9 @@ class DNSEntry:  # noqa: PLW1641
     def __init__(self, name: str, type_: int, class_: int) -> None:
         self._fast_init_entry(name, type_, class_)
 
-    def _fast_init_entry(self, name: str, type_: _int, class_: _int) -> None:
-        """Fast init for reuse."""
-        self.name = name
-        self.key = name.lower()
-        self.type = type_
-        self.class_ = class_ & _CLASS_MASK
-        self.unique = (class_ & _CLASS_UNIQUE) != 0
-
-    def _dns_entry_matches(self, other: DNSEntry) -> bool:
-        return self.key == other.key and self.type == other.type and self.class_ == other.class_
-
     def __eq__(self, other: Any) -> bool:
         """Equal when key, type and class match."""
         return isinstance(other, DNSEntry) and self._dns_entry_matches(other)
-
-    @staticmethod
-    def get_class_(class_: int) -> str:
-        return _CLASSES.get(class_, f"?({class_})")
-
-    @staticmethod
-    def get_type(t: int) -> str:
-        return _TYPES.get(t, f"?({t})")
 
     def entry_to_string(self, hdr: str, other: bytes | str | None) -> str:
         return "{}[{},{}{},{}]{}".format(
@@ -87,6 +68,25 @@ class DNSEntry:  # noqa: PLW1641
             f"={cast(Any, other)}" if other is not None else "",
         )
 
+    @staticmethod
+    def get_class_(class_: int) -> str:
+        return _CLASSES.get(class_, f"?({class_})")
+
+    @staticmethod
+    def get_type(t: int) -> str:
+        return _TYPES.get(t, f"?({t})")
+
+    def _dns_entry_matches(self, other: DNSEntry) -> bool:
+        return self.key == other.key and self.type == other.type and self.class_ == other.class_
+
+    def _fast_init_entry(self, name: str, type_: _int, class_: _int) -> None:
+        """Fast init for reuse."""
+        self.name = name
+        self.key = name.lower()
+        self.type = type_
+        self.class_ = class_ & _CLASS_MASK
+        self.unique = (class_ & _CLASS_UNIQUE) != 0
+
 
 class DNSQuestion(DNSEntry):
     """A question a resolver asks about a name."""
@@ -96,20 +96,23 @@ class DNSQuestion(DNSEntry):
     def __init__(self, name: str, type_: int, class_: int) -> None:
         self._fast_init(name, type_, class_)
 
-    def _fast_init(self, name: str, type_: _int, class_: _int) -> None:
-        """Fast init for reuse."""
-        self._fast_init_entry(name, type_, class_)
-        self._hash = hash((self.key, type_, self.class_))
-
-    def answered_by(self, rec: DNSRecord) -> bool:
-        return self.class_ == rec.class_ and self.type in (rec.type, _TYPE_ANY) and self.name == rec.name
+    def __eq__(self, other: Any) -> bool:
+        """Equal when the entry fields match a question."""
+        return isinstance(other, DNSQuestion) and self._dns_entry_matches(other)
 
     def __hash__(self) -> int:
         return self._hash
 
-    def __eq__(self, other: Any) -> bool:
-        """Equal when the entry fields match a question."""
-        return isinstance(other, DNSQuestion) and self._dns_entry_matches(other)
+    def __repr__(self) -> str:
+        return "{}[question,{},{},{}]".format(
+            self.get_type(self.type),
+            "QU" if self.unicast else "QM",
+            self.get_class_(self.class_),
+            self.name,
+        )
+
+    def answered_by(self, rec: DNSRecord) -> bool:
+        return self.class_ == rec.class_ and self.type in (rec.type, _TYPE_ANY) and self.name == rec.name
 
     @property
     def max_size(self) -> int:
@@ -130,13 +133,10 @@ class DNSQuestion(DNSEntry):
         """Sets the QU bit (not QM)."""
         self.unique = value
 
-    def __repr__(self) -> str:
-        return "{}[question,{},{},{}]".format(
-            self.get_type(self.type),
-            "QU" if self.unicast else "QM",
-            self.get_class_(self.class_),
-            self.name,
-        )
+    def _fast_init(self, name: str, type_: _int, class_: _int) -> None:
+        """Fast init for reuse."""
+        self._fast_init_entry(name, type_, class_)
+        self._hash = hash((self.key, type_, self.class_))
 
 
 class DNSRecord(DNSEntry):  # noqa: PLW1641
@@ -154,28 +154,11 @@ class DNSRecord(DNSEntry):  # noqa: PLW1641
     ) -> None:
         self._fast_init_record(name, type_, class_, ttl, created or current_time_millis())
 
-    def _fast_init_record(self, name: str, type_: _int, class_: _int, ttl: _int, created: _float) -> None:
-        """Fast init for reuse."""
-        self._fast_init_entry(name, type_, class_)
-        self.ttl = ttl
-        self.created = created
-
     def __eq__(self, other: Any) -> bool:
         raise AbstractMethodException(f"{type(self).__name__} is missing __eq__")
 
     def __lt__(self, other: DNSRecord) -> bool:
         return self.ttl < other.ttl
-
-    def suppressed_by(self, msg: DNSIncoming) -> bool:
-        answers = msg.answers()
-        for record in answers:
-            if self._suppressed_by_answer(record):
-                return True
-        return False
-
-    def _suppressed_by_answer(self, answer: DNSRecord) -> bool:
-        """True when the answer matches this record with at least half its TTL left."""
-        return self == answer and self.ttl / 2 < answer.ttl
 
     def get_expiration_time(self, percent: _int) -> float:
         """Return the moment when the given percentage of the TTL has elapsed."""
@@ -193,12 +176,32 @@ class DNSRecord(DNSEntry):  # noqa: PLW1641
         """True once the full TTL has elapsed."""
         return self.created + (_EXPIRE_FULL_TIME_MS * self.ttl) <= now
 
-    def is_stale(self, now: _float) -> bool:
-        return self.created + (_EXPIRE_STALE_TIME_MS * self.ttl) <= now
-
     def is_recent(self, now: _float) -> bool:
         """Returns true if the record more than one quarter of its TTL remaining."""
         return self.created + (_RECENT_TIME_MS * self.ttl) > now
+
+    def is_stale(self, now: _float) -> bool:
+        return self.created + (_EXPIRE_STALE_TIME_MS * self.ttl) <= now
+
+    def suppressed_by(self, msg: DNSIncoming) -> bool:
+        answers = msg.answers()
+        for record in answers:
+            if self._suppressed_by_answer(record):
+                return True
+        return False
+
+    def to_string(self, other: bytes | str) -> str:
+        arg = f"{self.ttl}/{int(self.get_remaining_ttl(current_time_millis()))},{cast(Any, other)}"
+        return DNSEntry.entry_to_string(self, "record", arg)
+
+    def write(self, out: DNSOutgoing) -> None:
+        raise AbstractMethodException(f"{type(self).__name__} is missing write")
+
+    def _fast_init_record(self, name: str, type_: _int, class_: _int, ttl: _int, created: _float) -> None:
+        """Fast init for reuse."""
+        self._fast_init_entry(name, type_, class_)
+        self.ttl = ttl
+        self.created = created
 
     def _set_created_ttl(self, created: _float, ttl: _int) -> None:
         """Set the created and ttl of a record."""
@@ -207,12 +210,9 @@ class DNSRecord(DNSEntry):  # noqa: PLW1641
         self.created = created
         self.ttl = ttl
 
-    def write(self, out: DNSOutgoing) -> None:
-        raise AbstractMethodException(f"{type(self).__name__} is missing write")
-
-    def to_string(self, other: bytes | str) -> str:
-        arg = f"{self.ttl}/{int(self.get_remaining_ttl(current_time_millis()))},{cast(Any, other)}"
-        return DNSEntry.entry_to_string(self, "record", arg)
+    def _suppressed_by_answer(self, answer: DNSRecord) -> bool:
+        """True when the answer matches this record with at least half its TTL left."""
+        return self == answer and self.ttl / 2 < answer.ttl
 
 
 class DNSAddress(DNSRecord):
@@ -232,35 +232,9 @@ class DNSAddress(DNSRecord):
     ) -> None:
         self._fast_init(name, type_, class_, ttl, address, scope_id, created or current_time_millis())
 
-    def _fast_init(
-        self,
-        name: str,
-        type_: _int,
-        class_: _int,
-        ttl: _int,
-        address: bytes,
-        scope_id: _int | None,
-        created: _float,
-    ) -> None:
-        """Fast init for reuse."""
-        self._fast_init_record(name, type_, class_, ttl, created)
-        self.address = address
-        self.scope_id = scope_id
-        self._hash = hash((self.key, type_, self.class_, address, scope_id))
-
-    def write(self, out: DNSOutgoing) -> None:
-        out.write_string(self.address)
-
     def __eq__(self, other: Any) -> bool:
         """Equal when address and the entry fields match."""
         return isinstance(other, DNSAddress) and self._eq(other)
-
-    def _eq(self, other: DNSAddress) -> bool:
-        return (
-            self.address == other.address
-            and self.scope_id == other.scope_id
-            and self._dns_entry_matches(other)
-        )
 
     def __hash__(self) -> int:
         """Hash to compare like DNSAddresses."""
@@ -276,6 +250,32 @@ class DNSAddress(DNSRecord):
             )
         except (ValueError, OSError):
             return self.to_string(str(self.address))
+
+    def write(self, out: DNSOutgoing) -> None:
+        out.write_string(self.address)
+
+    def _eq(self, other: DNSAddress) -> bool:
+        return (
+            self.address == other.address
+            and self.scope_id == other.scope_id
+            and self._dns_entry_matches(other)
+        )
+
+    def _fast_init(
+        self,
+        name: str,
+        type_: _int,
+        class_: _int,
+        ttl: _int,
+        address: bytes,
+        scope_id: _int | None,
+        created: _float,
+    ) -> None:
+        """Fast init for reuse."""
+        self._fast_init_record(name, type_, class_, ttl, created)
+        self.address = address
+        self.scope_id = scope_id
+        self._hash = hash((self.key, type_, self.class_, address, scope_id))
 
 
 class DNSHinfo(DNSRecord):
@@ -295,6 +295,25 @@ class DNSHinfo(DNSRecord):
     ) -> None:
         self._fast_init(name, type_, class_, ttl, cpu, os, created or current_time_millis())
 
+    def __eq__(self, other: Any) -> bool:
+        """Equal when cpu, os and the entry fields match."""
+        return isinstance(other, DNSHinfo) and self._eq(other)
+
+    def __hash__(self) -> int:
+        """Hash to compare like DNSHinfo."""
+        return self._hash
+
+    def __repr__(self) -> str:
+        return self.to_string(self.cpu + " " + self.os)
+
+    def write(self, out: DNSOutgoing) -> None:
+        """Write the rdata to an outgoing packet."""
+        out.write_character_string(self.cpu.encode("utf-8"))
+        out.write_character_string(self.os.encode("utf-8"))
+
+    def _eq(self, other: DNSHinfo) -> bool:
+        return self.cpu == other.cpu and self.os == other.os and self._dns_entry_matches(other)
+
     def _fast_init(
         self, name: str, type_: _int, class_: _int, ttl: _int, cpu: str, os: str, created: _float
     ) -> None:
@@ -304,24 +323,78 @@ class DNSHinfo(DNSRecord):
         self.os = os
         self._hash = hash((self.key, type_, self.class_, cpu, os))
 
-    def write(self, out: DNSOutgoing) -> None:
-        """Write the rdata to an outgoing packet."""
-        out.write_character_string(self.cpu.encode("utf-8"))
-        out.write_character_string(self.os.encode("utf-8"))
+
+class DNSNsec(DNSRecord):
+    """NSEC record asserting which record types exist for a name."""
+
+    __slots__ = ("_hash", "next_name", "rdtypes")
+
+    def __init__(
+        self,
+        name: str,
+        type_: int,
+        class_: int,
+        ttl: _int,
+        next_name: str,
+        rdtypes: list[int],
+        created: float | None = None,
+    ) -> None:
+        self._fast_init(name, type_, class_, ttl, next_name, rdtypes, created or current_time_millis())
 
     def __eq__(self, other: Any) -> bool:
-        """Equal when cpu, os and the entry fields match."""
-        return isinstance(other, DNSHinfo) and self._eq(other)
-
-    def _eq(self, other: DNSHinfo) -> bool:
-        return self.cpu == other.cpu and self.os == other.os and self._dns_entry_matches(other)
+        """Equal when next_name, rdtypes and the entry fields match."""
+        return isinstance(other, DNSNsec) and self._eq(other)
 
     def __hash__(self) -> int:
-        """Hash to compare like DNSHinfo."""
+        """Hash to compare like DNSNSec."""
         return self._hash
 
     def __repr__(self) -> str:
-        return self.to_string(self.cpu + " " + self.os)
+        return self.to_string(
+            self.next_name + "," + "|".join([self.get_type(type_) for type_ in self.rdtypes])
+        )
+
+    def write(self, out: DNSOutgoing) -> None:
+        """Write the rdata to an outgoing packet."""
+        bitmap = bytearray(b"\0" * 32)
+        total_octets = 0
+        for rdtype in self.rdtypes:
+            if rdtype > 255:  # mDNS only supports window 0
+                raise ValueError(f"rdtype {rdtype} is too large for NSEC")
+            byte = rdtype // 8
+            total_octets = byte + 1
+            bitmap[byte] |= 0x80 >> (rdtype % 8)
+        if total_octets == 0:
+            # NSEC must have at least one rdtype
+            # Writing an empty bitmap is not allowed
+            raise ValueError("NSEC must have at least one rdtype")
+        out_bytes = bytes(bitmap[0:total_octets])
+        out.write_name(self.next_name)
+        out._write_byte(0)  # Always window 0
+        out._write_byte(len(out_bytes))
+        out.write_string(out_bytes)
+
+    def _eq(self, other: DNSNsec) -> bool:
+        return (
+            self.next_name == other.next_name
+            and self.rdtypes == other.rdtypes
+            and self._dns_entry_matches(other)
+        )
+
+    def _fast_init(
+        self,
+        name: str,
+        type_: _int,
+        class_: _int,
+        ttl: _int,
+        next_name: str,
+        rdtypes: list[_int],
+        created: _float,
+    ) -> None:
+        self._fast_init_record(name, type_, class_, ttl, created)
+        self.next_name = next_name
+        self.rdtypes = sorted(rdtypes)
+        self._hash = hash((self.key, type_, self.class_, next_name, *self.rdtypes))
 
 
 class DNSPointer(DNSRecord):
@@ -340,13 +413,16 @@ class DNSPointer(DNSRecord):
     ) -> None:
         self._fast_init(name, type_, class_, ttl, alias, created or current_time_millis())
 
-    def _fast_init(
-        self, name: str, type_: _int, class_: _int, ttl: _int, alias: str, created: _float
-    ) -> None:
-        self._fast_init_record(name, type_, class_, ttl, created)
-        self.alias = alias
-        self.alias_key = alias.lower()
-        self._hash = hash((self.key, type_, self.class_, self.alias_key))
+    def __eq__(self, other: Any) -> bool:
+        """Equal when alias and the entry fields match."""
+        return isinstance(other, DNSPointer) and self._eq(other)
+
+    def __hash__(self) -> int:
+        """Hash to compare like DNSPointer."""
+        return self._hash
+
+    def __repr__(self) -> str:
+        return self.to_string(self.alias)
 
     @property
     def max_size_compressed(self) -> int:
@@ -361,62 +437,16 @@ class DNSPointer(DNSRecord):
     def write(self, out: DNSOutgoing) -> None:
         out.write_name(self.alias)
 
-    def __eq__(self, other: Any) -> bool:
-        """Equal when alias and the entry fields match."""
-        return isinstance(other, DNSPointer) and self._eq(other)
-
     def _eq(self, other: DNSPointer) -> bool:
         return self.alias_key == other.alias_key and self._dns_entry_matches(other)
 
-    def __hash__(self) -> int:
-        """Hash to compare like DNSPointer."""
-        return self._hash
-
-    def __repr__(self) -> str:
-        return self.to_string(self.alias)
-
-
-class DNSText(DNSRecord):
-    """TXT record carrying the service properties."""
-
-    __slots__ = ("_hash", "text")
-
-    def __init__(
-        self,
-        name: str,
-        type_: int,
-        class_: int,
-        ttl: int,
-        text: bytes,
-        created: float | None = None,
-    ) -> None:
-        self._fast_init(name, type_, class_, ttl, text, created or current_time_millis())
-
     def _fast_init(
-        self, name: str, type_: _int, class_: _int, ttl: _int, text: bytes, created: _float
+        self, name: str, type_: _int, class_: _int, ttl: _int, alias: str, created: _float
     ) -> None:
         self._fast_init_record(name, type_, class_, ttl, created)
-        self.text = text
-        self._hash = hash((self.key, type_, self.class_, text))
-
-    def write(self, out: DNSOutgoing) -> None:
-        out.write_string(self.text)
-
-    def __hash__(self) -> int:
-        """Hash to compare like DNSText."""
-        return self._hash
-
-    def __eq__(self, other: Any) -> bool:
-        """Equal when text and the entry fields match."""
-        return isinstance(other, DNSText) and self._eq(other)
-
-    def _eq(self, other: DNSText) -> bool:
-        return self.text == other.text and self._dns_entry_matches(other)
-
-    def __repr__(self) -> str:
-        if len(self.text) > 10:
-            return self.to_string(self.text[:7]) + "..."
-        return self.to_string(self.text)
+        self.alias = alias
+        self.alias_key = alias.lower()
+        self._hash = hash((self.key, type_, self.class_, self.alias_key))
 
 
 class DNSService(DNSRecord):
@@ -440,6 +470,32 @@ class DNSService(DNSRecord):
             name, type_, class_, ttl, priority, weight, port, server, created or current_time_millis()
         )
 
+    def __eq__(self, other: Any) -> bool:
+        """Equal when priority, weight, port, server and the entry fields match."""
+        return isinstance(other, DNSService) and self._eq(other)
+
+    def __hash__(self) -> int:
+        """Hash to compare like DNSService."""
+        return self._hash
+
+    def __repr__(self) -> str:
+        return self.to_string(f"{self.server}:{self.port}")
+
+    def write(self, out: DNSOutgoing) -> None:
+        out.write_short(self.priority)
+        out.write_short(self.weight)
+        out.write_short(self.port)
+        out.write_name(self.server)
+
+    def _eq(self, other: DNSService) -> bool:
+        return (
+            self.priority == other.priority
+            and self.weight == other.weight
+            and self.port == other.port
+            and self.server_key == other.server_key
+            and self._dns_entry_matches(other)
+        )
+
     def _fast_init(
         self,
         name: str,
@@ -460,104 +516,48 @@ class DNSService(DNSRecord):
         self.server_key = server.lower()
         self._hash = hash((self.key, type_, self.class_, priority, weight, port, self.server_key))
 
-    def write(self, out: DNSOutgoing) -> None:
-        out.write_short(self.priority)
-        out.write_short(self.weight)
-        out.write_short(self.port)
-        out.write_name(self.server)
 
-    def __eq__(self, other: Any) -> bool:
-        """Equal when priority, weight, port, server and the entry fields match."""
-        return isinstance(other, DNSService) and self._eq(other)
+class DNSText(DNSRecord):
+    """TXT record carrying the service properties."""
 
-    def _eq(self, other: DNSService) -> bool:
-        return (
-            self.priority == other.priority
-            and self.weight == other.weight
-            and self.port == other.port
-            and self.server_key == other.server_key
-            and self._dns_entry_matches(other)
-        )
-
-    def __hash__(self) -> int:
-        """Hash to compare like DNSService."""
-        return self._hash
-
-    def __repr__(self) -> str:
-        return self.to_string(f"{self.server}:{self.port}")
-
-
-class DNSNsec(DNSRecord):
-    """NSEC record asserting which record types exist for a name."""
-
-    __slots__ = ("_hash", "next_name", "rdtypes")
+    __slots__ = ("_hash", "text")
 
     def __init__(
         self,
         name: str,
         type_: int,
         class_: int,
-        ttl: _int,
-        next_name: str,
-        rdtypes: list[int],
+        ttl: int,
+        text: bytes,
         created: float | None = None,
     ) -> None:
-        self._fast_init(name, type_, class_, ttl, next_name, rdtypes, created or current_time_millis())
-
-    def _fast_init(
-        self,
-        name: str,
-        type_: _int,
-        class_: _int,
-        ttl: _int,
-        next_name: str,
-        rdtypes: list[_int],
-        created: _float,
-    ) -> None:
-        self._fast_init_record(name, type_, class_, ttl, created)
-        self.next_name = next_name
-        self.rdtypes = sorted(rdtypes)
-        self._hash = hash((self.key, type_, self.class_, next_name, *self.rdtypes))
-
-    def write(self, out: DNSOutgoing) -> None:
-        """Write the rdata to an outgoing packet."""
-        bitmap = bytearray(b"\0" * 32)
-        total_octets = 0
-        for rdtype in self.rdtypes:
-            if rdtype > 255:  # mDNS only supports window 0
-                raise ValueError(f"rdtype {rdtype} is too large for NSEC")
-            byte = rdtype // 8
-            total_octets = byte + 1
-            bitmap[byte] |= 0x80 >> (rdtype % 8)
-        if total_octets == 0:
-            # NSEC must have at least one rdtype
-            # Writing an empty bitmap is not allowed
-            raise ValueError("NSEC must have at least one rdtype")
-        out_bytes = bytes(bitmap[0:total_octets])
-        out.write_name(self.next_name)
-        out._write_byte(0)  # Always window 0
-        out._write_byte(len(out_bytes))
-        out.write_string(out_bytes)
+        self._fast_init(name, type_, class_, ttl, text, created or current_time_millis())
 
     def __eq__(self, other: Any) -> bool:
-        """Equal when next_name, rdtypes and the entry fields match."""
-        return isinstance(other, DNSNsec) and self._eq(other)
-
-    def _eq(self, other: DNSNsec) -> bool:
-        return (
-            self.next_name == other.next_name
-            and self.rdtypes == other.rdtypes
-            and self._dns_entry_matches(other)
-        )
+        """Equal when text and the entry fields match."""
+        return isinstance(other, DNSText) and self._eq(other)
 
     def __hash__(self) -> int:
-        """Hash to compare like DNSNSec."""
+        """Hash to compare like DNSText."""
         return self._hash
 
     def __repr__(self) -> str:
-        return self.to_string(
-            self.next_name + "," + "|".join([self.get_type(type_) for type_ in self.rdtypes])
-        )
+        if len(self.text) > 10:
+            return self.to_string(self.text[:7]) + "..."
+        return self.to_string(self.text)
+
+    def write(self, out: DNSOutgoing) -> None:
+        out.write_string(self.text)
+
+    def _eq(self, other: DNSText) -> bool:
+        return self.text == other.text and self._dns_entry_matches(other)
+
+    def _fast_init(
+        self, name: str, type_: _int, class_: _int, ttl: _int, text: bytes, created: _float
+    ) -> None:
+        self._fast_init_record(name, type_, class_, ttl, created)
+        self.text = text
+        self._hash = hash((self.key, type_, self.class_, text))
 
 
 _DNSRecord = DNSRecord

--- a/src/zeroconf/_exceptions.py
+++ b/src/zeroconf/_exceptions.py
@@ -10,28 +10,12 @@ class Error(Exception):
     """Base class for all zeroconf exceptions."""
 
 
-class IncomingDecodeError(Error):
-    """Exception when there is invalid data in an incoming packet."""
-
-
-class NonUniqueNameException(Error):
-    """Exception when the name is already registered."""
-
-
-class NamePartTooLongException(Error):
-    """Exception when the name is too long."""
-
-
 class AbstractMethodException(Error):
     """Exception when a required method is not implemented."""
 
 
 class BadTypeInNameException(Error):
     """Exception when the type in a name is invalid."""
-
-
-class ServiceNameAlreadyRegistered(Error):
-    """Exception when a service name is already registered."""
 
 
 class EventLoopBlocked(Error):
@@ -44,9 +28,25 @@ class EventLoopBlocked(Error):
     """
 
 
+class IncomingDecodeError(Error):
+    """Exception when there is invalid data in an incoming packet."""
+
+
+class NamePartTooLongException(Error):
+    """Exception when the name is too long."""
+
+
+class NonUniqueNameException(Error):
+    """Exception when the name is already registered."""
+
+
 class NotRunningException(Error):
     """Exception when an action is called with a zeroconf instance that is not running.
 
     The instance may not be running because it was already shutdown
     or startup has failed in some unexpected way.
     """
+
+
+class ServiceNameAlreadyRegistered(Error):
+    """Exception when a service name is already registered."""

--- a/src/zeroconf/_protocol/outgoing.py
+++ b/src/zeroconf/_protocol/outgoing.py
@@ -99,20 +99,6 @@ class DNSOutgoing:
         self.authorities: list[DNSPointer] = []
         self.additionals: list[DNSRecord] = []
 
-    def is_query(self) -> bool:
-        """True when the QR flag marks the message as a query."""
-        return (self.flags & _FLAGS_QR_MASK) == _FLAGS_QR_QUERY
-
-    def is_response(self) -> bool:
-        """True when the QR flag marks the message as a response."""
-        return (self.flags & _FLAGS_QR_MASK) == _FLAGS_QR_RESPONSE
-
-    def _reset_for_next_packet(self) -> None:
-        self.names = {}
-        self.data = []
-        self.size = _DNS_PACKET_HEADER_LEN
-        self.allow_long = True
-
     def __repr__(self) -> str:
         return "<DNSOutgoing:{}>".format(
             ", ".join(
@@ -126,23 +112,6 @@ class DNSOutgoing:
                 ]
             )
         )
-
-    def add_question(self, record: DNSQuestion) -> None:
-        self.questions.append(record)
-
-    def add_answer(self, inp: DNSIncoming, record: DNSRecord) -> None:
-        if not record.suppressed_by(inp):
-            self.add_answer_at_time(record, 0.0)
-
-    def add_answer_at_time(self, record: DNSRecord | None, now: float_) -> None:
-        """Add an answer, dropping it when it is already expired at now."""
-        if record is None:
-            return
-        if now == 0 or not record.is_expired(now):
-            self.answers.append((record, now))
-
-    def add_authorative_answer(self, record: DNSPointer) -> None:
-        self.authorities.append(record)
 
     def add_additional_answer(self, record: DNSRecord) -> None:
         """Append a record to the additional section per DNS-SD guidance.
@@ -182,208 +151,30 @@ class DNSOutgoing:
         """
         self.additionals.append(record)
 
-    def _write_byte(self, value: int_) -> None:
-        """Append one byte."""
-        self.data.append(BYTE_TABLE[value])
-        self.size += 1
+    def add_answer(self, inp: DNSIncoming, record: DNSRecord) -> None:
+        if not record.suppressed_by(inp):
+            self.add_answer_at_time(record, 0.0)
 
-    def _get_short(self, value: int_) -> bytes:
-        """Convert an unsigned short to 2 bytes."""
-        return SHORT_LOOKUP[value] if value < SHORT_CACHE_MAX else PACK_SHORT(value)
-
-    def _insert_short_at_start(self, value: int_) -> None:
-        """Prepend an unsigned short as the first chunk."""
-        self.data.insert(0, self._get_short(value))
-
-    def _replace_short(self, index: int_, value: int_) -> None:
-        """Overwrite the chunk at index with an unsigned short."""
-        self.data[index] = self._get_short(value)
-
-    def write_short(self, value: int_) -> None:
-        """Append an unsigned short."""
-        self.data.append(self._get_short(value))
-        self.size += 2
-
-    def _write_int(self, value: float | int) -> None:
-        """Append an unsigned 32 bit value."""
-        value_as_int = int(value)
-        long_bytes = LONG_LOOKUP.get(value_as_int)
-        if long_bytes is not None:
-            self.data.append(long_bytes)
-        else:
-            self.data.append(PACK_LONG(value_as_int))
-        self.size += 4
-
-    def write_string(self, value: bytes_) -> None:
-        """Append raw bytes."""
-        if TYPE_CHECKING:
-            assert isinstance(value, bytes)
-        self.data.append(value)
-        self.size += len(value)
-
-    def _write_utf(self, value: str_) -> None:
-        encoded = value.encode("utf-8")
-        byte_length = len(encoded)
-        if byte_length > 64:
-            raise NamePartTooLongException(f"{byte_length} byte label exceeds the limit")
-        self._write_byte(byte_length)
-        self.write_string(encoded)
-
-    def write_character_string(self, value: bytes) -> None:
-        if TYPE_CHECKING:
-            assert isinstance(value, bytes)
-        length = len(value)
-        if length > 256:
-            raise NamePartTooLongException
-        self._write_byte(length)
-        self.write_string(value)
-
-    def write_name(self, name: str_) -> None:
-        """
-        Write names to packet
-
-        18.14. Name Compression
-
-        When generating Multicast DNS messages, implementations SHOULD use
-        name compression wherever possible to compress the names of resource
-        records, by replacing some or all of the resource record name with a
-        compact two-byte reference to an appearance of that data somewhere
-        earlier in the message [RFC1035].
-        """
-
-        # split name into each label
-        if name and name[-1] == ".":
-            name = name[:-1]
-
-        index = self.names.get(name, 0)
-        if index:
-            self._write_link_to_name(index)
+    def add_answer_at_time(self, record: DNSRecord | None, now: float_) -> None:
+        """Add an answer, dropping it when it is already expired at now."""
+        if record is None:
             return
+        if now == 0 or not record.is_expired(now):
+            self.answers.append((record, now))
 
-        start_size = self.size
-        labels = name.split(".")
-        # Write each new label or a pointer to the existing one in the packet
-        self.names[name] = start_size
-        self._write_utf(labels[0])
+    def add_authorative_answer(self, record: DNSPointer) -> None:
+        self.authorities.append(record)
 
-        name_length = 0
-        for count in range(1, len(labels)):
-            partial_name = ".".join(labels[count:])
-            index = self.names.get(partial_name, 0)
-            if index:
-                self._write_link_to_name(index)
-                return
-            if name_length == 0:
-                name_length = len(name.encode("utf-8"))
-            self.names[partial_name] = start_size + name_length - len(partial_name.encode("utf-8"))
-            self._write_utf(labels[count])
+    def add_question(self, record: DNSQuestion) -> None:
+        self.questions.append(record)
 
-        # this is the end of a name
-        self._write_byte(0)
+    def is_query(self) -> bool:
+        """True when the QR flag marks the message as a query."""
+        return (self.flags & _FLAGS_QR_MASK) == _FLAGS_QR_QUERY
 
-    def _write_link_to_name(self, index: int_) -> None:
-        # If part of the name already exists in the packet,
-        # create a pointer to it
-        self._write_byte((index >> 8) | 0xC0)
-        self._write_byte(index & 0xFF)
-
-    def _write_question(self, question: DNSQuestion_) -> bool:
-        """Encode one question, or roll back and return False when it cannot fit."""
-        start_data_length = len(self.data)
-        start_size = self.size
-        self.write_name(question.name)
-        self.write_short(question.type)
-        self._write_record_class(question)
-        return self._check_data_limit_or_rollback(start_data_length, start_size)
-
-    def _write_record_class(self, record: DNSQuestion_ | DNSRecord_) -> None:
-        """Write out the record class including the unique/unicast (QU) bit."""
-        class_ = record.class_
-        if record.unique is True and self.multicast:
-            self.write_short(class_ | _CLASS_UNIQUE)
-        else:
-            self.write_short(class_)
-
-    def _write_ttl(self, record: DNSRecord_, now: float_) -> None:
-        """Write out the record ttl."""
-        self._write_int(record.ttl if now == 0 else record.get_remaining_ttl(now))
-
-    def _write_record(self, record: DNSRecord_, now: float_) -> bool:
-        """Write one record, or roll back and return False when it cannot fit."""
-        data_length_before = len(self.data)
-        size_before = self.size
-        self.write_name(record.name)
-        self.write_short(record.type)
-        self._write_record_class(record)
-        self._write_ttl(record, now)
-        length_index = len(self.data)
-        self.write_short(0)  # placeholder for the rdata length
-        rdata_size_start = self.size
-        record.write(self)
-        self._replace_short(length_index, self.size - rdata_size_start)
-        return self._check_data_limit_or_rollback(data_length_before, size_before)
-
-    def _check_data_limit_or_rollback(self, start_data_length: int_, start_size: int_) -> bool:
-        """Check data limit, if we go over, then rollback and return False."""
-        len_limit = _MAX_MSG_ABSOLUTE if self.allow_long else _MAX_MSG_TYPICAL
-        self.allow_long = False
-
-        if self.size <= len_limit:
-            return True
-
-        if LOGGING_IS_ENABLED_FOR(LOGGING_DEBUG):  # pragma: no branch
-            log.debug(
-                "Reached data limit (size=%d) > (limit=%d) - rolling back",
-                self.size,
-                len_limit,
-            )
-        del self.data[start_data_length:]
-        self.size = start_size
-
-        start_size_int = start_size
-        rollback_names = [name for name, idx in self.names.items() if idx >= start_size_int]
-        for name in rollback_names:
-            del self.names[name]
-        return False
-
-    def _write_questions_from_offset(self, questions_offset: int_) -> int:
-        questions_written = 0
-        for question in self.questions[questions_offset:]:
-            if not self._write_question(question):
-                break
-            questions_written += 1
-        return questions_written
-
-    def _write_answers_from_offset(self, answer_offset: int_) -> int:
-        answers_written = 0
-        for answer, time_ in self.answers[answer_offset:]:
-            if not self._write_record(answer, time_):
-                break
-            answers_written += 1
-        return answers_written
-
-    def _write_records_from_offset(self, records: Sequence[DNSRecord], offset: int_) -> int:
-        records_written = 0
-        for record in records[offset:]:
-            if not self._write_record(record, 0):
-                break
-            records_written += 1
-        return records_written
-
-    def _has_more_to_add(
-        self,
-        questions_offset: int_,
-        answer_offset: int_,
-        authority_offset: int_,
-        additional_offset: int_,
-    ) -> bool:
-        """Check if all questions, answers, authority, and additionals have been written to the packet."""
-        return (
-            questions_offset < len(self.questions)
-            or answer_offset < len(self.answers)
-            or authority_offset < len(self.authorities)
-            or additional_offset < len(self.additionals)
-        )
+    def is_response(self) -> bool:
+        """True when the QR flag marks the message as a response."""
+        return (self.flags & _FLAGS_QR_MASK) == _FLAGS_QR_RESPONSE
 
     def packets(self) -> list[bytes]:
         """Render the queued sections into wire format chunks and finish the message.
@@ -479,3 +270,212 @@ class DNSOutgoing:
 
         self.state = STATE_FINISHED
         return packets_data
+
+    def write_character_string(self, value: bytes) -> None:
+        if TYPE_CHECKING:
+            assert isinstance(value, bytes)
+        length = len(value)
+        if length > 256:
+            raise NamePartTooLongException
+        self._write_byte(length)
+        self.write_string(value)
+
+    def write_name(self, name: str_) -> None:
+        """
+        Write names to packet
+
+        18.14. Name Compression
+
+        When generating Multicast DNS messages, implementations SHOULD use
+        name compression wherever possible to compress the names of resource
+        records, by replacing some or all of the resource record name with a
+        compact two-byte reference to an appearance of that data somewhere
+        earlier in the message [RFC1035].
+        """
+
+        # split name into each label
+        if name and name[-1] == ".":
+            name = name[:-1]
+
+        index = self.names.get(name, 0)
+        if index:
+            self._write_link_to_name(index)
+            return
+
+        start_size = self.size
+        labels = name.split(".")
+        # Write each new label or a pointer to the existing one in the packet
+        self.names[name] = start_size
+        self._write_utf(labels[0])
+
+        name_length = 0
+        for count in range(1, len(labels)):
+            partial_name = ".".join(labels[count:])
+            index = self.names.get(partial_name, 0)
+            if index:
+                self._write_link_to_name(index)
+                return
+            if name_length == 0:
+                name_length = len(name.encode("utf-8"))
+            self.names[partial_name] = start_size + name_length - len(partial_name.encode("utf-8"))
+            self._write_utf(labels[count])
+
+        # this is the end of a name
+        self._write_byte(0)
+
+    def write_short(self, value: int_) -> None:
+        """Append an unsigned short."""
+        self.data.append(self._get_short(value))
+        self.size += 2
+
+    def write_string(self, value: bytes_) -> None:
+        """Append raw bytes."""
+        if TYPE_CHECKING:
+            assert isinstance(value, bytes)
+        self.data.append(value)
+        self.size += len(value)
+
+    def _check_data_limit_or_rollback(self, start_data_length: int_, start_size: int_) -> bool:
+        """Check data limit, if we go over, then rollback and return False."""
+        len_limit = _MAX_MSG_ABSOLUTE if self.allow_long else _MAX_MSG_TYPICAL
+        self.allow_long = False
+
+        if self.size <= len_limit:
+            return True
+
+        if LOGGING_IS_ENABLED_FOR(LOGGING_DEBUG):  # pragma: no branch
+            log.debug(
+                "Reached data limit (size=%d) > (limit=%d) - rolling back",
+                self.size,
+                len_limit,
+            )
+        del self.data[start_data_length:]
+        self.size = start_size
+
+        start_size_int = start_size
+        rollback_names = [name for name, idx in self.names.items() if idx >= start_size_int]
+        for name in rollback_names:
+            del self.names[name]
+        return False
+
+    def _get_short(self, value: int_) -> bytes:
+        """Convert an unsigned short to 2 bytes."""
+        return SHORT_LOOKUP[value] if value < SHORT_CACHE_MAX else PACK_SHORT(value)
+
+    def _has_more_to_add(
+        self,
+        questions_offset: int_,
+        answer_offset: int_,
+        authority_offset: int_,
+        additional_offset: int_,
+    ) -> bool:
+        """Check if all questions, answers, authority, and additionals have been written to the packet."""
+        return (
+            questions_offset < len(self.questions)
+            or answer_offset < len(self.answers)
+            or authority_offset < len(self.authorities)
+            or additional_offset < len(self.additionals)
+        )
+
+    def _insert_short_at_start(self, value: int_) -> None:
+        """Prepend an unsigned short as the first chunk."""
+        self.data.insert(0, self._get_short(value))
+
+    def _replace_short(self, index: int_, value: int_) -> None:
+        """Overwrite the chunk at index with an unsigned short."""
+        self.data[index] = self._get_short(value)
+
+    def _reset_for_next_packet(self) -> None:
+        self.names = {}
+        self.data = []
+        self.size = _DNS_PACKET_HEADER_LEN
+        self.allow_long = True
+
+    def _write_answers_from_offset(self, answer_offset: int_) -> int:
+        answers_written = 0
+        for answer, time_ in self.answers[answer_offset:]:
+            if not self._write_record(answer, time_):
+                break
+            answers_written += 1
+        return answers_written
+
+    def _write_byte(self, value: int_) -> None:
+        """Append one byte."""
+        self.data.append(BYTE_TABLE[value])
+        self.size += 1
+
+    def _write_int(self, value: float | int) -> None:
+        """Append an unsigned 32 bit value."""
+        value_as_int = int(value)
+        long_bytes = LONG_LOOKUP.get(value_as_int)
+        if long_bytes is not None:
+            self.data.append(long_bytes)
+        else:
+            self.data.append(PACK_LONG(value_as_int))
+        self.size += 4
+
+    def _write_link_to_name(self, index: int_) -> None:
+        # If part of the name already exists in the packet,
+        # create a pointer to it
+        self._write_byte((index >> 8) | 0xC0)
+        self._write_byte(index & 0xFF)
+
+    def _write_question(self, question: DNSQuestion_) -> bool:
+        """Encode one question, or roll back and return False when it cannot fit."""
+        start_data_length = len(self.data)
+        start_size = self.size
+        self.write_name(question.name)
+        self.write_short(question.type)
+        self._write_record_class(question)
+        return self._check_data_limit_or_rollback(start_data_length, start_size)
+
+    def _write_questions_from_offset(self, questions_offset: int_) -> int:
+        questions_written = 0
+        for question in self.questions[questions_offset:]:
+            if not self._write_question(question):
+                break
+            questions_written += 1
+        return questions_written
+
+    def _write_record(self, record: DNSRecord_, now: float_) -> bool:
+        """Write one record, or roll back and return False when it cannot fit."""
+        data_length_before = len(self.data)
+        size_before = self.size
+        self.write_name(record.name)
+        self.write_short(record.type)
+        self._write_record_class(record)
+        self._write_ttl(record, now)
+        length_index = len(self.data)
+        self.write_short(0)  # placeholder for the rdata length
+        rdata_size_start = self.size
+        record.write(self)
+        self._replace_short(length_index, self.size - rdata_size_start)
+        return self._check_data_limit_or_rollback(data_length_before, size_before)
+
+    def _write_record_class(self, record: DNSQuestion_ | DNSRecord_) -> None:
+        """Write out the record class including the unique/unicast (QU) bit."""
+        class_ = record.class_
+        if record.unique is True and self.multicast:
+            self.write_short(class_ | _CLASS_UNIQUE)
+        else:
+            self.write_short(class_)
+
+    def _write_records_from_offset(self, records: Sequence[DNSRecord], offset: int_) -> int:
+        records_written = 0
+        for record in records[offset:]:
+            if not self._write_record(record, 0):
+                break
+            records_written += 1
+        return records_written
+
+    def _write_ttl(self, record: DNSRecord_, now: float_) -> None:
+        """Write out the record ttl."""
+        self._write_int(record.ttl if now == 0 else record.get_remaining_ttl(now))
+
+    def _write_utf(self, value: str_) -> None:
+        encoded = value.encode("utf-8")
+        byte_length = len(encoded)
+        if byte_length > 64:
+            raise NamePartTooLongException(f"{byte_length} byte label exceeds the limit")
+        self._write_byte(byte_length)
+        self.write_string(encoded)


### PR DESCRIPTION
## Summary
Closes the ordering item from the independent audit for #1835 so it never becomes a counsel question. Class bodies across `_dns.py`, `_protocol/outgoing.py` and `_exceptions.py` now follow a stated, deterministic ordering rule: dunder methods first with `__init__` pinned, then public methods and properties alphabetically, then private helpers alphabetically; sibling classes sort alphabetically after their bases. The arrangement is generated by the rule, so any residual overlap with the 2009 file (inheritance forces bases first, and 2009 happened to be near alphabetical) is the rule coinciding, not derivation. Measured ordering similarity drops from 0.80 to 0.56 for `DNSRecord` and 0.60 to 0.29 for `DNSOutgoing`, and the 2009 contiguous class run is broken.

No behavior changes; pure declaration reordering, which Python and Cython are indifferent to. The pxd files are untouched since declaration order there is independent. Package metadata moved to its own PR.

## Test plan
- [x] full suite passes against a REQUIRE_CYTHON rebuild
- [x] ordering similarity re-measured before and after, numbers above
- [ ] CodSpeed should be flat; reordering must not shift the hot paths