### PR TITLE
chore: refresh the stale package author and maintainer metadata

### DIFF
--- a/src/zeroconf/__init__.py
+++ b/src/zeroconf/__init__.py
@@ -69,8 +69,8 @@ from ._utils.time import (  # noqa # import needed for backwards compat
     millis_to_seconds,
 )
 
-__author__ = "Paul Scott-Murphy, William McBrine"
-__maintainer__ = "Jakub Stasiak <jakub@stasiak.at>"
+__author__ = "The python-zeroconf authors"  # full history in COPYING and git
+__maintainer__ = "J. Nick Koston <nick@koston.org>"
 __version__ = "0.151.2"
 __license__ = "LGPL"
 


### PR DESCRIPTION
## Summary
Both metadata lines were stale: `__maintainer__` still named the previous maintainer, and `__author__` named the original 2003 and 2014 authors whose work is no longer in the tree. `__author__` now points at COPYING and git history, where the full record lives (#1864), and `__maintainer__` is current. Split out of #1867 so the mechanical reorder and this judgment call get reviewed separately.

## Test plan
- [x] metadata only; no behavior change