### PR TITLE
chore: add a zc fixture and service info helper to dry up the tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -16,7 +16,7 @@ from unittest import mock
 
 import ifaddr
 
-from zeroconf import DNSIncoming, DNSOutgoing, DNSQuestion, DNSRecord, Zeroconf, const
+from zeroconf import DNSIncoming, DNSOutgoing, DNSQuestion, DNSRecord, ServiceInfo, Zeroconf, const
 from zeroconf._history import QuestionHistory
 
 _MONOTONIC_RESOLUTION = time.get_clock_info("monotonic").resolution
@@ -57,6 +57,28 @@ IPV6_LOOPBACK_FIND_TIMEOUT = 0.5
 class QuestionHistoryWithoutSuppression(QuestionHistory):
     def suppresses(self, question: DNSQuestion, now: float, known_answers: set[DNSRecord]) -> bool:
         return False
+
+
+def make_service_info(
+    type_: str,
+    name: str,
+    *,
+    port: int = 80,
+    properties: dict | bytes | None = None,
+    server: str = "spare-rig.local.",
+    addresses: list[bytes] | None = None,
+) -> ServiceInfo:
+    """Build a ServiceInfo with the suite's canonical fixture values."""
+    return ServiceInfo(
+        type_,
+        name,
+        port,
+        0,
+        0,
+        {"path": "/healthz/"} if properties is None else properties,
+        server,
+        addresses=[socket.inet_aton("10.7.4.2")] if addresses is None else addresses,
+    )
 
 
 def mock_incoming_msg(records: Iterable[DNSRecord]) -> DNSIncoming:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,6 +95,14 @@ def blockbuster(
         yield bb
 
 
+@pytest.fixture
+def zc() -> Iterator[Zeroconf]:
+    """A running Zeroconf bound to loopback, closed after the test."""
+    instance = Zeroconf(interfaces=["127.0.0.1"])
+    yield instance
+    instance.close()
+
+
 @pytest.fixture(autouse=True)
 def verify_threads_ended():
     """Verify that the threads are not running after the test."""

--- a/tests/services/test_registry.py
+++ b/tests/services/test_registry.py
@@ -8,6 +8,8 @@ import unittest
 import zeroconf as r
 from zeroconf import ServiceInfo
 
+from .. import make_service_info
+
 
 class TestServiceRegistry(unittest.TestCase):
     def test_only_register_once(self):
@@ -16,16 +18,7 @@ class TestServiceRegistry(unittest.TestCase):
         registration_name = f"{name}.{type_}"
 
         desc = {"path": "/healthz/"}
-        info = ServiceInfo(
-            type_,
-            registration_name,
-            80,
-            0,
-            0,
-            desc,
-            "spare-rig.local.",
-            addresses=[socket.inet_aton("10.7.4.2")],
-        )
+        info = make_service_info(type_, registration_name, properties=desc)
 
         registry = r.ServiceRegistry()
         registry.async_add(info)
@@ -83,16 +76,7 @@ class TestServiceRegistry(unittest.TestCase):
         registration_name = f"{name}.{type_}"
 
         desc = {"path": "/healthz/"}
-        info = ServiceInfo(
-            type_,
-            registration_name,
-            80,
-            0,
-            0,
-            desc,
-            "spare-rig.local.",
-            addresses=[socket.inet_aton("10.7.4.2")],
-        )
+        info = make_service_info(type_, registration_name, properties=desc)
 
         registry = r.ServiceRegistry()
         registry.async_add(info)
@@ -106,16 +90,7 @@ class TestServiceRegistry(unittest.TestCase):
         registration_name = f"{name}.{type_}"
 
         desc = {"path": "/healthz/"}
-        info = ServiceInfo(
-            type_,
-            registration_name,
-            80,
-            0,
-            0,
-            desc,
-            "spare-rig.local.",
-            addresses=[socket.inet_aton("10.7.4.2")],
-        )
+        info = make_service_info(type_, registration_name, properties=desc)
 
         registry = r.ServiceRegistry()
         registry.async_add(info)
@@ -156,16 +131,7 @@ class TestServiceRegistry(unittest.TestCase):
         type_ = "_test-srvc-type._tcp.local."
         registration_name = f"xxxyyy.{type_}"
         desc = {"path": "/healthz/"}
-        info = ServiceInfo(
-            type_,
-            registration_name,
-            80,
-            0,
-            0,
-            desc,
-            "spare-rig.local.",
-            addresses=[socket.inet_aton("10.7.4.2")],
-        )
+        info = make_service_info(type_, registration_name, properties=desc)
 
         registry = r.ServiceRegistry()
         registry.async_add(info)

--- a/tests/services/test_types.py
+++ b/tests/services/test_types.py
@@ -11,7 +11,13 @@ import unittest
 import zeroconf as r
 from zeroconf import ServiceInfo, Zeroconf, ZeroconfServiceTypes
 
-from .. import IPV6_LOOPBACK_FIND_TIMEOUT, LOOPBACK_FIND_TIMEOUT, _clear_cache, has_working_ipv6
+from .. import (
+    IPV6_LOOPBACK_FIND_TIMEOUT,
+    LOOPBACK_FIND_TIMEOUT,
+    _clear_cache,
+    has_working_ipv6,
+    make_service_info,
+)
 
 log = logging.getLogger("zeroconf")
 original_logging_level = logging.NOTSET
@@ -35,16 +41,7 @@ def test_integration_with_listener(quick_timing, disable_duplicate_packet_suppre
 
     zeroconf_registrar = Zeroconf(interfaces=["127.0.0.1"])
     desc = {"path": "/healthz/"}
-    info = ServiceInfo(
-        type_,
-        registration_name,
-        80,
-        0,
-        0,
-        desc,
-        "spare-rig.local.",
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
+    info = make_service_info(type_, registration_name, properties=desc)
     zeroconf_registrar.registry.async_add(info)
     try:
         service_types = ZeroconfServiceTypes.find(interfaces=["127.0.0.1"], timeout=LOOPBACK_FIND_TIMEOUT)
@@ -137,16 +134,7 @@ def test_integration_with_subtype_and_listener(quick_timing, disable_duplicate_p
 
     zeroconf_registrar = Zeroconf(interfaces=["127.0.0.1"])
     desc = {"path": "/healthz/"}
-    info = ServiceInfo(
-        discovery_type,
-        registration_name,
-        80,
-        0,
-        0,
-        desc,
-        "spare-rig.local.",
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
+    info = make_service_info(discovery_type, registration_name, properties=desc)
     zeroconf_registrar.registry.async_add(info)
     try:
         service_types = ZeroconfServiceTypes.find(interfaces=["127.0.0.1"], timeout=LOOPBACK_FIND_TIMEOUT)

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -47,6 +47,7 @@ from . import (
     QuestionHistoryWithoutSuppression,
     _clear_cache,
     has_working_ipv6,
+    make_service_info,
     time_changed_millis,
 )
 
@@ -151,16 +152,7 @@ async def test_async_service_registration(quick_timing: None) -> None:
     aiozc.zeroconf.add_service_listener(type_, listener)
 
     desc = {"path": "/healthz/"}
-    info = ServiceInfo(
-        type_,
-        registration_name,
-        80,
-        0,
-        0,
-        desc,
-        "spare-rig.local.",
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
+    info = make_service_info(type_, registration_name, properties=desc)
     task = await aiozc.async_register_service(info)
     await task
     new_info = ServiceInfo(
@@ -288,16 +280,7 @@ async def test_async_service_registration_same_server_different_ports(quick_timi
     aiozc.zeroconf.add_service_listener(type_, listener)
 
     desc = {"path": "/healthz/"}
-    info = ServiceInfo(
-        type_,
-        registration_name,
-        80,
-        0,
-        0,
-        desc,
-        "spare-rig.local.",
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
+    info = make_service_info(type_, registration_name, properties=desc)
     info2 = ServiceInfo(
         type_,
         registration_name2,
@@ -355,26 +338,8 @@ async def test_async_service_registration_same_server_same_ports(quick_timing: N
     aiozc.zeroconf.add_service_listener(type_, listener)
 
     desc = {"path": "/healthz/"}
-    info = ServiceInfo(
-        type_,
-        registration_name,
-        80,
-        0,
-        0,
-        desc,
-        "spare-rig.local.",
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
-    info2 = ServiceInfo(
-        type_,
-        registration_name2,
-        80,
-        0,
-        0,
-        desc,
-        "spare-rig.local.",
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
+    info = make_service_info(type_, registration_name, properties=desc)
+    info2 = make_service_info(type_, registration_name2, properties=desc)
     tasks = []
     tasks.append(await aiozc.async_register_service(info))
     tasks.append(await aiozc.async_register_service(info2))
@@ -403,16 +368,7 @@ async def test_async_service_registration_name_conflict(quick_timing: None) -> N
     registration_name = f"{name}.{type_}"
 
     desc = {"path": "/healthz/"}
-    info = ServiceInfo(
-        type_,
-        registration_name,
-        80,
-        0,
-        0,
-        desc,
-        "spare-rig.local.",
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
+    info = make_service_info(type_, registration_name, properties=desc)
     task = await aiozc.async_register_service(info)
     await task
 
@@ -451,16 +407,7 @@ async def test_async_service_registration_name_does_not_match_type() -> None:
     registration_name = f"{name}.{type_}"
 
     desc = {"path": "/healthz/"}
-    info = ServiceInfo(
-        type_,
-        registration_name,
-        80,
-        0,
-        0,
-        desc,
-        "spare-rig.local.",
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
+    info = make_service_info(type_, registration_name, properties=desc)
     info.type = "_wrong._tcp.local."
     with pytest.raises(BadTypeInNameException):
         task = await aiozc.async_register_service(info)
@@ -478,16 +425,7 @@ async def test_async_service_registration_name_strict_check(quick_timing: None) 
     registration_name = f"{name}.{type_}"
 
     desc = {"path": "/healthz/"}
-    info = ServiceInfo(
-        type_,
-        registration_name,
-        80,
-        0,
-        0,
-        desc,
-        "spare-rig.local.",
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
+    info = make_service_info(type_, registration_name, properties=desc)
     with pytest.raises(BadTypeInNameException):
         await zc.async_check_service(info, allow_name_change=False)
 
@@ -529,16 +467,7 @@ async def test_async_tasks(quick_timing: None) -> None:
     aiozc.zeroconf.add_service_listener(type_, listener)
 
     desc = {"path": "/healthz/"}
-    info = ServiceInfo(
-        type_,
-        registration_name,
-        80,
-        0,
-        0,
-        desc,
-        "spare-rig.local.",
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
+    info = make_service_info(type_, registration_name, properties=desc)
     task = await aiozc.async_register_service(info)
     assert isinstance(task, asyncio.Task)
     await task
@@ -580,16 +509,7 @@ async def test_async_wait_unblocks_on_update(quick_timing: None) -> None:
     registration_name = f"{name}.{type_}"
 
     desc = {"path": "/healthz/"}
-    info = ServiceInfo(
-        type_,
-        registration_name,
-        80,
-        0,
-        0,
-        desc,
-        "spare-rig.local.",
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
+    info = make_service_info(type_, registration_name, properties=desc)
     task = await aiozc.async_register_service(info)
 
     # Should unblock due to update from the
@@ -754,16 +674,7 @@ async def test_async_service_browser(quick_timing: None) -> None:
     await aiozc.async_add_service_listener(type_, listener)
 
     desc = {"path": "/healthz/"}
-    info = ServiceInfo(
-        type_,
-        registration_name,
-        80,
-        0,
-        0,
-        desc,
-        "spare-rig.local.",
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
+    info = make_service_info(type_, registration_name, properties=desc)
     task = await aiozc.async_register_service(info)
     await task
     new_info = ServiceInfo(
@@ -907,16 +818,7 @@ async def test_async_zeroconf_service_types(quick_timing: None) -> None:
 
     zeroconf_registrar = AsyncZeroconf(interfaces=["127.0.0.1"])
     desc = {"path": "/healthz/"}
-    info = ServiceInfo(
-        type_,
-        registration_name,
-        80,
-        0,
-        0,
-        desc,
-        "spare-rig.local.",
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
+    info = make_service_info(type_, registration_name, properties=desc)
     task = await zeroconf_registrar.async_register_service(info)
     await task
     # Wait for the last announce broadcast before clearing. With
@@ -1170,16 +1072,7 @@ async def test_info_asking_default_is_asking_qm_questions_after_the_first_qu(qui
     registration_name = f"{name}.{type_}"
 
     desc = {"path": "/healthz/"}
-    info = ServiceInfo(
-        type_,
-        registration_name,
-        80,
-        0,
-        0,
-        desc,
-        "spare-rig.local.",
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
+    info = make_service_info(type_, registration_name, properties=desc)
 
     zeroconf_info.registry.async_add(info)
 
@@ -1347,16 +1240,7 @@ async def test_legacy_unicast_response(run_isolated):
     registration_name = f"{name}.{type_}"
 
     desc = {"path": "/healthz/"}
-    info = ServiceInfo(
-        type_,
-        registration_name,
-        80,
-        0,
-        0,
-        desc,
-        "spare-rig.local.",
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
+    info = make_service_info(type_, registration_name, properties=desc)
 
     aiozc.zeroconf.registry.async_add(info)
     query = DNSOutgoing(const._FLAGS_QR_QUERY, multicast=False, id_=888)

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -23,7 +23,7 @@ from zeroconf._handlers.multicast_outgoing_queue import (
 from zeroconf._utils.time import millis_to_seconds
 from zeroconf.asyncio import AsyncZeroconf
 
-from . import _clear_cache, _inject_response, has_working_ipv6
+from . import _clear_cache, _inject_response, has_working_ipv6, make_service_info
 
 log = logging.getLogger("zeroconf")
 original_logging_level = logging.NOTSET
@@ -40,215 +40,185 @@ def teardown_module():
         log.setLevel(original_logging_level)
 
 
-class TestRegistrar(unittest.TestCase):
-    def test_ttl(self):
-        # instantiate a zeroconf instance
-        zc = Zeroconf(interfaces=["127.0.0.1"])
-
-        # service definition
-        type_ = "_test-srvc-type._tcp.local."
-        name = "xxxyyy"
-        registration_name = f"{name}.{type_}"
-
-        desc = {"path": "/healthz/"}
-        info = ServiceInfo(
-            type_,
-            registration_name,
-            80,
-            0,
-            0,
-            desc,
-            "spare-rig.local.",
-            addresses=[socket.inet_aton("10.7.4.2")],
-        )
-
-        nbr_answers = nbr_additionals = nbr_authorities = 0
-
-        def get_ttl(record_type):
-            if expected_ttl is not None:
-                return expected_ttl
-            if record_type in [const._TYPE_A, const._TYPE_SRV, const._TYPE_NSEC]:
-                return const._DNS_HOST_TTL
-            return const._DNS_OTHER_TTL
-
-        def _process_outgoing_packet(out):
-            nonlocal nbr_answers, nbr_additionals, nbr_authorities
-
-            for answer, _ in out.answers:
-                nbr_answers += 1
-                assert answer.ttl == get_ttl(answer.type)
-            for answer in out.additionals:
-                nbr_additionals += 1
-                assert answer.ttl == get_ttl(answer.type)
-            for answer in out.authorities:
-                nbr_authorities += 1
-                assert answer.ttl == get_ttl(answer.type)
-
-        # register service with default TTL
-        expected_ttl = None
-        for _ in range(3):
-            _process_outgoing_packet(zc.generate_service_query(info))
-        zc.registry.async_add(info)
-        for _ in range(3):
-            _process_outgoing_packet(zc.generate_service_broadcast(info, None))
-        assert nbr_answers == 15 and nbr_additionals == 0 and nbr_authorities == 3
-        nbr_answers = nbr_additionals = nbr_authorities = 0
-
-        # query
-        query = r.DNSOutgoing(const._FLAGS_QR_QUERY | const._FLAGS_AA)
-        assert query.is_query() is True
-        query.add_question(r.DNSQuestion(info.type, const._TYPE_PTR, const._CLASS_IN))
-        query.add_question(r.DNSQuestion(info.name, const._TYPE_SRV, const._CLASS_IN))
-        query.add_question(r.DNSQuestion(info.name, const._TYPE_TXT, const._CLASS_IN))
-        query.add_question(r.DNSQuestion(info.server or info.name, const._TYPE_A, const._CLASS_IN))
-        question_answers = zc.query_handler.async_response(
-            [r.DNSIncoming(packet) for packet in query.packets()], False
-        )
-        assert question_answers
-        _process_outgoing_packet(construct_outgoing_multicast_answers(question_answers.mcast_aggregate))
-
-        # The additonals should all be suppressed since they are all in the answers section
-        # There will be one NSEC additional to indicate the lack of AAAA record
-        #
-        assert nbr_answers == 4 and nbr_additionals == 1 and nbr_authorities == 0
-        nbr_answers = nbr_additionals = nbr_authorities = 0
-
-        # unregister
-        expected_ttl = 0
-        zc.registry.async_remove(info)
-        for _ in range(3):
-            _process_outgoing_packet(zc.generate_service_broadcast(info, 0))
-        assert nbr_answers == 15 and nbr_additionals == 0 and nbr_authorities == 0
-        nbr_answers = nbr_additionals = nbr_authorities = 0
-
-        expected_ttl = None
-        for _ in range(3):
-            _process_outgoing_packet(zc.generate_service_query(info))
-        zc.registry.async_add(info)
-        # register service with custom TTL
-        expected_ttl = const._DNS_HOST_TTL * 2
-        assert expected_ttl != const._DNS_HOST_TTL
-        for _ in range(3):
-            _process_outgoing_packet(zc.generate_service_broadcast(info, expected_ttl))
-        assert nbr_answers == 15 and nbr_additionals == 0 and nbr_authorities == 3
-        nbr_answers = nbr_additionals = nbr_authorities = 0
-
-        # query
-        expected_ttl = None
-        query = r.DNSOutgoing(const._FLAGS_QR_QUERY | const._FLAGS_AA)
-        query.add_question(r.DNSQuestion(info.type, const._TYPE_PTR, const._CLASS_IN))
-        query.add_question(r.DNSQuestion(info.name, const._TYPE_SRV, const._CLASS_IN))
-        query.add_question(r.DNSQuestion(info.name, const._TYPE_TXT, const._CLASS_IN))
-        query.add_question(r.DNSQuestion(info.server or info.name, const._TYPE_A, const._CLASS_IN))
-        question_answers = zc.query_handler.async_response(
-            [r.DNSIncoming(packet) for packet in query.packets()], False
-        )
-        assert question_answers
-        _process_outgoing_packet(construct_outgoing_multicast_answers(question_answers.mcast_aggregate))
-
-        # There will be one NSEC additional to indicate the lack of AAAA record
-        assert nbr_answers == 4 and nbr_additionals == 1 and nbr_authorities == 0
-        nbr_answers = nbr_additionals = nbr_authorities = 0
-
-        # unregister
-        expected_ttl = 0
-        zc.registry.async_remove(info)
-        for _ in range(3):
-            _process_outgoing_packet(zc.generate_service_broadcast(info, 0))
-        assert nbr_answers == 15 and nbr_additionals == 0 and nbr_authorities == 0
-        nbr_answers = nbr_additionals = nbr_authorities = 0
-        zc.close()
-
-    @pytest.mark.usefixtures("quick_timing")
-    def test_name_conflicts(self):
-        # instantiate a zeroconf instance
-        zc = Zeroconf(interfaces=["127.0.0.1"])
-        type_ = "_homeassistant._tcp.local."
-        name = "Home"
-        registration_name = f"{name}.{type_}"
-
-        info = ServiceInfo(
-            type_,
-            name=registration_name,
-            server="random123.local.",
-            addresses=[socket.inet_pton(socket.AF_INET, "1.2.3.4")],
-            port=80,
-            properties={"version": "1.0"},
-        )
-        zc.register_service(info)
-
-        conflicting_info = ServiceInfo(
-            type_,
-            name=registration_name,
-            server="random456.local.",
-            addresses=[socket.inet_pton(socket.AF_INET, "4.5.6.7")],
-            port=80,
-            properties={"version": "1.0"},
-        )
-        with pytest.raises(r.NonUniqueNameException):
-            zc.register_service(conflicting_info)
-        zc.close()
-
-    @pytest.mark.usefixtures("quick_timing")
-    def test_register_and_lookup_type_by_uppercase_name(self):
-        # instantiate a zeroconf instance
-        zc = Zeroconf(interfaces=["127.0.0.1"])
-        type_ = "_mylowertype._tcp.local."
-        name = "Home"
-        registration_name = f"{name}.{type_}"
-
-        info = ServiceInfo(
-            type_,
-            name=registration_name,
-            server="random123.local.",
-            addresses=[socket.inet_pton(socket.AF_INET, "1.2.3.4")],
-            port=80,
-            properties={"version": "1.0"},
-        )
-        zc.register_service(info)
-        _clear_cache(zc)
-        info = ServiceInfo(type_, registration_name)
-        info.load_from_cache(zc)
-        assert info.addresses == []
-
-        out = r.DNSOutgoing(const._FLAGS_QR_QUERY)
-        out.add_question(r.DNSQuestion(type_.upper(), const._TYPE_PTR, const._CLASS_IN))
-        zc.send(out)
-        info = ServiceInfo(type_, registration_name)
-        for _ in range(50):
-            time.sleep(0.02)
-            info.load_from_cache(zc)
-            # Wait for both A and TXT records — they arrive as separate
-            # cache updates and the listener may schedule the assertions
-            # between the two. Breaking on just `info.addresses` makes
-            # the test flaky under PyPy / skip_cython.
-            if info.addresses and info.properties:
-                break
-        assert info.addresses == [socket.inet_pton(socket.AF_INET, "1.2.3.4")]
-        assert info.properties == {b"version": b"1.0"}
-        zc.close()
-
-
-def test_ptr_optimization(quick_timing: None) -> None:
-    # instantiate a zeroconf instance
-    zc = Zeroconf(interfaces=["127.0.0.1"])
-
+def test_ttl(zc: Zeroconf) -> None:
     # service definition
     type_ = "_test-srvc-type._tcp.local."
     name = "xxxyyy"
     registration_name = f"{name}.{type_}"
 
     desc = {"path": "/healthz/"}
+    info = make_service_info(type_, registration_name, properties=desc)
+
+    nbr_answers = nbr_additionals = nbr_authorities = 0
+
+    def get_ttl(record_type):
+        if expected_ttl is not None:
+            return expected_ttl
+        if record_type in [const._TYPE_A, const._TYPE_SRV, const._TYPE_NSEC]:
+            return const._DNS_HOST_TTL
+        return const._DNS_OTHER_TTL
+
+    def _process_outgoing_packet(out):
+        nonlocal nbr_answers, nbr_additionals, nbr_authorities
+
+        for answer, _ in out.answers:
+            nbr_answers += 1
+            assert answer.ttl == get_ttl(answer.type)
+        for answer in out.additionals:
+            nbr_additionals += 1
+            assert answer.ttl == get_ttl(answer.type)
+        for answer in out.authorities:
+            nbr_authorities += 1
+            assert answer.ttl == get_ttl(answer.type)
+
+    # register service with default TTL
+    expected_ttl = None
+    for _ in range(3):
+        _process_outgoing_packet(zc.generate_service_query(info))
+    zc.registry.async_add(info)
+    for _ in range(3):
+        _process_outgoing_packet(zc.generate_service_broadcast(info, None))
+    assert nbr_answers == 15 and nbr_additionals == 0 and nbr_authorities == 3
+    nbr_answers = nbr_additionals = nbr_authorities = 0
+
+    # query
+    query = r.DNSOutgoing(const._FLAGS_QR_QUERY | const._FLAGS_AA)
+    assert query.is_query() is True
+    query.add_question(r.DNSQuestion(info.type, const._TYPE_PTR, const._CLASS_IN))
+    query.add_question(r.DNSQuestion(info.name, const._TYPE_SRV, const._CLASS_IN))
+    query.add_question(r.DNSQuestion(info.name, const._TYPE_TXT, const._CLASS_IN))
+    query.add_question(r.DNSQuestion(info.server or info.name, const._TYPE_A, const._CLASS_IN))
+    question_answers = zc.query_handler.async_response(
+        [r.DNSIncoming(packet) for packet in query.packets()], False
+    )
+    assert question_answers
+    _process_outgoing_packet(construct_outgoing_multicast_answers(question_answers.mcast_aggregate))
+
+    # The additonals should all be suppressed since they are all in the answers section
+    # There will be one NSEC additional to indicate the lack of AAAA record
+    #
+    assert nbr_answers == 4 and nbr_additionals == 1 and nbr_authorities == 0
+    nbr_answers = nbr_additionals = nbr_authorities = 0
+
+    # unregister
+    expected_ttl = 0
+    zc.registry.async_remove(info)
+    for _ in range(3):
+        _process_outgoing_packet(zc.generate_service_broadcast(info, 0))
+    assert nbr_answers == 15 and nbr_additionals == 0 and nbr_authorities == 0
+    nbr_answers = nbr_additionals = nbr_authorities = 0
+
+    expected_ttl = None
+    for _ in range(3):
+        _process_outgoing_packet(zc.generate_service_query(info))
+    zc.registry.async_add(info)
+    # register service with custom TTL
+    expected_ttl = const._DNS_HOST_TTL * 2
+    assert expected_ttl != const._DNS_HOST_TTL
+    for _ in range(3):
+        _process_outgoing_packet(zc.generate_service_broadcast(info, expected_ttl))
+    assert nbr_answers == 15 and nbr_additionals == 0 and nbr_authorities == 3
+    nbr_answers = nbr_additionals = nbr_authorities = 0
+
+    # query
+    expected_ttl = None
+    query = r.DNSOutgoing(const._FLAGS_QR_QUERY | const._FLAGS_AA)
+    query.add_question(r.DNSQuestion(info.type, const._TYPE_PTR, const._CLASS_IN))
+    query.add_question(r.DNSQuestion(info.name, const._TYPE_SRV, const._CLASS_IN))
+    query.add_question(r.DNSQuestion(info.name, const._TYPE_TXT, const._CLASS_IN))
+    query.add_question(r.DNSQuestion(info.server or info.name, const._TYPE_A, const._CLASS_IN))
+    question_answers = zc.query_handler.async_response(
+        [r.DNSIncoming(packet) for packet in query.packets()], False
+    )
+    assert question_answers
+    _process_outgoing_packet(construct_outgoing_multicast_answers(question_answers.mcast_aggregate))
+
+    # There will be one NSEC additional to indicate the lack of AAAA record
+    assert nbr_answers == 4 and nbr_additionals == 1 and nbr_authorities == 0
+    nbr_answers = nbr_additionals = nbr_authorities = 0
+
+    # unregister
+    expected_ttl = 0
+    zc.registry.async_remove(info)
+    for _ in range(3):
+        _process_outgoing_packet(zc.generate_service_broadcast(info, 0))
+    assert nbr_answers == 15 and nbr_additionals == 0 and nbr_authorities == 0
+    nbr_answers = nbr_additionals = nbr_authorities = 0
+
+
+@pytest.mark.usefixtures("quick_timing")
+def test_name_conflicts(zc: Zeroconf) -> None:
+    type_ = "_homeassistant._tcp.local."
+    name = "Home"
+    registration_name = f"{name}.{type_}"
+
     info = ServiceInfo(
         type_,
-        registration_name,
-        80,
-        0,
-        0,
-        desc,
-        "spare-rig.local.",
-        addresses=[socket.inet_aton("10.7.4.2")],
+        name=registration_name,
+        server="random123.local.",
+        addresses=[socket.inet_pton(socket.AF_INET, "1.2.3.4")],
+        port=80,
+        properties={"version": "1.0"},
     )
+    zc.register_service(info)
+
+    conflicting_info = ServiceInfo(
+        type_,
+        name=registration_name,
+        server="random456.local.",
+        addresses=[socket.inet_pton(socket.AF_INET, "4.5.6.7")],
+        port=80,
+        properties={"version": "1.0"},
+    )
+    with pytest.raises(r.NonUniqueNameException):
+        zc.register_service(conflicting_info)
+
+
+@pytest.mark.usefixtures("quick_timing")
+def test_register_and_lookup_type_by_uppercase_name(zc: Zeroconf) -> None:
+    type_ = "_mylowertype._tcp.local."
+    name = "Home"
+    registration_name = f"{name}.{type_}"
+
+    info = ServiceInfo(
+        type_,
+        name=registration_name,
+        server="random123.local.",
+        addresses=[socket.inet_pton(socket.AF_INET, "1.2.3.4")],
+        port=80,
+        properties={"version": "1.0"},
+    )
+    zc.register_service(info)
+    _clear_cache(zc)
+    info = ServiceInfo(type_, registration_name)
+    info.load_from_cache(zc)
+    assert info.addresses == []
+
+    out = r.DNSOutgoing(const._FLAGS_QR_QUERY)
+    out.add_question(r.DNSQuestion(type_.upper(), const._TYPE_PTR, const._CLASS_IN))
+    zc.send(out)
+    info = ServiceInfo(type_, registration_name)
+    for _ in range(50):
+        time.sleep(0.02)
+        info.load_from_cache(zc)
+        # Wait for both A and TXT records — they arrive as separate
+        # cache updates and the listener may schedule the assertions
+        # between the two. Breaking on just `info.addresses` makes
+        # the test flaky under PyPy / skip_cython.
+        if info.addresses and info.properties:
+            break
+    assert info.addresses == [socket.inet_pton(socket.AF_INET, "1.2.3.4")]
+    assert info.properties == {b"version": b"1.0"}
+
+
+def test_ptr_optimization(zc: Zeroconf, quick_timing: None) -> None:
+    # service definition
+    type_ = "_test-srvc-type._tcp.local."
+    name = "xxxyyy"
+    registration_name = f"{name}.{type_}"
+
+    desc = {"path": "/healthz/"}
+    info = make_service_info(type_, registration_name, properties=desc)
 
     # register
     zc.register_service(info)
@@ -299,14 +269,12 @@ def test_ptr_optimization(quick_timing: None) -> None:
 
     # unregister
     zc.unregister_service(info)
-    zc.close()
 
 
 @unittest.skipIf(not has_working_ipv6(), "Requires IPv6")
 @unittest.skipIf(os.environ.get("SKIP_IPV6"), "IPv6 tests disabled")
-def test_any_query_for_ptr():
+def test_any_query_for_ptr(zc: Zeroconf) -> None:
     """Test that queries for ANY will return PTR records and the response is aggregated."""
-    zc = Zeroconf(interfaces=["127.0.0.1"])
     type_ = "_anyptr._tcp.local."
     name = "knownname"
     registration_name = f"{name}.{type_}"
@@ -328,14 +296,12 @@ def test_any_query_for_ptr():
     assert mcast_answers[0].alias == registration_name  # type: ignore[attr-defined]
     # unregister
     zc.registry.async_remove(info)
-    zc.close()
 
 
 @unittest.skipIf(not has_working_ipv6(), "Requires IPv6")
 @unittest.skipIf(os.environ.get("SKIP_IPV6"), "IPv6 tests disabled")
-def test_aaaa_query():
+def test_aaaa_query(zc: Zeroconf) -> None:
     """Test that queries for AAAA records work and should respond right away."""
-    zc = Zeroconf(interfaces=["127.0.0.1"])
     type_ = "_knownaaaservice._tcp.local."
     name = "knownname"
     registration_name = f"{name}.{type_}"
@@ -355,14 +321,12 @@ def test_aaaa_query():
     assert mcast_answers[0].address == ipv6_address  # type: ignore[attr-defined]
     # unregister
     zc.registry.async_remove(info)
-    zc.close()
 
 
 @unittest.skipIf(not has_working_ipv6(), "Requires IPv6")
 @unittest.skipIf(os.environ.get("SKIP_IPV6"), "IPv6 tests disabled")
-def test_aaaa_query_upper_case():
+def test_aaaa_query_upper_case(zc: Zeroconf) -> None:
     """Test that queries for AAAA records work and should respond right away with an upper case name."""
-    zc = Zeroconf(interfaces=["127.0.0.1"])
     type_ = "_knownaaaservice._tcp.local."
     name = "knownname"
     registration_name = f"{name}.{type_}"
@@ -382,14 +346,12 @@ def test_aaaa_query_upper_case():
     assert mcast_answers[0].address == ipv6_address  # type: ignore[attr-defined]
     # unregister
     zc.registry.async_remove(info)
-    zc.close()
 
 
 @unittest.skipIf(not has_working_ipv6(), "Requires IPv6")
 @unittest.skipIf(os.environ.get("SKIP_IPV6"), "IPv6 tests disabled")
-def test_a_and_aaaa_record_fate_sharing():
+def test_a_and_aaaa_record_fate_sharing(zc: Zeroconf) -> None:
     """Test that queries for AAAA always return A records in the additionals and should respond right away."""
-    zc = Zeroconf(interfaces=["127.0.0.1"])
     type_ = "_a-and-aaaa-service._tcp.local."
     name = "knownname"
     registration_name = f"{name}.{type_}"
@@ -440,29 +402,16 @@ def test_a_and_aaaa_record_fate_sharing():
 
     # unregister
     zc.registry.async_remove(info)
-    zc.close()
 
 
-def test_unicast_response():
+def test_unicast_response(zc: Zeroconf) -> None:
     """Ensure we send a unicast response when the source port is not the MDNS port."""
-    # instantiate a zeroconf instance
-    zc = Zeroconf(interfaces=["127.0.0.1"])
-
     # service definition
     type_ = "_test-srvc-type._tcp.local."
     name = "xxxyyy"
     registration_name = f"{name}.{type_}"
     desc = {"path": "/healthz/"}
-    info = ServiceInfo(
-        type_,
-        registration_name,
-        80,
-        0,
-        0,
-        desc,
-        "spare-rig.local.",
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
+    info = make_service_info(type_, registration_name, properties=desc)
     # register
     zc.registry.async_add(info)
     _clear_cache(zc)
@@ -498,30 +447,17 @@ def test_unicast_response():
 
     # unregister
     zc.registry.async_remove(info)
-    zc.close()
 
 
 @pytest.mark.asyncio
-async def test_probe_answered_immediately():
+async def test_probe_answered_immediately(zc: Zeroconf) -> None:
     """Verify probes are responded to immediately."""
-    # instantiate a zeroconf instance
-    zc = Zeroconf(interfaces=["127.0.0.1"])
-
     # service definition
     type_ = "_test-srvc-type._tcp.local."
     name = "xxxyyy"
     registration_name = f"{name}.{type_}"
     desc = {"path": "/healthz/"}
-    info = ServiceInfo(
-        type_,
-        registration_name,
-        80,
-        0,
-        0,
-        desc,
-        "spare-rig.local.",
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
+    info = make_service_info(type_, registration_name, properties=desc)
     zc.registry.async_add(info)
     query = r.DNSOutgoing(const._FLAGS_QR_QUERY)
     question = r.DNSQuestion(info.type, const._TYPE_PTR, const._CLASS_IN)
@@ -549,30 +485,17 @@ async def test_probe_answered_immediately():
     assert question_answers.mcast_now
     assert not question_answers.mcast_aggregate
     assert not question_answers.mcast_aggregate_last_second
-    zc.close()
 
 
 @pytest.mark.asyncio
-async def test_probe_answered_immediately_with_uppercase_name():
+async def test_probe_answered_immediately_with_uppercase_name(zc: Zeroconf) -> None:
     """Verify probes are responded to immediately with an uppercase name."""
-    # instantiate a zeroconf instance
-    zc = Zeroconf(interfaces=["127.0.0.1"])
-
     # service definition
     type_ = "_test-srvc-type._tcp.local."
     name = "xxxyyy"
     registration_name = f"{name}.{type_}"
     desc = {"path": "/healthz/"}
-    info = ServiceInfo(
-        type_,
-        registration_name,
-        80,
-        0,
-        0,
-        desc,
-        "spare-rig.local.",
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
+    info = make_service_info(type_, registration_name, properties=desc)
     zc.registry.async_add(info)
     query = r.DNSOutgoing(const._FLAGS_QR_QUERY)
     question = r.DNSQuestion(info.type.upper(), const._TYPE_PTR, const._CLASS_IN)
@@ -600,14 +523,10 @@ async def test_probe_answered_immediately_with_uppercase_name():
     assert question_answers.mcast_now
     assert not question_answers.mcast_aggregate
     assert not question_answers.mcast_aggregate_last_second
-    zc.close()
 
 
-def test_qu_response(quick_timing: None) -> None:
+def test_qu_response(zc: Zeroconf, quick_timing: None) -> None:
     """Handle multicast incoming with the QU bit set."""
-    # instantiate a zeroconf instance
-    zc = Zeroconf(interfaces=["127.0.0.1"])
-
     # service definition
     type_ = "_test-srvc-type._tcp.local."
     other_type_ = "_notthesame._tcp.local."
@@ -615,16 +534,7 @@ def test_qu_response(quick_timing: None) -> None:
     registration_name = f"{name}.{type_}"
     registration_name2 = f"{name}.{other_type_}"
     desc = {"path": "/healthz/"}
-    info = ServiceInfo(
-        type_,
-        registration_name,
-        80,
-        0,
-        0,
-        desc,
-        "spare-rig.local.",
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
+    info = make_service_info(type_, registration_name, properties=desc)
     info2 = ServiceInfo(
         other_type_,
         registration_name2,
@@ -728,11 +638,9 @@ def test_qu_response(quick_timing: None) -> None:
     _validate_complete_response(question_answers.ucast)
     # unregister
     zc.unregister_service(info)
-    zc.close()
 
 
-def test_known_answer_supression():
-    zc = Zeroconf(interfaces=["127.0.0.1"])
+def test_known_answer_supression(zc: Zeroconf) -> None:
     type_ = "_knownanswersv8._tcp.local."
     name = "knownname"
     registration_name = f"{name}.{type_}"
@@ -871,12 +779,10 @@ def test_known_answer_supression():
 
     # unregister
     zc.registry.async_remove(info)
-    zc.close()
 
 
-def test_no_nsec_answer_for_service_without_addresses() -> None:
+def test_no_nsec_answer_for_service_without_addresses(zc: Zeroconf) -> None:
     """A service with no address records cannot assert which types exist, so no NSEC is sent."""
-    zc = Zeroconf(interfaces=["127.0.0.1"])
     type_ = "_noaddrnsec._tcp.local."
     registration_name = f"noaddr.{type_}"
     server_name = "noaddr-host.local."
@@ -896,11 +802,9 @@ def test_no_nsec_answer_for_service_without_addresses() -> None:
     assert not question_answers.mcast_aggregate_last_second
 
     zc.registry.async_remove(info)
-    zc.close()
 
 
-def test_multi_packet_known_answer_supression():
-    zc = Zeroconf(interfaces=["127.0.0.1"])
+def test_multi_packet_known_answer_supression(zc: Zeroconf) -> None:
     type_ = "_handlermultis._tcp.local."
     name = "knownname"
     name2 = "knownname2"
@@ -972,11 +876,9 @@ def test_multi_packet_known_answer_supression():
     zc.registry.async_remove(info)
     zc.registry.async_remove(info2)
     zc.registry.async_remove(info3)
-    zc.close()
 
 
-def test_known_answer_supression_service_type_enumeration_query():
-    zc = Zeroconf(interfaces=["127.0.0.1"])
+def test_known_answer_supression_service_type_enumeration_query(zc: Zeroconf) -> None:
     type_ = "_otherknown._tcp.local."
     name = "knownname"
     registration_name = f"{name}.{type_}"
@@ -1059,11 +961,9 @@ def test_known_answer_supression_service_type_enumeration_query():
     # unregister
     zc.registry.async_remove(info)
     zc.registry.async_remove(info2)
-    zc.close()
 
 
-def test_upper_case_enumeration_query():
-    zc = Zeroconf(interfaces=["127.0.0.1"])
+def test_upper_case_enumeration_query(zc: Zeroconf) -> None:
     type_ = "_otherknown._tcp.local."
     name = "knownname"
     registration_name = f"{name}.{type_}"
@@ -1113,11 +1013,9 @@ def test_upper_case_enumeration_query():
     # unregister
     zc.registry.async_remove(info)
     zc.registry.async_remove(info2)
-    zc.close()
 
 
-def test_enumeration_query_with_no_registered_services():
-    zc = Zeroconf(interfaces=["127.0.0.1"])
+def test_enumeration_query_with_no_registered_services(zc: Zeroconf) -> None:
     _clear_cache(zc)
     generated = r.DNSOutgoing(const._FLAGS_QR_QUERY)
     question = r.DNSQuestion(const._SERVICE_TYPE_ENUMERATION_NAME.upper(), const._TYPE_PTR, const._CLASS_IN)
@@ -1126,7 +1024,6 @@ def test_enumeration_query_with_no_registered_services():
     question_answers = zc.query_handler.async_response([r.DNSIncoming(packet) for packet in packets], False)
     assert not question_answers
     # unregister
-    zc.close()
 
 
 # This test uses asyncio because it needs to access the cache directly
@@ -1655,16 +1552,7 @@ async def test_response_aggregation_timings(run_isolated: None) -> None:
     registration_name3 = f"{name}.{type_3}"
 
     desc = {"path": "/healthz/"}
-    info = ServiceInfo(
-        type_,
-        registration_name,
-        80,
-        0,
-        0,
-        desc,
-        "spare-rig.local.",
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
+    info = make_service_info(type_, registration_name, properties=desc)
     info2 = ServiceInfo(
         type_2,
         registration_name2,

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -15,7 +15,7 @@ import zeroconf as r
 from zeroconf import Zeroconf
 from zeroconf._services.info import ServiceInfo
 
-from . import _clear_cache, has_working_ipv6
+from . import _clear_cache, has_working_ipv6, make_service_info
 
 log = logging.getLogger("zeroconf")
 original_logging_level = logging.NOTSET
@@ -188,16 +188,7 @@ class ListenerTest(unittest.TestCase):
 
             properties["prop_blank"] = b"an updated string"
             desc.update(properties)
-            info_service = ServiceInfo(
-                subtype,
-                registration_name,
-                80,
-                0,
-                0,
-                desc,
-                "spare-rig.local.",
-                addresses=[socket.inet_aton("10.7.4.2")],
-            )
+            info_service = make_service_info(subtype, registration_name, properties=desc)
             zeroconf_registrar.update_service(info_service)
 
             sub_service_added.wait(1)  # we cleared the cache above


### PR DESCRIPTION
## Summary
Code cleanup, not related to #1835; the duplication just became obvious while doing the audits. Two pieces of shared infrastructure and the heaviest call sites converted:

- a `zc` pytest fixture in conftest that yields a running Zeroconf bound to loopback and closes it after the test; eighteen tests in test_handlers drop their hand rolled construct and close boilerplate, and the one remaining unittest class there is converted to bare functions
- a `make_service_info` helper in the tests package carrying the suite's canonical fixture values; twenty seven canonical eight line ServiceInfo constructions across six files collapse to one line each, with genuine variants left explicit

Net minus 253 lines. Remaining files can adopt the fixture and helper incrementally.

## Test plan
- [x] full suite passes