### PR TITLE
chore: replace the remaining 2009 era path fixture values

### DIFF
--- a/tests/services/test_browser.py
+++ b/tests/services/test_browser.py
@@ -601,7 +601,7 @@ async def test_asking_default_is_asking_qm_questions_after_the_first_qu(quick_ti
             80,
             0,
             0,
-            {"path": "/~paulsm/"},
+            {"path": "/healthz/"},
             "spare-rig.local.",
             addresses=[socket.inet_aton("10.7.4.2")],
         )
@@ -702,7 +702,7 @@ async def test_ttl_refresh_cancelled_rescue_query(quick_timing: None) -> None:
             80,
             0,
             0,
-            {"path": "/~paulsm/"},
+            {"path": "/healthz/"},
             "spare-rig.local.",
             addresses=[socket.inet_aton("10.7.4.2")],
         )
@@ -874,7 +874,7 @@ def test_legacy_record_update_listener(quick_timing: None) -> None:
         80,
         0,
         0,
-        {"path": "/~paulsm/"},
+        {"path": "/healthz/"},
         "spare-rig.local.",
         addresses=[socket.inet_aton("10.7.4.2")],
     )
@@ -914,7 +914,7 @@ def test_service_browser_is_aware_of_port_changes():
 
     browser = ServiceBrowser(zc, type_, [on_service_state_change])
 
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     address_parsed = "10.7.4.2"
     address = socket.inet_aton(address_parsed)
     info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, "spare-rig.local.", addresses=[address])
@@ -985,7 +985,7 @@ def test_service_browser_listeners_update_service():
 
     browser = r.ServiceBrowser(zc, type_, None, listener)
 
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     address_parsed = "10.7.4.2"
     address = socket.inet_aton(address_parsed)
     info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, "spare-rig.local.", addresses=[address])
@@ -1046,7 +1046,7 @@ def test_service_browser_listeners_no_update_service():
 
     browser = r.ServiceBrowser(zc, type_, None, listener)
 
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     address_parsed = "10.7.4.2"
     address = socket.inet_aton(address_parsed)
     info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, "spare-rig.local.", addresses=[address])
@@ -1105,7 +1105,7 @@ def test_service_browser_nsec_record_does_not_trigger_update():
     listener = MyServiceListener()
     browser = r.ServiceBrowser(zc, type_, None, listener)
     try:
-        desc = {"path": "/~paulsm/"}
+        desc = {"path": "/healthz/"}
         address = socket.inet_aton("10.7.4.2")
         info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, "spare-rig.local.", addresses=[address])
 
@@ -1437,7 +1437,7 @@ def test_service_browser_matching():
 
     browser = r.ServiceBrowser(zc, type_, None, listener)
 
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     address_parsed = "10.7.4.2"
     address = socket.inet_aton(address_parsed)
     info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, "spare-rig.local.", addresses=[address])
@@ -1525,7 +1525,7 @@ def test_service_browser_expire_callbacks():
 
     browser = r.ServiceBrowser(zc, type_, None, listener)
 
-    desc = {"path": "/~paul2/"}
+    desc = {"path": "/status1/"}
     address_parsed = "10.7.4.3"
     address = socket.inet_aton(address_parsed)
     info = ServiceInfo(
@@ -1678,7 +1678,7 @@ async def test_close_zeroconf_without_browser_before_start_up_queries(quick_timi
             80,
             0,
             0,
-            {"path": "/~paulsm/"},
+            {"path": "/healthz/"},
             "spare-rig.local.",
             addresses=[socket.inet_aton("10.7.4.2")],
         )
@@ -1745,7 +1745,7 @@ async def test_close_zeroconf_without_browser_after_start_up_queries(quick_timin
             80,
             0,
             0,
-            {"path": "/~paulsm/"},
+            {"path": "/healthz/"},
             "spare-rig.local.",
             addresses=[socket.inet_aton("10.7.4.2")],
         )

--- a/tests/services/test_info.py
+++ b/tests/services/test_info.py
@@ -45,7 +45,7 @@ def teardown_module():
 class TestServiceInfo(unittest.TestCase):
     def test_get_name(self):
         """Verify the name accessor can strip the type."""
-        desc = {"path": "/~paulsm/"}
+        desc = {"path": "/healthz/"}
         service_name = "name._type._tcp.local."
         service_type = "_type._tcp.local."
         service_server = "ash-1.local."
@@ -66,7 +66,7 @@ class TestServiceInfo(unittest.TestCase):
         """Verify records with the wrong name are rejected."""
 
         zc = r.Zeroconf(interfaces=["127.0.0.1"])
-        desc = {"path": "/~paulsm/"}
+        desc = {"path": "/healthz/"}
         service_name = "name._type._tcp.local."
         service_type = "_type._tcp.local."
         service_server = "ash-1.local."
@@ -204,7 +204,7 @@ class TestServiceInfo(unittest.TestCase):
     def test_service_info_rejects_expired_records(self):
         """Verify records that are expired are rejected."""
         zc = r.Zeroconf(interfaces=["127.0.0.1"])
-        desc = {"path": "/~paulsm/"}
+        desc = {"path": "/healthz/"}
         service_name = "name._type._tcp.local."
         service_type = "_type._tcp.local."
         service_server = "ash-1.local."
@@ -597,7 +597,7 @@ class TestServiceInfo(unittest.TestCase):
         """Verify the first property is always used when there are duplicates in a txt record."""
 
         zc = r.Zeroconf(interfaces=["127.0.0.1"])
-        desc = {"path": "/~paulsm/"}
+        desc = {"path": "/healthz/"}
         service_name = "name._type._tcp.local."
         service_type = "_type._tcp.local."
         service_server = "ash-1.local."
@@ -648,7 +648,7 @@ class TestServiceInfo(unittest.TestCase):
             22,
             0,
             0,
-            {"path": "/~paulsm/"},
+            {"path": "/healthz/"},
             service_server,
             addresses=[socket.inet_aton("10.7.4.2")],
         )
@@ -697,7 +697,7 @@ class TestServiceInfo(unittest.TestCase):
 def test_multiple_addresses():
     type_ = "_http._tcp.local."
     registration_name = f"xxxyyy.{type_}"
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     address_parsed = "10.7.4.2"
     address = socket.inet_aton(address_parsed)
 
@@ -1077,7 +1077,7 @@ async def test_multiple_a_addresses_newest_address_first():
     """Test that info.addresses returns the newest seen address first."""
     type_ = "_http._tcp.local."
     registration_name = f"multiarec.{type_}"
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     aiozc = AsyncZeroconf(interfaces=["127.0.0.1"])
     cache = aiozc.zeroconf.cache
     host = "multahost.local."
@@ -1096,7 +1096,7 @@ async def test_multiple_a_addresses_newest_address_first():
 async def test_invalid_a_addresses(caplog):
     type_ = "_http._tcp.local."
     registration_name = f"multiarec.{type_}"
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     aiozc = AsyncZeroconf(interfaces=["127.0.0.1"])
     cache = aiozc.zeroconf.cache
     host = "multahost.local."
@@ -1117,7 +1117,7 @@ async def test_invalid_a_addresses(caplog):
 @unittest.skipIf(os.environ.get("SKIP_IPV6"), "IPv6 tests disabled")
 def test_filter_address_by_type_from_service_info():
     """Verify dns_addresses can filter by ipversion."""
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     type_ = "_homeassistant._tcp.local."
     name = "MyTestHome"
     registration_name = f"{name}.{type_}"
@@ -1147,7 +1147,7 @@ def test_changing_name_updates_serviceinfo_key():
         80,
         0,
         0,
-        {"path": "/~paulsm/"},
+        {"path": "/healthz/"},
         "spare-rig.local.",
         addresses=[socket.inet_aton("10.7.4.2")],
     )
@@ -1169,7 +1169,7 @@ def test_serviceinfo_address_updates():
             80,
             0,
             0,
-            {"path": "/~paulsm/"},
+            {"path": "/healthz/"},
             "spare-rig.local.",
             addresses=[socket.inet_aton("10.7.4.2")],
             parsed_addresses=["10.7.4.2"],
@@ -1181,7 +1181,7 @@ def test_serviceinfo_address_updates():
         80,
         0,
         0,
-        {"path": "/~paulsm/"},
+        {"path": "/healthz/"},
         "spare-rig.local.",
         addresses=[socket.inet_aton("10.7.4.2")],
     )
@@ -1201,44 +1201,44 @@ def test_serviceinfo_accepts_bytes_or_string_dict():
         80,
         0,
         0,
-        {b"path": b"/~paulsm/"},
+        {b"path": b"/healthz/"},
         server_name,
         addresses=addresses,
     )
-    assert info_service.dns_text().text == b"\x0epath=/~paulsm/"
+    assert info_service.dns_text().text == b"\x0epath=/healthz/"
     info_service = ServiceInfo(
         type_,
         f"{name}.{type_}",
         80,
         0,
         0,
-        {"path": "/~paulsm/"},
+        {"path": "/healthz/"},
         server_name,
         addresses=addresses,
     )
-    assert info_service.dns_text().text == b"\x0epath=/~paulsm/"
+    assert info_service.dns_text().text == b"\x0epath=/healthz/"
     info_service = ServiceInfo(
         type_,
         f"{name}.{type_}",
         80,
         0,
         0,
-        {b"path": "/~paulsm/"},
+        {b"path": "/healthz/"},
         server_name,
         addresses=addresses,
     )
-    assert info_service.dns_text().text == b"\x0epath=/~paulsm/"
+    assert info_service.dns_text().text == b"\x0epath=/healthz/"
     info_service = ServiceInfo(
         type_,
         f"{name}.{type_}",
         80,
         0,
         0,
-        {"path": b"/~paulsm/"},
+        {"path": b"/healthz/"},
         server_name,
         addresses=addresses,
     )
-    assert info_service.dns_text().text == b"\x0epath=/~paulsm/"
+    assert info_service.dns_text().text == b"\x0epath=/healthz/"
 
 
 def test_asking_qu_questions(quick_request_timing):
@@ -1330,7 +1330,7 @@ async def test_release_wait_when_new_recorded_added():
     """Test that async_request returns as soon as new matching records are added to the cache."""
     type_ = "_http._tcp.local."
     registration_name = f"multiarec.{type_}"
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     aiozc = AsyncZeroconf(interfaces=["127.0.0.1"])
     host = "multahost.local."
 
@@ -1395,7 +1395,7 @@ async def test_port_changes_are_seen():
     """Test that port changes are seen by async_request."""
     type_ = "_http._tcp.local."
     registration_name = f"multiarec.{type_}"
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     aiozc = AsyncZeroconf(interfaces=["127.0.0.1"])
     host = "multahost.local."
 
@@ -1478,7 +1478,7 @@ async def test_port_changes_are_seen_with_directed_request():
     """Test that port changes are seen by async_request with a directed request."""
     type_ = "_http._tcp.local."
     registration_name = f"multiarec.{type_}"
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     aiozc = AsyncZeroconf(interfaces=["127.0.0.1"])
     host = "multahost.local."
 
@@ -1964,7 +1964,7 @@ async def test_release_wait_when_new_recorded_added_concurrency():
     """Test that concurrent async_request returns as soon as new matching records are added to the cache."""
     type_ = "_http._tcp.local."
     registration_name = f"multiareccon.{type_}"
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     aiozc = AsyncZeroconf(interfaces=["127.0.0.1"])
     host = "multahostcon.local."
     await aiozc.zeroconf.async_wait_for_start()
@@ -2035,7 +2035,7 @@ async def test_service_info_address_nsec_records() -> None:
     """Test we can generate address nsec records from ServiceInfo."""
     type_ = "_http._tcp.local."
     registration_name = f"multiareccon.{type_}"
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     host = "multahostcon.local."
     info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, host, addresses=[b"\x7f\x00\x00\x01"])
     nsec_record = info.dns_address_nsec(50)
@@ -2063,7 +2063,7 @@ def test_service_info_dns_nsec_deprecated() -> None:
     registration_name = f"depnsec.{type_}"
     host = "depnsec-host.local."
     info = ServiceInfo(
-        type_, registration_name, 80, 0, 0, {"path": "/~paulsm/"}, host, addresses=[b"\x7f\x00\x00\x01"]
+        type_, registration_name, 80, 0, 0, {"path": "/healthz/"}, host, addresses=[b"\x7f\x00\x00\x01"]
     )
     with pytest.warns(DeprecationWarning, match="dns_address_nsec"):
         record = info.dns_nsec([const._TYPE_AAAA], 50)
@@ -2261,7 +2261,7 @@ def test_load_from_cache_complete_with_locally_set_properties():
         ]
     )
 
-    info = ServiceInfo(type_, registration_name, 80, 0, 0, {"path": "/~paulsm/"}, host)
+    info = ServiceInfo(type_, registration_name, 80, 0, 0, {"path": "/healthz/"}, host)
     assert info.load_from_cache(zc) is True
     zc.close()
 
@@ -2583,7 +2583,7 @@ async def test_own_nsec_response_does_not_complete_service(aiozc_loopback: Async
         80,
         0,
         0,
-        {"path": "/~paulsm/"},
+        {"path": "/healthz/"},
         host,
         addresses=[socket.inet_aton("10.7.4.2")],
     )

--- a/tests/services/test_registry.py
+++ b/tests/services/test_registry.py
@@ -15,7 +15,7 @@ class TestServiceRegistry(unittest.TestCase):
         name = "xxxyyy"
         registration_name = f"{name}.{type_}"
 
-        desc = {"path": "/~paulsm/"}
+        desc = {"path": "/healthz/"}
         info = ServiceInfo(
             type_,
             registration_name,
@@ -40,7 +40,7 @@ class TestServiceRegistry(unittest.TestCase):
         registration_name = f"{name}.{type_}"
         registration_name2 = f"{name2}.{type_}"
 
-        desc = {"path": "/~paulsm/"}
+        desc = {"path": "/healthz/"}
         info = ServiceInfo(
             type_,
             registration_name,
@@ -82,7 +82,7 @@ class TestServiceRegistry(unittest.TestCase):
         name = "xxxyyy"
         registration_name = f"{name}.{type_}"
 
-        desc = {"path": "/~paulsm/"}
+        desc = {"path": "/healthz/"}
         info = ServiceInfo(
             type_,
             registration_name,
@@ -105,7 +105,7 @@ class TestServiceRegistry(unittest.TestCase):
         name = "xxxyyy"
         registration_name = f"{name}.{type_}"
 
-        desc = {"path": "/~paulsm/"}
+        desc = {"path": "/healthz/"}
         info = ServiceInfo(
             type_,
             registration_name,
@@ -131,7 +131,7 @@ class TestServiceRegistry(unittest.TestCase):
         name = "Xxxyyy"
         registration_name = f"{name}.{type_}"
 
-        desc = {"path": "/~paulsm/"}
+        desc = {"path": "/healthz/"}
         info = ServiceInfo(
             type_,
             registration_name,
@@ -155,7 +155,7 @@ class TestServiceRegistry(unittest.TestCase):
     def test_empty_buckets_are_removed_when_last_entry_is_removed(self):
         type_ = "_test-srvc-type._tcp.local."
         registration_name = f"xxxyyy.{type_}"
-        desc = {"path": "/~paulsm/"}
+        desc = {"path": "/healthz/"}
         info = ServiceInfo(
             type_,
             registration_name,
@@ -178,7 +178,7 @@ class TestServiceRegistry(unittest.TestCase):
     def test_bulk_remove_preserves_order_of_survivors(self):
         type_ = "_test-srvc-type._tcp.local."
         server = "shared.local."
-        desc = {"path": "/~paulsm/"}
+        desc = {"path": "/healthz/"}
         infos = [
             ServiceInfo(
                 type_,
@@ -209,7 +209,7 @@ class TestServiceRegistry(unittest.TestCase):
         """Re-adding after the bucket was deleted must rebuild it cleanly."""
         type_ = "_test-srvc-type._tcp.local."
         server = "spare-rig.local."
-        desc = {"path": "/~paulsm/"}
+        desc = {"path": "/healthz/"}
         info = ServiceInfo(
             type_,
             f"only.{type_}",
@@ -239,7 +239,7 @@ class TestServiceRegistry(unittest.TestCase):
             80,
             0,
             0,
-            {"path": "/~paulsm/"},
+            {"path": "/healthz/"},
             server,
             addresses=[socket.inet_aton("10.7.4.2")],
         )
@@ -249,7 +249,7 @@ class TestServiceRegistry(unittest.TestCase):
             81,
             0,
             0,
-            {"path": "/~paulsm/"},
+            {"path": "/healthz/"},
             server,
             addresses=[socket.inet_aton("10.7.4.3")],
         )

--- a/tests/services/test_types.py
+++ b/tests/services/test_types.py
@@ -34,7 +34,7 @@ def test_integration_with_listener(quick_timing, disable_duplicate_packet_suppre
     registration_name = f"{name}.{type_}"
 
     zeroconf_registrar = Zeroconf(interfaces=["127.0.0.1"])
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     info = ServiceInfo(
         type_,
         registration_name,
@@ -66,7 +66,7 @@ def test_integration_with_listener_v6_records(quick_timing, disable_duplicate_pa
     addr = "2606:2800:220:1:248:1893:25c8:1946"  # example.com
 
     zeroconf_registrar = Zeroconf(interfaces=["127.0.0.1"])
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     info = ServiceInfo(
         type_,
         registration_name,
@@ -102,7 +102,7 @@ def test_integration_with_listener_ipv6(quick_timing, disable_duplicate_packet_s
     addr = "2606:2800:220:1:248:1893:25c8:1946"  # example.com
 
     zeroconf_registrar = Zeroconf(ip_version=r.IPVersion.V6Only)
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     info = ServiceInfo(
         type_,
         registration_name,
@@ -136,7 +136,7 @@ def test_integration_with_subtype_and_listener(quick_timing, disable_duplicate_p
     registration_name = f"{name}.{type_}"
 
     zeroconf_registrar = Zeroconf(interfaces=["127.0.0.1"])
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     info = ServiceInfo(
         discovery_type,
         registration_name,

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -150,7 +150,7 @@ async def test_async_service_registration(quick_timing: None) -> None:
 
     aiozc.zeroconf.add_service_listener(type_, listener)
 
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     info = ServiceInfo(
         type_,
         registration_name,
@@ -221,7 +221,7 @@ async def test_async_service_registration_with_server_missing(quick_timing: None
 
     aiozc.zeroconf.add_service_listener(type_, listener)
 
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     info = ServiceInfo(
         type_,
         registration_name,
@@ -287,7 +287,7 @@ async def test_async_service_registration_same_server_different_ports(quick_timi
 
     aiozc.zeroconf.add_service_listener(type_, listener)
 
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     info = ServiceInfo(
         type_,
         registration_name,
@@ -354,7 +354,7 @@ async def test_async_service_registration_same_server_same_ports(quick_timing: N
 
     aiozc.zeroconf.add_service_listener(type_, listener)
 
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     info = ServiceInfo(
         type_,
         registration_name,
@@ -402,7 +402,7 @@ async def test_async_service_registration_name_conflict(quick_timing: None) -> N
     name = "xxxyyy"
     registration_name = f"{name}.{type_}"
 
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     info = ServiceInfo(
         type_,
         registration_name,
@@ -450,7 +450,7 @@ async def test_async_service_registration_name_does_not_match_type() -> None:
     name = "xxxyyy"
     registration_name = f"{name}.{type_}"
 
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     info = ServiceInfo(
         type_,
         registration_name,
@@ -477,7 +477,7 @@ async def test_async_service_registration_name_strict_check(quick_timing: None) 
     name = "CustomerInformationService-F4D4895E9EEB"
     registration_name = f"{name}.{type_}"
 
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     info = ServiceInfo(
         type_,
         registration_name,
@@ -528,7 +528,7 @@ async def test_async_tasks(quick_timing: None) -> None:
     listener = MyListener()
     aiozc.zeroconf.add_service_listener(type_, listener)
 
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     info = ServiceInfo(
         type_,
         registration_name,
@@ -579,7 +579,7 @@ async def test_async_wait_unblocks_on_update(quick_timing: None) -> None:
     name = "xxxyyy"
     registration_name = f"{name}.{type_}"
 
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     info = ServiceInfo(
         type_,
         registration_name,
@@ -625,7 +625,7 @@ async def test_service_info_async_request(quick_timing: None, quick_request_timi
     await asyncio.sleep(_LISTENER_TIME / 1000 / 2)
     get_service_info_task2 = asyncio.ensure_future(aiozc.async_get_service_info(type_, registration_name))
 
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     info = ServiceInfo(
         type_,
         registration_name,
@@ -753,7 +753,7 @@ async def test_async_service_browser(quick_timing: None) -> None:
     listener = MyListener()
     await aiozc.async_add_service_listener(type_, listener)
 
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     info = ServiceInfo(
         type_,
         registration_name,
@@ -804,7 +804,7 @@ async def test_async_context_manager(quick_timing: None) -> None:
             80,
             0,
             0,
-            {"path": "/~paulsm/"},
+            {"path": "/healthz/"},
             "spare-rig.local.",
             addresses=[socket.inet_aton("10.7.4.2")],
         )
@@ -850,7 +850,7 @@ async def test_async_unregister_all_services(quick_timing: None) -> None:
     registration_name = f"{name}.{type_}"
     registration_name2 = f"{name2}.{type_}"
 
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     info = ServiceInfo(
         type_,
         registration_name,
@@ -906,7 +906,7 @@ async def test_async_zeroconf_service_types(quick_timing: None) -> None:
     registration_name = f"{name}.{type_}"
 
     zeroconf_registrar = AsyncZeroconf(interfaces=["127.0.0.1"])
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     info = ServiceInfo(
         type_,
         registration_name,
@@ -976,7 +976,7 @@ async def test_service_browser_instantiation_generates_add_events_from_cache():
 
     listener = MyServiceListener()
 
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     address_parsed = "10.7.4.2"
     address = socket.inet_aton(address_parsed)
     info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, "spare-rig.local.", addresses=[address])
@@ -1061,7 +1061,7 @@ async def test_integration(quick_timing: None) -> None:
             80,
             0,
             0,
-            {"path": "/~paulsm/"},
+            {"path": "/healthz/"},
             "spare-rig.local.",
             addresses=[socket.inet_aton("10.7.4.2")],
         )
@@ -1169,7 +1169,7 @@ async def test_info_asking_default_is_asking_qm_questions_after_the_first_qu(qui
     name = "xxxyyy"
     registration_name = f"{name}.{type_}"
 
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     info = ServiceInfo(
         type_,
         registration_name,
@@ -1242,7 +1242,7 @@ async def test_service_browser_ignores_unrelated_updates():
 
     listener = MyServiceListener()
 
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     address_parsed = "10.7.4.2"
     address = socket.inet_aton(address_parsed)
     info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, "spare-rig.local.", addresses=[address])
@@ -1346,7 +1346,7 @@ async def test_legacy_unicast_response(run_isolated):
     name = "xxxyyy"
     registration_name = f"{name}.{type_}"
 
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     info = ServiceInfo(
         type_,
         registration_name,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -287,7 +287,7 @@ def test_async_updates_from_response():
     service_name = "name._type._tcp.local."
     service_type = "_type._tcp.local."
     service_server = "spare-rig.local."
-    service_text = b"path=/~paulsm/"
+    service_text = b"path=/healthz/"
     service_address = "10.7.4.2"
 
     zeroconf = r.Zeroconf(interfaces=["127.0.0.1"])
@@ -297,7 +297,7 @@ def test_async_updates_from_response():
         _inject_response(zeroconf, mock_incoming_msg(r.ServiceStateChange.Added))
         dns_text = zeroconf.cache.get_by_details(service_name, const._TYPE_TXT, const._CLASS_IN)
         assert dns_text is not None
-        assert cast(r.DNSText, dns_text).text == service_text  # service_text is b'path=/~paulsm/'
+        assert cast(r.DNSText, dns_text).text == service_text  # service_text is b'path=/healthz/'
         all_dns_text = zeroconf.cache.get_all_by_details(service_name, const._TYPE_TXT, const._CLASS_IN)
         assert [dns_text] == all_dns_text
 
@@ -340,7 +340,7 @@ def test_generate_service_query_set_qu_bit():
     """Test generate_service_query sets the QU bit."""
 
     zeroconf_registrar = Zeroconf(interfaces=["127.0.0.1"])
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     type_ = "._hap._tcp.local."
     registration_name = "this-host-is-not-used._hap._tcp.local."
     info = r.ServiceInfo(
@@ -383,7 +383,7 @@ def test_invalid_packets_ignored_and_does_not_cause_loop_exception():
         const._TYPE_TXT,
         const._CLASS_IN | const._CLASS_UNIQUE,
         500,
-        b"path=/~paulsm/",
+        b"path=/healthz/",
     )
     assert isinstance(entry, r.DNSText)
     assert isinstance(entry, r.DNSRecord)
@@ -403,7 +403,7 @@ def test_goodbye_all_services():
     assert out is None
     type_ = "_http._tcp.local."
     registration_name = f"xxxyyy.{type_}"
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     info = r.ServiceInfo(
         type_,
         registration_name,
@@ -447,7 +447,7 @@ def test_register_service_with_custom_ttl(quick_timing: None) -> None:
         80,
         0,
         0,
-        {"path": "/~paulsm/"},
+        {"path": "/healthz/"},
         "ash-90.local.",
         addresses=[socket.inet_aton("10.7.4.2")],
     )
@@ -474,7 +474,7 @@ def test_logging_packets(caplog: pytest.LogCaptureFixture, quick_timing: None) -
         80,
         0,
         0,
-        {"path": "/~paulsm/"},
+        {"path": "/healthz/"},
         "ash-90.local.",
         addresses=[socket.inet_aton("10.7.4.2")],
     )
@@ -515,7 +515,7 @@ def test_sending_unicast():
         const._TYPE_TXT,
         const._CLASS_IN | const._CLASS_UNIQUE,
         500,
-        b"path=/~paulsm/",
+        b"path=/healthz/",
     )
     generated.add_answer_at_time(entry, 0)
     zc.send(generated, "2001:db8::1", const._MDNS_PORT)  # https://www.iana.org/go/rfc3849
@@ -549,7 +549,7 @@ def test_tc_bit_defers():
     registration2_name = f"{name2}.{type_}"
     registration3_name = f"{name3}.{type_}"
 
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     server_name = "spare-rig.local."
     server_name2 = "ash-3.local."
     server_name3 = "ash-4.local."
@@ -649,7 +649,7 @@ def test_tc_bit_defers_last_response_missing():
     registration2_name = f"{name2}.{type_}"
     registration3_name = f"{name3}.{type_}"
 
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     server_name = "spare-rig.local."
     server_name2 = "ash-3.local."
     server_name3 = "ash-4.local."
@@ -767,7 +767,7 @@ def test_tc_bit_defer_window_is_bounded():
         80,
         0,
         0,
-        {"path": "/~paulsm/"},
+        {"path": "/healthz/"},
         "spare-rig.local.",
         addresses=[socket.inet_aton("10.7.4.2")],
     )
@@ -955,7 +955,7 @@ def test_shutdown_while_register_in_process(quick_timing: None) -> None:
         80,
         0,
         0,
-        {"path": "/~paulsm/"},
+        {"path": "/healthz/"},
         "ash-90.local.",
         addresses=[socket.inet_aton("10.7.4.2")],
     )

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -50,7 +50,7 @@ class TestRegistrar(unittest.TestCase):
         name = "xxxyyy"
         registration_name = f"{name}.{type_}"
 
-        desc = {"path": "/~paulsm/"}
+        desc = {"path": "/healthz/"}
         info = ServiceInfo(
             type_,
             registration_name,
@@ -238,7 +238,7 @@ def test_ptr_optimization(quick_timing: None) -> None:
     name = "xxxyyy"
     registration_name = f"{name}.{type_}"
 
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     info = ServiceInfo(
         type_,
         registration_name,
@@ -310,7 +310,7 @@ def test_any_query_for_ptr():
     type_ = "_anyptr._tcp.local."
     name = "knownname"
     registration_name = f"{name}.{type_}"
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     server_name = "spare-rig.local."
     ipv6_address = socket.inet_pton(socket.AF_INET6, "2001:db8::1")
     info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, server_name, addresses=[ipv6_address])
@@ -339,7 +339,7 @@ def test_aaaa_query():
     type_ = "_knownaaaservice._tcp.local."
     name = "knownname"
     registration_name = f"{name}.{type_}"
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     server_name = "spare-rig.local."
     ipv6_address = socket.inet_pton(socket.AF_INET6, "2001:db8::1")
     info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, server_name, addresses=[ipv6_address])
@@ -366,7 +366,7 @@ def test_aaaa_query_upper_case():
     type_ = "_knownaaaservice._tcp.local."
     name = "knownname"
     registration_name = f"{name}.{type_}"
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     server_name = "spare-rig.local."
     ipv6_address = socket.inet_pton(socket.AF_INET6, "2001:db8::1")
     info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, server_name, addresses=[ipv6_address])
@@ -393,7 +393,7 @@ def test_a_and_aaaa_record_fate_sharing():
     type_ = "_a-and-aaaa-service._tcp.local."
     name = "knownname"
     registration_name = f"{name}.{type_}"
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     server_name = "spare-rig.local."
     ipv6_address = socket.inet_pton(socket.AF_INET6, "2001:db8::1")
     ipv4_address = socket.inet_aton("10.7.4.2")
@@ -452,7 +452,7 @@ def test_unicast_response():
     type_ = "_test-srvc-type._tcp.local."
     name = "xxxyyy"
     registration_name = f"{name}.{type_}"
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     info = ServiceInfo(
         type_,
         registration_name,
@@ -511,7 +511,7 @@ async def test_probe_answered_immediately():
     type_ = "_test-srvc-type._tcp.local."
     name = "xxxyyy"
     registration_name = f"{name}.{type_}"
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     info = ServiceInfo(
         type_,
         registration_name,
@@ -562,7 +562,7 @@ async def test_probe_answered_immediately_with_uppercase_name():
     type_ = "_test-srvc-type._tcp.local."
     name = "xxxyyy"
     registration_name = f"{name}.{type_}"
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     info = ServiceInfo(
         type_,
         registration_name,
@@ -614,7 +614,7 @@ def test_qu_response(quick_timing: None) -> None:
     name = "xxxyyy"
     registration_name = f"{name}.{type_}"
     registration_name2 = f"{name}.{other_type_}"
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     info = ServiceInfo(
         type_,
         registration_name,
@@ -736,7 +736,7 @@ def test_known_answer_supression():
     type_ = "_knownanswersv8._tcp.local."
     name = "knownname"
     registration_name = f"{name}.{type_}"
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     server_name = "spare-rig.local."
     info = ServiceInfo(
         type_,
@@ -880,7 +880,7 @@ def test_no_nsec_answer_for_service_without_addresses() -> None:
     type_ = "_noaddrnsec._tcp.local."
     registration_name = f"noaddr.{type_}"
     server_name = "noaddr-host.local."
-    info = ServiceInfo(type_, registration_name, 80, 0, 0, {"path": "/~paulsm/"}, server_name)
+    info = ServiceInfo(type_, registration_name, 80, 0, 0, {"path": "/healthz/"}, server_name)
     zc.registry.async_add(info)
     _clear_cache(zc)
 
@@ -910,7 +910,7 @@ def test_multi_packet_known_answer_supression():
     registration2_name = f"{name2}.{type_}"
     registration3_name = f"{name3}.{type_}"
 
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     server_name = "spare-rig.local."
     server_name2 = "ash-3.local."
     server_name3 = "ash-4.local."
@@ -980,7 +980,7 @@ def test_known_answer_supression_service_type_enumeration_query():
     type_ = "_otherknown._tcp.local."
     name = "knownname"
     registration_name = f"{name}.{type_}"
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     server_name = "spare-rig.local."
     info = ServiceInfo(
         type_,
@@ -997,7 +997,7 @@ def test_known_answer_supression_service_type_enumeration_query():
     type_2 = "_otherknown2._tcp.local."
     name = "knownname"
     registration_name2 = f"{name}.{type_2}"
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     server_name2 = "ash-3.local."
     info2 = ServiceInfo(
         type_2,
@@ -1067,7 +1067,7 @@ def test_upper_case_enumeration_query():
     type_ = "_otherknown._tcp.local."
     name = "knownname"
     registration_name = f"{name}.{type_}"
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     server_name = "spare-rig.local."
     info = ServiceInfo(
         type_,
@@ -1084,7 +1084,7 @@ def test_upper_case_enumeration_query():
     type_2 = "_otherknown2._tcp.local."
     name = "knownname"
     registration_name2 = f"{name}.{type_2}"
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     server_name2 = "ash-3.local."
     info2 = ServiceInfo(
         type_2,
@@ -1141,7 +1141,7 @@ async def test_qu_response_only_sends_additionals_if_sends_answer():
     type_ = "_addtest1._tcp.local."
     name = "knownname"
     registration_name = f"{name}.{type_}"
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     server_name = "spare-rig.local."
     info = ServiceInfo(
         type_,
@@ -1158,7 +1158,7 @@ async def test_qu_response_only_sends_additionals_if_sends_answer():
     type_2 = "_addtest2._tcp.local."
     name = "knownname"
     registration_name2 = f"{name}.{type_2}"
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     server_name2 = "ash-3.local."
     info2 = ServiceInfo(
         type_2,
@@ -1307,7 +1307,7 @@ async def test_cache_flush_bit():
     type_ = "_cacheflush._tcp.local."
     name = "knownname"
     registration_name = f"{name}.{type_}"
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     server_name = "server-uu1.local."
     info = ServiceInfo(
         type_,
@@ -1422,7 +1422,7 @@ async def test_record_update_manager_add_listener_callsback_existing_records():
     type_ = "_cacheflush._tcp.local."
     name = "knownname"
     registration_name = f"{name}.{type_}"
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     server_name = "server-uu1.local."
     info = ServiceInfo(
         type_,
@@ -1654,7 +1654,7 @@ async def test_response_aggregation_timings(run_isolated: None) -> None:
     registration_name2 = f"{name}.{type_2}"
     registration_name3 = f"{name}.{type_3}"
 
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     info = ServiceInfo(
         type_,
         registration_name,
@@ -1791,7 +1791,7 @@ async def test_response_aggregation_timings_multiple(
     name = "xxxyyy"
     registration_name2 = f"{name}.{type_2}"
 
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     info2 = ServiceInfo(
         type_2,
         registration_name2,
@@ -1886,7 +1886,7 @@ async def test_response_aggregation_random_delay():
     registration_name4 = f"{name}.{type_4}"
     registration_name5 = f"{name}.{type_5}"
 
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     info = ServiceInfo(
         type_,
         registration_name,
@@ -1984,7 +1984,7 @@ async def test_future_answers_are_removed_on_send():
     registration_name = f"{name}.{type_}"
     registration_name2 = f"{name}.{type_2}"
 
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     info = ServiceInfo(
         type_,
         registration_name,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -110,7 +110,7 @@ def test_large_packet_exception_log_handling():
 
 
 def verify_name_change(zc, type_, name, number_hosts):
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     info_service = ServiceInfo(
         type_,
         f"{name}.{type_}",

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -52,7 +52,7 @@ def test_guard_against_oversized_packets():
                 const._TYPE_TXT,
                 const._CLASS_IN | const._CLASS_UNIQUE,
                 500,
-                b"path=/~paulsm/",
+                b"path=/healthz/",
             ),
             0,
         )
@@ -76,7 +76,7 @@ def test_guard_against_oversized_packets():
         const._TYPE_TXT,
         const._CLASS_IN | const._CLASS_UNIQUE,
         500,
-        b"path=/~paulsm/",
+        b"path=/healthz/",
     )
 
     generated.add_answer_at_time(
@@ -101,7 +101,7 @@ def test_guard_against_oversized_packets():
                 const._TYPE_TXT,
                 const._CLASS_IN | const._CLASS_UNIQUE,
                 500,
-                b"path=/~paulsm/",
+                b"path=/healthz/",
             )
         )
         is None
@@ -117,7 +117,7 @@ def test_guard_against_oversized_packets():
                 const._TYPE_TXT,
                 const._CLASS_IN | const._CLASS_UNIQUE,
                 500,
-                b"path=/~paulsm/",
+                b"path=/healthz/",
             )
         )
         is None

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -92,7 +92,7 @@ class ListenerTest(unittest.TestCase):
         }
 
         zeroconf_registrar = Zeroconf(interfaces=["127.0.0.1"])
-        desc: dict[str, Any] = {"path": "/~paulsm/"}
+        desc: dict[str, Any] = {"path": "/healthz/"}
         desc.update(properties)
         addresses = [socket.inet_aton("10.7.4.2")]
         if has_working_ipv6() and not os.environ.get("SKIP_IPV6"):

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -69,7 +69,7 @@ def test_legacy_record_update_listener(quick_timing: None) -> None:
         80,
         0,
         0,
-        {"path": "/~paulsm/"},
+        {"path": "/healthz/"},
         "spare-rig.local.",
         addresses=[socket.inet_aton("10.7.4.2")],
     )

--- a/tests/utils/test_name.py
+++ b/tests/utils/test_name.py
@@ -36,7 +36,7 @@ def test_service_type_name_overlong_full_name():
 )
 def test_service_type_name_non_strict_compliant_names(instance_name, service_type):
     """Test service_type_name for valid names, but not strict-compliant."""
-    desc = {"path": "/~paulsm/"}
+    desc = {"path": "/healthz/"}
     service_name = f"{instance_name}.{service_type}"
     service_server = "ash-1.local."
     service_address = socket.inet_aton("10.7.4.2")


### PR DESCRIPTION
## Summary
One more fixture family for #1835 that the earlier sweeps missed: the TXT record test property {"path": "/~paulsm/"} used 116 times across the suite descends from the 2009 fixtures. Replaced with neutral equal length paths so the handful of tests that assert hardcoded TXT length prefix bytes keep passing.

## Test plan
- [x] full suite passes
