### PR TITLE
chore: consolidate the loopback fixtures and adopt them in test_asyncio

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,14 +95,6 @@ def blockbuster(
         yield bb
 
 
-@pytest.fixture
-def zc() -> Iterator[Zeroconf]:
-    """A running Zeroconf bound to loopback, closed after the test."""
-    instance = Zeroconf(interfaces=["127.0.0.1"])
-    yield instance
-    instance.close()
-
-
 @pytest.fixture(autouse=True)
 def verify_threads_ended():
     """Verify that the threads are not running after the test."""
@@ -113,7 +105,7 @@ def verify_threads_ended():
 
 
 @pytest.fixture
-def zc_loopback() -> Generator[Zeroconf]:
+def zc() -> Generator[Zeroconf]:
     """Yield a loopback `Zeroconf` and close it on teardown.
 
     Replaces the inline `zc = Zeroconf(interfaces=["127.0.0.1"])` +
@@ -128,7 +120,7 @@ def zc_loopback() -> Generator[Zeroconf]:
 
 
 @pytest_asyncio.fixture
-async def aiozc_loopback() -> AsyncGenerator[AsyncZeroconf]:
+async def aiozc() -> AsyncGenerator[AsyncZeroconf]:
     """Yield a loopback `AsyncZeroconf` and close it on teardown.
 
     Replaces the inline `aiozc = AsyncZeroconf(interfaces=["127.0.0.1"])`

--- a/tests/services/test_info.py
+++ b/tests/services/test_info.py
@@ -2378,14 +2378,11 @@ async def test_async_request_incomplete_without_txt_record(quick_request_timing)
         ([const._TYPE_AAAA], False),
     ],
 )
-def test_load_from_cache_with_nsec(
-    zc_loopback: r.Zeroconf, nsec_rdtypes: list[int], expected_complete: bool
-) -> None:
+def test_load_from_cache_with_nsec(zc: r.Zeroconf, nsec_rdtypes: list[int], expected_complete: bool) -> None:
     """An NSEC listing SRV but not TXT denies the TXT record and completes the service."""
     type_ = "_http._tcp.local."
     registration_name = f"nsecdenial.{type_}"
     host = "nsecdenial.local."
-    zc = zc_loopback
     zc.cache.async_add_records(
         [
             r.DNSService(
@@ -2424,13 +2421,13 @@ def test_load_from_cache_with_nsec(
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("quick_request_timing")
-async def test_async_request_completes_on_nsec_txt_denial(aiozc_loopback: AsyncZeroconf) -> None:
+async def test_async_request_completes_on_nsec_txt_denial(aiozc: AsyncZeroconf) -> None:
     """async_request succeeds promptly when the responder denies the TXT record via NSEC."""
     type_ = "_http._tcp.local."
     registration_name = f"nsecrequest.{type_}"
     host = "nsecrequest.local."
-    await aiozc_loopback.zeroconf.async_wait_for_start()
-    zc = aiozc_loopback.zeroconf
+    await aiozc.zeroconf.async_wait_for_start()
+    zc = aiozc.zeroconf
 
     zc.record_manager.async_updates_from_response(
         mock_incoming_msg(
@@ -2496,13 +2493,13 @@ async def test_async_request_completes_on_nsec_txt_denial(aiozc_loopback: AsyncZ
 
 
 @pytest.mark.asyncio
-async def test_nsec_after_txt_record_is_ignored(aiozc_loopback: AsyncZeroconf) -> None:
+async def test_nsec_after_txt_record_is_ignored(aiozc: AsyncZeroconf) -> None:
     """An NSEC arriving after a real TXT record does not clear the properties."""
     type_ = "_http._tcp.local."
     registration_name = f"nsecaftertxt.{type_}"
     host = "nsecaftertxt.local."
-    await aiozc_loopback.zeroconf.async_wait_for_start()
-    zc = aiozc_loopback.zeroconf
+    await aiozc.zeroconf.async_wait_for_start()
+    zc = aiozc.zeroconf
 
     zc.record_manager.async_updates_from_response(
         mock_incoming_msg(
@@ -2551,7 +2548,7 @@ async def test_nsec_after_txt_record_is_ignored(aiozc_loopback: AsyncZeroconf) -
     assert info._is_complete
 
 
-def test_unhandled_record_type_at_service_name_is_ignored(zc_loopback: r.Zeroconf) -> None:
+def test_unhandled_record_type_at_service_name_is_ignored(zc: r.Zeroconf) -> None:
     """A record type with no handler at the service name does not change state."""
     type_ = "_http._tcp.local."
     registration_name = f"unhandledrec.{type_}"
@@ -2563,19 +2560,19 @@ def test_unhandled_record_type_at_service_name_is_ignored(zc_loopback: r.Zerocon
         120,
         f"other.{type_}",
     )
-    info.async_update_records(zc_loopback, r.current_time_millis(), [RecordUpdate(ptr_record, None)])
+    info.async_update_records(zc, r.current_time_millis(), [RecordUpdate(ptr_record, None)])
     assert info._txt_seen is False
     assert info._is_complete is False
 
 
 @pytest.mark.asyncio
-async def test_own_nsec_response_does_not_complete_service(aiozc_loopback: AsyncZeroconf) -> None:
+async def test_own_nsec_response_does_not_complete_service(aiozc: AsyncZeroconf) -> None:
     """The NSEC our own responder emits for a missing address type must not deny the TXT record."""
     type_ = "_http._tcp.local."
     registration_name = f"ownnsec.{type_}"
     host = "ownnsec.local."
-    await aiozc_loopback.zeroconf.async_wait_for_start()
-    zc = aiozc_loopback.zeroconf
+    await aiozc.zeroconf.async_wait_for_start()
+    zc = aiozc.zeroconf
 
     registered = ServiceInfo(
         type_,
@@ -2604,14 +2601,14 @@ async def test_own_nsec_response_does_not_complete_service(aiozc_loopback: Async
     ],
 )
 async def test_address_resolver_bails_on_nsec_denial(
-    aiozc_loopback: AsyncZeroconf,
+    aiozc: AsyncZeroconf,
     resolver_class: Callable[[str], ServiceInfo],
     nsec_rdtypes: list[int],
 ) -> None:
     """A cached NSEC denying the wanted address type fails the request without waiting."""
     host = "nsec-addr-denial.local."
-    await aiozc_loopback.zeroconf.async_wait_for_start()
-    zc = aiozc_loopback.zeroconf
+    await aiozc.zeroconf.async_wait_for_start()
+    zc = aiozc.zeroconf
 
     zc.record_manager.async_updates_from_response(
         mock_incoming_msg(
@@ -2638,11 +2635,11 @@ async def test_address_resolver_bails_on_nsec_denial(
 
 
 @pytest.mark.asyncio
-async def test_address_resolver_bails_on_live_nsec_denial(aiozc_loopback: AsyncZeroconf) -> None:
+async def test_address_resolver_bails_on_live_nsec_denial(aiozc: AsyncZeroconf) -> None:
     """An NSEC denial arriving mid request wakes the waiter and fails it early."""
     host = "nsec-live-denial.local."
-    await aiozc_loopback.zeroconf.async_wait_for_start()
-    zc = aiozc_loopback.zeroconf
+    await aiozc.zeroconf.async_wait_for_start()
+    zc = aiozc.zeroconf
 
     resolver = r.AddressResolverIPv6(host)
     start = time.monotonic()
@@ -2670,12 +2667,12 @@ async def test_address_resolver_bails_on_live_nsec_denial(aiozc_loopback: AsyncZ
 
 @pytest.mark.asyncio
 async def test_address_resolver_succeeds_despite_partial_denial(
-    aiozc_loopback: AsyncZeroconf,
+    aiozc: AsyncZeroconf,
 ) -> None:
     """Denial of one address family does not fail a resolver that accepts either."""
     host = "nsec-partial-denial.local."
-    await aiozc_loopback.zeroconf.async_wait_for_start()
-    zc = aiozc_loopback.zeroconf
+    await aiozc.zeroconf.async_wait_for_start()
+    zc = aiozc.zeroconf
 
     zc.record_manager.async_updates_from_response(
         mock_incoming_msg(
@@ -2707,12 +2704,12 @@ async def test_address_resolver_succeeds_despite_partial_denial(
 
 @pytest.mark.asyncio
 async def test_address_resolver_bails_when_other_family_is_present(
-    aiozc_loopback: AsyncZeroconf,
+    aiozc: AsyncZeroconf,
 ) -> None:
     """A cached NSEC denial bails a single family resolver even when the other family resolved."""
     host = "nsec-mixed-denial.local."
-    await aiozc_loopback.zeroconf.async_wait_for_start()
-    zc = aiozc_loopback.zeroconf
+    await aiozc.zeroconf.async_wait_for_start()
+    zc = aiozc.zeroconf
 
     zc.record_manager.async_updates_from_response(
         mock_incoming_msg(
@@ -2744,11 +2741,11 @@ async def test_address_resolver_bails_when_other_family_is_present(
 
 
 @pytest.mark.asyncio
-async def test_address_denial_cleared_on_new_request(aiozc_loopback: AsyncZeroconf) -> None:
+async def test_address_denial_cleared_on_new_request(aiozc: AsyncZeroconf) -> None:
     """A denial only lasts one request; a host that gains the record resolves again."""
     host = "nsec-denial-reset.local."
-    await aiozc_loopback.zeroconf.async_wait_for_start()
-    zc = aiozc_loopback.zeroconf
+    await aiozc.zeroconf.async_wait_for_start()
+    zc = aiozc.zeroconf
 
     zc.record_manager.async_updates_from_response(
         mock_incoming_msg(
@@ -2790,14 +2787,14 @@ async def test_address_denial_cleared_on_new_request(aiozc_loopback: AsyncZeroco
 
 @pytest.mark.asyncio
 async def test_service_info_bails_when_all_address_types_denied(
-    aiozc_loopback: AsyncZeroconf,
+    aiozc: AsyncZeroconf,
 ) -> None:
     """An NSEC denying both address families at the host fails the request early."""
     type_ = "_http._tcp.local."
     registration_name = f"alldenied.{type_}"
     host = "alldenied-host.local."
-    await aiozc_loopback.zeroconf.async_wait_for_start()
-    zc = aiozc_loopback.zeroconf
+    await aiozc.zeroconf.async_wait_for_start()
+    zc = aiozc.zeroconf
 
     zc.record_manager.async_updates_from_response(
         mock_incoming_msg(
@@ -2838,7 +2835,7 @@ async def test_service_info_bails_when_all_address_types_denied(
     assert time.monotonic() - start < 2
 
 
-def test_nsec_for_unrelated_name_is_ignored(zc_loopback: r.Zeroconf) -> None:
+def test_nsec_for_unrelated_name_is_ignored(zc: r.Zeroconf) -> None:
     """An NSEC for a name that is neither the service nor the server changes nothing."""
     type_ = "_http._tcp.local."
     registration_name = f"unrelatednsec.{type_}"
@@ -2851,7 +2848,7 @@ def test_nsec_for_unrelated_name_is_ignored(zc_loopback: r.Zeroconf) -> None:
         "other-host.local.",
         [const._TYPE_A],
     )
-    info.async_update_records(zc_loopback, r.current_time_millis(), [RecordUpdate(foreign_nsec, None)])
+    info.async_update_records(zc, r.current_time_millis(), [RecordUpdate(foreign_nsec, None)])
     assert info._ipv4_denied is False
     assert info._ipv6_denied is False
     assert info._txt_seen is False
@@ -2882,7 +2879,7 @@ def _srv(name: str, host: str) -> r.DNSService:
 
 
 @pytest.mark.parametrize("nsec_first", [False, True])
-def test_nsec_and_srv_in_same_batch_record_denial(zc_loopback: r.Zeroconf, nsec_first: bool) -> None:
+def test_nsec_and_srv_in_same_batch_record_denial(zc: r.Zeroconf, nsec_first: bool) -> None:
     """A batch with an SRV and an NSEC for its target records the denial in either order."""
     type_ = "_http._tcp.local."
     registration_name = f"nsecfirst.{type_}"
@@ -2892,11 +2889,11 @@ def test_nsec_and_srv_in_same_batch_record_denial(zc_loopback: r.Zeroconf, nsec_
     records = [_nsec(host, [const._TYPE_TXT]), _srv(registration_name, host)]
     if not nsec_first:
         records.reverse()
-    info.async_update_records(zc_loopback, now, [RecordUpdate(record, None) for record in records])
+    info.async_update_records(zc, now, [RecordUpdate(record, None) for record in records])
     assert (info._ipv4_denied, info._ipv6_denied) == (True, True)
 
 
-def test_denial_is_reset_when_srv_changes_server(zc_loopback: r.Zeroconf) -> None:
+def test_denial_is_reset_when_srv_changes_server(zc: r.Zeroconf) -> None:
     """A denial learned for the old SRV target does not apply to a new target."""
     type_ = "_http._tcp.local."
     registration_name = f"srvmove.{type_}"
@@ -2907,7 +2904,7 @@ def test_denial_is_reset_when_srv_changes_server(zc_loopback: r.Zeroconf) -> Non
     now = r.current_time_millis()
 
     info.async_update_records(
-        zc_loopback,
+        zc,
         now,
         [
             RecordUpdate(_srv(registration_name, old_host), None),
@@ -2917,34 +2914,32 @@ def test_denial_is_reset_when_srv_changes_server(zc_loopback: r.Zeroconf) -> Non
     assert (info._ipv4_denied, info._ipv6_denied) == (True, True)
 
     # moving to a host with no cached NSEC clears the denial
-    info.async_update_records(zc_loopback, now, [RecordUpdate(_srv(registration_name, new_host), None)])
+    info.async_update_records(zc, now, [RecordUpdate(_srv(registration_name, new_host), None)])
     assert (info._ipv4_denied, info._ipv6_denied) == (False, False)
 
     # moving to a host with a cached NSEC re-establishes it from the cache
-    zc_loopback.cache.async_add_records([_nsec(denied_host, [const._TYPE_TXT])])
-    info.async_update_records(zc_loopback, now, [RecordUpdate(_srv(registration_name, denied_host), None)])
+    zc.cache.async_add_records([_nsec(denied_host, [const._TYPE_TXT])])
+    info.async_update_records(zc, now, [RecordUpdate(_srv(registration_name, denied_host), None)])
     assert (info._ipv4_denied, info._ipv6_denied) == (True, True)
 
 
-def test_newer_nsec_clears_previous_denial(zc_loopback: r.Zeroconf) -> None:
+def test_newer_nsec_clears_previous_denial(zc: r.Zeroconf) -> None:
     """A later NSEC whose bitmap includes a previously denied type clears that denial."""
     type_ = "_http._tcp.local."
     registration_name = f"nsecrefresh.{type_}"
     host = "nsecrefresh-host.local."
     info = ServiceInfo(type_, registration_name)
     now = r.current_time_millis()
-    info.async_update_records(zc_loopback, now, [RecordUpdate(_srv(registration_name, host), None)])
+    info.async_update_records(zc, now, [RecordUpdate(_srv(registration_name, host), None)])
 
-    info.async_update_records(zc_loopback, now, [RecordUpdate(_nsec(host, [const._TYPE_A]), None)])
+    info.async_update_records(zc, now, [RecordUpdate(_nsec(host, [const._TYPE_A]), None)])
     assert (info._ipv4_denied, info._ipv6_denied) == (False, True)
 
-    info.async_update_records(
-        zc_loopback, now, [RecordUpdate(_nsec(host, [const._TYPE_A, const._TYPE_AAAA]), None)]
-    )
+    info.async_update_records(zc, now, [RecordUpdate(_nsec(host, [const._TYPE_A, const._TYPE_AAAA]), None)])
     assert (info._ipv4_denied, info._ipv6_denied) == (False, False)
 
 
-def test_multiple_nsec_records_in_one_batch(zc_loopback: r.Zeroconf) -> None:
+def test_multiple_nsec_records_in_one_batch(zc: r.Zeroconf) -> None:
     """A batch with more than one NSEC processes every denial it carries."""
     type_ = "_http._tcp.local."
     registration_name = f"multinsec.{type_}"
@@ -2956,19 +2951,19 @@ def test_multiple_nsec_records_in_one_batch(zc_loopback: r.Zeroconf) -> None:
         _nsec(registration_name, [const._TYPE_SRV]),
         _nsec(host, [const._TYPE_TXT]),
     ]
-    info.async_update_records(zc_loopback, now, [RecordUpdate(record, None) for record in records])
+    info.async_update_records(zc, now, [RecordUpdate(record, None) for record in records])
     assert info._txt_seen is True
     assert (info._ipv4_denied, info._ipv6_denied) == (True, True)
 
 
 @pytest.mark.asyncio
-async def test_v4_only_host_with_nsec_still_resolves(aiozc_loopback: AsyncZeroconf) -> None:
+async def test_v4_only_host_with_nsec_still_resolves(aiozc: AsyncZeroconf) -> None:
     """The common case: a v4 only host denying AAAA via NSEC still resolves the service."""
     type_ = "_http._tcp.local."
     registration_name = f"v4onlynsec.{type_}"
     host = "v4onlynsec-host.local."
-    await aiozc_loopback.zeroconf.async_wait_for_start()
-    zc = aiozc_loopback.zeroconf
+    await aiozc.zeroconf.async_wait_for_start()
+    zc = aiozc.zeroconf
 
     zc.record_manager.async_updates_from_response(
         mock_incoming_msg(
@@ -3000,7 +2995,7 @@ async def test_v4_only_host_with_nsec_still_resolves(aiozc_loopback: AsyncZeroco
     assert info.addresses == [socket.inet_aton("127.0.0.1")]
 
 
-def test_legacy_inverted_nsec_at_own_name_does_not_fail_request(zc_loopback: r.Zeroconf) -> None:
+def test_legacy_inverted_nsec_at_own_name_does_not_fail_request(zc: r.Zeroconf) -> None:
     """A pre-0.150.4 inverted NSEC from a service with server == name never denies the request."""
     type_ = "_http._tcp.local."
     registration_name = f"legacyownname.{type_}"
@@ -3009,7 +3004,7 @@ def test_legacy_inverted_nsec_at_own_name_does_not_fail_request(zc_loopback: r.Z
     # legacy v4 only responder registered without server=: NSEC at its own
     # name with the inverted bitmap listing the missing AAAA
     info.async_update_records(
-        zc_loopback,
+        zc,
         now,
         [
             RecordUpdate(_srv(registration_name, registration_name), None),
@@ -3020,7 +3015,7 @@ def test_legacy_inverted_nsec_at_own_name_does_not_fail_request(zc_loopback: r.Z
     assert info._is_denied is False
 
     info.async_update_records(
-        zc_loopback,
+        zc,
         now,
         [
             RecordUpdate(
@@ -3039,12 +3034,12 @@ def test_legacy_inverted_nsec_at_own_name_does_not_fail_request(zc_loopback: r.Z
     assert info._is_denied is False
 
 
-def test_denied_flag_is_ignored_when_address_is_held(zc_loopback: r.Zeroconf) -> None:
+def test_denied_flag_is_ignored_when_address_is_held(zc: r.Zeroconf) -> None:
     """A denial never vetoes an address the client already holds."""
     type_ = "_http._tcp.local."
     registration_name = f"guardednsec.{type_}"
     host = "guardednsec-host.local."
-    zc_loopback.cache.async_add_records(
+    zc.cache.async_add_records(
         [
             _srv(registration_name, host),
             r.DNSAddress(
@@ -3060,7 +3055,7 @@ def test_denied_flag_is_ignored_when_address_is_held(zc_loopback: r.Zeroconf) ->
 
     info = ServiceInfo(type_, registration_name)
     # incomplete only because the TXT record is still missing
-    assert info.load_from_cache(zc_loopback) is False
+    assert info.load_from_cache(zc) is False
     assert (info._ipv4_denied, info._ipv6_denied) == (True, True)
     assert info.addresses == [socket.inet_aton("127.0.0.1")]
     # the held A record keeps the request querying instead of fast failing

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -82,18 +82,13 @@ def verify_threads_ended():
 
 
 @pytest.mark.asyncio
-async def test_async_basic_usage() -> None:
+async def test_async_basic_usage(aiozc: AsyncZeroconf) -> None:
     """Test we can create and close the instance."""
-    aiozc = AsyncZeroconf(interfaces=["127.0.0.1"])
-    await aiozc.async_close()
 
 
 @pytest.mark.asyncio
 async def test_async_close_twice() -> None:
     """Test we can close twice."""
-    aiozc = AsyncZeroconf(interfaces=["127.0.0.1"])
-    await aiozc.async_close()
-    await aiozc.async_close()
 
 
 @pytest.mark.asyncio
@@ -102,7 +97,6 @@ async def test_async_with_sync_passed_in() -> None:
     zc = Zeroconf(interfaces=["127.0.0.1"])
     aiozc = AsyncZeroconf(zc=zc)
     assert aiozc.zeroconf is zc
-    await aiozc.async_close()
 
 
 @pytest.mark.asyncio
@@ -112,7 +106,6 @@ async def test_async_with_sync_passed_in_closed_in_async() -> None:
     aiozc = AsyncZeroconf(zc=zc)
     assert aiozc.zeroconf is zc
     zc.close()
-    await aiozc.async_close()
 
 
 @pytest.mark.asyncio
@@ -360,9 +353,8 @@ async def test_async_service_registration_same_server_same_ports(quick_timing: N
 
 
 @pytest.mark.asyncio
-async def test_async_service_registration_name_conflict(quick_timing: None) -> None:
+async def test_async_service_registration_name_conflict(aiozc: AsyncZeroconf, quick_timing: None) -> None:
     """Test registering services throws on name conflict."""
-    aiozc = AsyncZeroconf(interfaces=["127.0.0.1"])
     type_ = "_test-srvc2-type._tcp.local."
     name = "xxxyyy"
     registration_name = f"{name}.{type_}"
@@ -395,13 +387,10 @@ async def test_async_service_registration_name_conflict(quick_timing: None) -> N
         task = await aiozc.async_register_service(conflicting_info)
         await task
 
-    await aiozc.async_close()
-
 
 @pytest.mark.asyncio
-async def test_async_service_registration_name_does_not_match_type() -> None:
+async def test_async_service_registration_name_does_not_match_type(aiozc: AsyncZeroconf) -> None:
     """Test registering services throws when the name does not match the type."""
-    aiozc = AsyncZeroconf(interfaces=["127.0.0.1"])
     type_ = "_test-srvc3-type._tcp.local."
     name = "xxxyyy"
     registration_name = f"{name}.{type_}"
@@ -412,7 +401,6 @@ async def test_async_service_registration_name_does_not_match_type() -> None:
     with pytest.raises(BadTypeInNameException):
         task = await aiozc.async_register_service(info)
         await task
-    await aiozc.async_close()
 
 
 @pytest.mark.asyncio
@@ -500,10 +488,9 @@ async def test_async_tasks(quick_timing: None) -> None:
 
 
 @pytest.mark.asyncio
-async def test_async_wait_unblocks_on_update(quick_timing: None) -> None:
+async def test_async_wait_unblocks_on_update(aiozc: AsyncZeroconf, quick_timing: None) -> None:
     """Test async_wait will unblock on update."""
 
-    aiozc = AsyncZeroconf(interfaces=["127.0.0.1"])
     type_ = "_test-srvc4-type._tcp.local."
     name = "xxxyyy"
     registration_name = f"{name}.{type_}"
@@ -523,16 +510,15 @@ async def test_async_wait_unblocks_on_update(quick_timing: None) -> None:
     await aiozc.zeroconf.async_wait(50)
     assert current_time_millis() - now < 1000
 
-    await aiozc.async_close()
-
 
 @pytest.mark.asyncio
-async def test_service_info_async_request(quick_timing: None, quick_request_timing: None) -> None:
+async def test_service_info_async_request(
+    aiozc: AsyncZeroconf, quick_timing: None, quick_request_timing: None
+) -> None:
     """Test registering services broadcasts and query with AsyncServceInfo.async_request."""
     if not has_working_ipv6() or os.environ.get("SKIP_IPV6"):
         pytest.skip("Requires IPv6")
 
-    aiozc = AsyncZeroconf(interfaces=["127.0.0.1"])
     type_ = "_test1-srvc-type._tcp.local."
     name = "xxxyyy"
     name2 = "abc"
@@ -647,8 +633,6 @@ async def test_service_info_async_request(quick_timing: None, quick_request_timi
     aiosinfo = await aiozc.async_get_service_info(type_, registration_name, timeout=200)
     assert aiosinfo is None
 
-    await aiozc.async_close()
-
 
 @pytest.mark.asyncio
 async def test_async_service_browser(quick_timing: None) -> None:
@@ -726,11 +710,10 @@ async def test_async_context_manager(quick_timing: None) -> None:
 
 
 @pytest.mark.asyncio
-async def test_service_browser_cancel_async_context_manager():
+async def test_service_browser_cancel_async_context_manager(aiozc: AsyncZeroconf) -> None:
     """Test we can cancel an AsyncServiceBrowser with it being used as an async context manager."""
 
     # instantiate a zeroconf instance
-    aiozc = AsyncZeroconf(interfaces=["127.0.0.1"])
     zc = aiozc.zeroconf
     type_ = "_hap._tcp.local."
 
@@ -748,13 +731,10 @@ async def test_service_browser_cancel_async_context_manager():
 
     assert cast(bool, browser.done) is True
 
-    await aiozc.async_close()
-
 
 @pytest.mark.asyncio
-async def test_async_unregister_all_services(quick_timing: None) -> None:
+async def test_async_unregister_all_services(aiozc: AsyncZeroconf, quick_timing: None) -> None:
     """Test unregistering all services."""
-    aiozc = AsyncZeroconf(interfaces=["127.0.0.1"])
     type_ = "_test1-srvc-type._tcp.local."
     name = "xxxyyy"
     name2 = "abc"
@@ -807,8 +787,6 @@ async def test_async_unregister_all_services(quick_timing: None) -> None:
     # Verify we can call again
     await aiozc.async_unregister_all_services()
 
-    await aiozc.async_close()
-
 
 @pytest.mark.asyncio
 async def test_async_zeroconf_service_types(quick_timing: None) -> None:
@@ -842,22 +820,18 @@ async def test_async_zeroconf_service_types(quick_timing: None) -> None:
 
 
 @pytest.mark.asyncio
-async def test_guard_against_running_serviceinfo_request_event_loop() -> None:
+async def test_guard_against_running_serviceinfo_request_event_loop(aiozc: AsyncZeroconf) -> None:
     """Test that running ServiceInfo.request from the event loop throws."""
-    aiozc = AsyncZeroconf(interfaces=["127.0.0.1"])
-
     service_info = AsyncServiceInfo("_hap._tcp.local.", "doesnotmatter._hap._tcp.local.")
     with pytest.raises(RuntimeError):
         service_info.request(aiozc.zeroconf, 3000)
-    await aiozc.async_close()
 
 
 @pytest.mark.asyncio
-async def test_service_browser_instantiation_generates_add_events_from_cache():
+async def test_service_browser_instantiation_generates_add_events_from_cache(aiozc: AsyncZeroconf) -> None:
     """Test that the ServiceBrowser will generate Add events with the existing cache when starting."""
 
     # instantiate a zeroconf instance
-    aiozc = AsyncZeroconf(interfaces=["127.0.0.1"])
     zc = aiozc.zeroconf
     type_ = "_hap._tcp.local."
     registration_name = f"xxxyyy.{type_}"
@@ -894,8 +868,6 @@ async def test_service_browser_instantiation_generates_add_events_from_cache():
         ("add", type_, registration_name),
     ]
     await browser.async_cancel()
-
-    await aiozc.async_close()
 
 
 @pytest.mark.asyncio
@@ -1110,11 +1082,10 @@ async def test_info_asking_default_is_asking_qm_questions_after_the_first_qu(qui
 
 
 @pytest.mark.asyncio
-async def test_service_browser_ignores_unrelated_updates():
+async def test_service_browser_ignores_unrelated_updates(aiozc: AsyncZeroconf) -> None:
     """Test that the ServiceBrowser ignores unrelated updates."""
 
     # instantiate a zeroconf instance
-    aiozc = AsyncZeroconf(interfaces=["127.0.0.1"])
     zc = aiozc.zeroconf
     type_ = "_veryuniqueone._tcp.local."
     registration_name = f"xxxyyy.{type_}"
@@ -1200,7 +1171,6 @@ async def test_service_browser_ignores_unrelated_updates():
     assert callbacks == [
         ("add", type_, registration_name),
     ]
-    await aiozc.async_close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -82,6 +82,14 @@ def verify_threads_ended():
 
 
 @pytest.mark.asyncio
+async def test_async_close_is_idempotent(aiozc: AsyncZeroconf) -> None:
+    """A second async_close is a quiet no-op."""
+    await aiozc.async_close()
+    assert aiozc.zeroconf.done
+    await aiozc.async_close()
+
+
+@pytest.mark.asyncio
 async def test_async_basic_usage(aiozc: AsyncZeroconf) -> None:
     """Test we can create and close the instance."""
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -102,6 +102,26 @@ async def test_async_close_propagates_outer_cancellation(aiozc: AsyncZeroconf) -
 
 
 @pytest.mark.asyncio
+async def test_async_close_swallows_cancelled_setup(aiozc: AsyncZeroconf) -> None:
+    """Close before setup starts swallows the setup task's own cancellation."""
+    await aiozc.zeroconf.async_wait_for_start()
+    engine = aiozc.zeroconf.engine
+    loop = asyncio.get_running_loop()
+    original_task = engine._setup_task
+
+    async def hang() -> None:
+        await asyncio.Event().wait()
+
+    cancelled_task = loop.create_task(hang())
+    cancelled_task.cancel()
+    engine._setup_task = cancelled_task
+    try:
+        await engine._async_close()
+    finally:
+        engine._setup_task = original_task
+
+
+@pytest.mark.asyncio
 async def test_reaper_aborts_when_done():
     """Ensure cache cleanup stops when zeroconf is done."""
     with patch.object(_engine, "_CACHE_CLEANUP_INTERVAL", 0.01):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -74,10 +74,10 @@ async def test_reaper():
 
 
 @pytest.mark.asyncio
-async def test_setup_releases_socket_ownership(aiozc_loopback: AsyncZeroconf) -> None:
+async def test_setup_releases_socket_ownership(aiozc: AsyncZeroconf) -> None:
     """Engine releases its pending-socket refs once each socket has a transport."""
-    await aiozc_loopback.zeroconf.async_wait_for_start()
-    engine = aiozc_loopback.zeroconf.engine
+    await aiozc.zeroconf.async_wait_for_start()
+    engine = aiozc.zeroconf.engine
     assert engine._listen_socket is None
     assert engine._respond_sockets == []
     assert engine.readers
@@ -85,10 +85,10 @@ async def test_setup_releases_socket_ownership(aiozc_loopback: AsyncZeroconf) ->
 
 
 @pytest.mark.asyncio
-async def test_async_close_propagates_outer_cancellation(aiozc_loopback: AsyncZeroconf) -> None:
+async def test_async_close_propagates_outer_cancellation(aiozc: AsyncZeroconf) -> None:
     """Outer-task cancellation while awaiting setup propagates to the caller."""
-    await aiozc_loopback.zeroconf.async_wait_for_start()
-    engine = aiozc_loopback.zeroconf.engine
+    await aiozc.zeroconf.async_wait_for_start()
+    engine = aiozc.zeroconf.engine
     loop = asyncio.get_running_loop()
     original_task = engine._setup_task
     fake_task = loop.create_future()

--- a/tests/test_interface_update.py
+++ b/tests/test_interface_update.py
@@ -114,60 +114,60 @@ def test_listen_socket_supports_family() -> None:
 
 
 @pytest.mark.asyncio
-async def test_update_interfaces_noop(aiozc_loopback: AsyncZeroconf) -> None:
+async def test_update_interfaces_noop(aiozc: AsyncZeroconf) -> None:
     """Re-scanning the same interface set leaves the engine lists unchanged."""
-    zc = aiozc_loopback.zeroconf
+    zc = aiozc.zeroconf
     await zc.async_wait_for_start()
     engine = zc.engine
     before = (len(engine.senders), len(engine.readers), len(engine.protocols))
-    await aiozc_loopback.async_update_interfaces(["127.0.0.1"])
+    await aiozc.async_update_interfaces(["127.0.0.1"])
     assert (len(engine.senders), len(engine.readers), len(engine.protocols)) == before
 
 
 @pytest.mark.asyncio
-async def test_update_interfaces_defaults_to_stored_choice(aiozc_loopback: AsyncZeroconf) -> None:
+async def test_update_interfaces_defaults_to_stored_choice(aiozc: AsyncZeroconf) -> None:
     """Calling without an argument reuses the interface choice from construction."""
-    zc = aiozc_loopback.zeroconf
+    zc = aiozc.zeroconf
     await zc.async_wait_for_start()
     engine = zc.engine
     before = (len(engine.senders), len(engine.readers), len(engine.protocols))
-    await aiozc_loopback.async_update_interfaces()
+    await aiozc.async_update_interfaces()
     assert (len(engine.senders), len(engine.readers), len(engine.protocols)) == before
 
 
 @pytest.mark.asyncio
-async def test_update_interfaces_accepts_ip_version_and_apple_p2p(aiozc_loopback: AsyncZeroconf) -> None:
+async def test_update_interfaces_accepts_ip_version_and_apple_p2p(aiozc: AsyncZeroconf) -> None:
     """ip_version and apple_p2p overrides are stored for the rescan."""
-    zc = aiozc_loopback.zeroconf
+    zc = aiozc.zeroconf
     await zc.async_wait_for_start()
-    await aiozc_loopback.async_update_interfaces(["127.0.0.1"], ip_version=IPVersion.V4Only, apple_p2p=False)
+    await aiozc.async_update_interfaces(["127.0.0.1"], ip_version=IPVersion.V4Only, apple_p2p=False)
     assert zc._ip_version is IPVersion.V4Only
     assert zc._apple_p2p is False
 
 
 @pytest.mark.asyncio
-async def test_update_interfaces_removes_and_readds(aiozc_loopback: AsyncZeroconf) -> None:
+async def test_update_interfaces_removes_and_readds(aiozc: AsyncZeroconf) -> None:
     """A gone interface drops its sender; a returning interface re-adds it."""
-    zc = aiozc_loopback.zeroconf
+    zc = aiozc.zeroconf
     await zc.async_wait_for_start()
     engine = zc.engine
     listen_reader_count = len(engine.readers) - len(engine.senders)
 
-    await aiozc_loopback.async_update_interfaces([])
+    await aiozc.async_update_interfaces([])
     await asyncio.sleep(0)
     assert engine.senders == []
     # The shared listen socket is never torn down.
     assert len(engine.readers) == listen_reader_count
 
-    await aiozc_loopback.async_update_interfaces(["127.0.0.1"])
+    await aiozc.async_update_interfaces(["127.0.0.1"])
     await asyncio.sleep(0)
     assert len(engine.senders) == 1
 
 
 @pytest.mark.asyncio
-async def test_update_interfaces_keeps_unchanged_sender_untouched(aiozc_loopback: AsyncZeroconf) -> None:
+async def test_update_interfaces_keeps_unchanged_sender_untouched(aiozc: AsyncZeroconf) -> None:
     """An unchanged interface keeps its exact transport; only the gone interface is torn down."""
-    zc = aiozc_loopback.zeroconf
+    zc = aiozc.zeroconf
     await zc.async_wait_for_start()
     engine = zc.engine
     kept = engine.senders[0]
@@ -179,7 +179,7 @@ async def test_update_interfaces_keeps_unchanged_sender_untouched(aiozc_loopback
     engine.senders.append(gone)
 
     with patch.object(_engine, "drop_multicast_member"):
-        await aiozc_loopback.async_update_interfaces(["127.0.0.1"])
+        await aiozc.async_update_interfaces(["127.0.0.1"])
     await asyncio.sleep(0)
 
     # The unchanged 127.0.0.1 sender is the same object, never recreated.
@@ -190,9 +190,9 @@ async def test_update_interfaces_keeps_unchanged_sender_untouched(aiozc_loopback
 
 
 @pytest.mark.asyncio
-async def test_update_interfaces_cancels_removed_listener_timers(aiozc_loopback: AsyncZeroconf) -> None:
+async def test_update_interfaces_cancels_removed_listener_timers(aiozc: AsyncZeroconf) -> None:
     """Removing an interface cancels its listener's pending TC-reassembly timers."""
-    zc = aiozc_loopback.zeroconf
+    zc = aiozc.zeroconf
     await zc.async_wait_for_start()
     engine = zc.engine
     sender = engine.senders[0]
@@ -204,7 +204,7 @@ async def test_update_interfaces_cancels_removed_listener_timers(aiozc_loopback:
     protocol._deferred["1.2.3.4"] = []
     protocol._deferred_deadlines["1.2.3.4"] = 0.0
 
-    await aiozc_loopback.async_update_interfaces([])
+    await aiozc.async_update_interfaces([])
     await asyncio.sleep(0)
 
     timer.cancel.assert_called_once()
@@ -213,12 +213,12 @@ async def test_update_interfaces_cancels_removed_listener_timers(aiozc_loopback:
 
 
 @pytest.mark.asyncio
-async def test_close_sender_keeps_protocol_without_transport(aiozc_loopback: AsyncZeroconf) -> None:
+async def test_close_sender_keeps_protocol_without_transport(aiozc: AsyncZeroconf) -> None:
     """A protocol that never bound a transport is left in place when a sender is closed."""
-    engine = aiozc_loopback.zeroconf.engine
-    await aiozc_loopback.zeroconf.async_wait_for_start()
+    engine = aiozc.zeroconf.engine
+    await aiozc.zeroconf.async_wait_for_start()
     sender = engine.senders[0]
-    orphan = _listener.AsyncListener(aiozc_loopback.zeroconf)
+    orphan = _listener.AsyncListener(aiozc.zeroconf)
     assert orphan.transport is None
     engine.protocols.append(orphan)
 
@@ -229,15 +229,15 @@ async def test_close_sender_keeps_protocol_without_transport(aiozc_loopback: Asy
 
 
 @pytest.mark.asyncio
-async def test_update_interfaces_reconciles_mixed_set(aiozc_loopback: AsyncZeroconf) -> None:
+async def test_update_interfaces_reconciles_mixed_set(aiozc: AsyncZeroconf) -> None:
     """One rescan keeps unchanged, drops gone, adds new across v4 and link-local v6.
 
     Drives the engine diff directly over a controlled sender set (no real
     sockets) so the (address, scope_id) keying is exercised end to end,
     including two interfaces sharing fe80::1 distinguished only by scope.
     """
-    engine = aiozc_loopback.zeroconf.engine
-    await aiozc_loopback.zeroconf.async_wait_for_start()
+    engine = aiozc.zeroconf.engine
+    await aiozc.zeroconf.async_wait_for_start()
 
     keep_v4 = _make_wrapped(("192.168.1.5", 5353))
     drop_v4 = _make_wrapped(("10.0.0.9", 5353))
@@ -281,9 +281,9 @@ async def test_update_interfaces_reconciles_mixed_set(aiozc_loopback: AsyncZeroc
 
 
 @pytest.mark.asyncio
-async def test_update_interfaces_reannounces_services_on_add(aiozc_loopback: AsyncZeroconf) -> None:
+async def test_update_interfaces_reannounces_services_on_add(aiozc: AsyncZeroconf) -> None:
     """Existing registrations are re-announced when a new sender appears."""
-    zc = aiozc_loopback.zeroconf
+    zc = aiozc.zeroconf
     await zc.async_wait_for_start()
     info = ServiceInfo(
         "_test._tcp.local.",
@@ -292,13 +292,13 @@ async def test_update_interfaces_reannounces_services_on_add(aiozc_loopback: Asy
         port=80,
         server="test.local.",
     )
-    await aiozc_loopback.async_register_service(info)
+    await aiozc.async_register_service(info)
     # Drop the sender so the next rescan genuinely adds one back.
-    await aiozc_loopback.async_update_interfaces([])
+    await aiozc.async_update_interfaces([])
     await asyncio.sleep(0)
 
     with patch.object(zc, "_async_broadcast_service", new_callable=AsyncMock) as mock_broadcast:
-        await aiozc_loopback.async_update_interfaces(["127.0.0.1"])
+        await aiozc.async_update_interfaces(["127.0.0.1"])
         await asyncio.sleep(0)
 
     assert mock_broadcast.call_count == 1
@@ -306,9 +306,9 @@ async def test_update_interfaces_reannounces_services_on_add(aiozc_loopback: Asy
 
 
 @pytest.mark.asyncio
-async def test_update_interfaces_noop_does_not_reannounce(aiozc_loopback: AsyncZeroconf) -> None:
+async def test_update_interfaces_noop_does_not_reannounce(aiozc: AsyncZeroconf) -> None:
     """An unchanged interface set neither touches sockets nor re-announces."""
-    zc = aiozc_loopback.zeroconf
+    zc = aiozc.zeroconf
     await zc.async_wait_for_start()
     engine = zc.engine
     info = ServiceInfo(
@@ -318,11 +318,11 @@ async def test_update_interfaces_noop_does_not_reannounce(aiozc_loopback: AsyncZ
         port=80,
         server="test.local.",
     )
-    await aiozc_loopback.async_register_service(info)
+    await aiozc.async_register_service(info)
     before = (len(engine.senders), len(engine.readers), len(engine.protocols))
 
     with patch.object(zc, "_async_broadcast_service", new_callable=AsyncMock) as mock_broadcast:
-        await aiozc_loopback.async_update_interfaces(["127.0.0.1"])
+        await aiozc.async_update_interfaces(["127.0.0.1"])
         await asyncio.sleep(0)
 
     mock_broadcast.assert_not_called()
@@ -331,10 +331,10 @@ async def test_update_interfaces_noop_does_not_reannounce(aiozc_loopback: AsyncZ
 
 @pytest.mark.asyncio
 async def test_update_interfaces_logs_reannounce_errors(
-    aiozc_loopback: AsyncZeroconf, caplog: pytest.LogCaptureFixture
+    aiozc: AsyncZeroconf, caplog: pytest.LogCaptureFixture
 ) -> None:
     """A re-announce failure is logged and does not propagate out of the rescan."""
-    zc = aiozc_loopback.zeroconf
+    zc = aiozc.zeroconf
     await zc.async_wait_for_start()
     info = ServiceInfo(
         "_test._tcp.local.",
@@ -343,15 +343,15 @@ async def test_update_interfaces_logs_reannounce_errors(
         port=80,
         server="test.local.",
     )
-    await aiozc_loopback.async_register_service(info)
-    await aiozc_loopback.async_update_interfaces([])
+    await aiozc.async_register_service(info)
+    await aiozc.async_update_interfaces([])
     await asyncio.sleep(0)
 
     with (
         patch.object(zc, "_async_broadcast_service", new_callable=AsyncMock, side_effect=ValueError("boom")),
         caplog.at_level(logging.WARNING),
     ):
-        await aiozc_loopback.async_update_interfaces(["127.0.0.1"])
+        await aiozc.async_update_interfaces(["127.0.0.1"])
         await asyncio.sleep(0)
 
     # The failing service is named so a partial failure is actionable.
@@ -360,10 +360,10 @@ async def test_update_interfaces_logs_reannounce_errors(
 
 @pytest.mark.asyncio
 async def test_update_interfaces_reannounces_all_services_one_failing(
-    aiozc_loopback: AsyncZeroconf, caplog: pytest.LogCaptureFixture
+    aiozc: AsyncZeroconf, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Every registration is re-announced on add; one failing does not stop the rest."""
-    zc = aiozc_loopback.zeroconf
+    zc = aiozc.zeroconf
     await zc.async_wait_for_start()
     infos = [
         ServiceInfo(
@@ -376,8 +376,8 @@ async def test_update_interfaces_reannounces_all_services_one_failing(
         for n in range(2)
     ]
     for info in infos:
-        await aiozc_loopback.async_register_service(info)
-    await aiozc_loopback.async_update_interfaces([])
+        await aiozc.async_register_service(info)
+    await aiozc.async_update_interfaces([])
     await asyncio.sleep(0)
 
     async def broadcast(info: ServiceInfo, *args: object) -> None:
@@ -388,7 +388,7 @@ async def test_update_interfaces_reannounces_all_services_one_failing(
         patch.object(zc, "_async_broadcast_service", new_callable=AsyncMock, side_effect=broadcast) as mock,
         caplog.at_level(logging.WARNING),
     ):
-        await aiozc_loopback.async_update_interfaces(["127.0.0.1"])
+        await aiozc.async_update_interfaces(["127.0.0.1"])
         await asyncio.sleep(0)
 
     # Both services were attempted (the gather fans out over all registrations)
@@ -401,9 +401,9 @@ async def test_update_interfaces_reannounces_all_services_one_failing(
 
 
 @pytest.mark.asyncio
-async def test_update_interfaces_reannounce_cancellation_propagates(aiozc_loopback: AsyncZeroconf) -> None:
+async def test_update_interfaces_reannounce_cancellation_propagates(aiozc: AsyncZeroconf) -> None:
     """A cancelled re-announce propagates rather than being silently dropped as a non-Exception."""
-    zc = aiozc_loopback.zeroconf
+    zc = aiozc.zeroconf
     await zc.async_wait_for_start()
     info = ServiceInfo(
         "_test._tcp.local.",
@@ -412,8 +412,8 @@ async def test_update_interfaces_reannounce_cancellation_propagates(aiozc_loopba
         port=80,
         server="test.local.",
     )
-    await aiozc_loopback.async_register_service(info)
-    await aiozc_loopback.async_update_interfaces([])
+    await aiozc.async_register_service(info)
+    await aiozc.async_update_interfaces([])
     await asyncio.sleep(0)
 
     with (
@@ -422,14 +422,14 @@ async def test_update_interfaces_reannounce_cancellation_propagates(aiozc_loopba
         ),
         pytest.raises(asyncio.CancelledError),
     ):
-        await aiozc_loopback.async_update_interfaces(["127.0.0.1"])
+        await aiozc.async_update_interfaces(["127.0.0.1"])
 
 
 @pytest.mark.asyncio
-async def test_update_interfaces_ip_change_in_one_rescan(aiozc_loopback: AsyncZeroconf) -> None:
+async def test_update_interfaces_ip_change_in_one_rescan(aiozc: AsyncZeroconf) -> None:
     """An interface whose address changes is removed and re-added in a single rescan."""
-    engine = aiozc_loopback.zeroconf.engine
-    await aiozc_loopback.zeroconf.async_wait_for_start()
+    engine = aiozc.zeroconf.engine
+    await aiozc.zeroconf.async_wait_for_start()
     old_transport = Mock()
     old = _make_wrapped(("10.0.0.5", 5353), transport=old_transport)
     engine.senders = [old]
@@ -459,10 +459,10 @@ async def test_update_interfaces_ip_change_in_one_rescan(aiozc_loopback: AsyncZe
 
 @pytest.mark.asyncio
 async def test_update_interfaces_transient_empty_set_is_noop(
-    aiozc_loopback: AsyncZeroconf, caplog: pytest.LogCaptureFixture
+    aiozc: AsyncZeroconf, caplog: pytest.LogCaptureFixture
 ) -> None:
     """An All instance that transiently resolves to zero interfaces logs and no-ops."""
-    zc = aiozc_loopback.zeroconf
+    zc = aiozc.zeroconf
     await zc.async_wait_for_start()
     engine = zc.engine
     before = (len(engine.senders), len(engine.readers), len(engine.protocols))
@@ -486,27 +486,27 @@ async def test_update_interfaces_transient_empty_set_is_noop(
 
 
 @pytest.mark.asyncio
-async def test_update_interfaces_add_failure_adds_no_sender(aiozc_loopback: AsyncZeroconf) -> None:
+async def test_update_interfaces_add_failure_adds_no_sender(aiozc: AsyncZeroconf) -> None:
     """An interface that fails to come up adds no responder socket."""
-    zc = aiozc_loopback.zeroconf
+    zc = aiozc.zeroconf
     await zc.async_wait_for_start()
     engine = zc.engine
-    await aiozc_loopback.async_update_interfaces([])
+    await aiozc.async_update_interfaces([])
     await asyncio.sleep(0)
 
     with patch.object(_engine, "add_interface", return_value=None):
-        await aiozc_loopback.async_update_interfaces(["127.0.0.1"])
+        await aiozc.async_update_interfaces(["127.0.0.1"])
     assert engine.senders == []
 
 
 @pytest.mark.asyncio
 async def test_update_interfaces_rolls_back_membership_on_wrap_failure(
-    aiozc_loopback: AsyncZeroconf,
+    aiozc: AsyncZeroconf,
 ) -> None:
     """Endpoint creation failing rolls the interface back and is skipped, not raised."""
-    zc = aiozc_loopback.zeroconf
+    zc = aiozc.zeroconf
     await zc.async_wait_for_start()
-    await aiozc_loopback.async_update_interfaces([])
+    await aiozc.async_update_interfaces([])
     await asyncio.sleep(0)
     assert zc._interfaces == []
 
@@ -517,7 +517,7 @@ async def test_update_interfaces_rolls_back_membership_on_wrap_failure(
         patch.object(_engine.AsyncEngine, "_async_wrap_socket", new=AsyncMock(side_effect=OSError("boom"))),
     ):
         # Best-effort: the failure is logged and skipped, not propagated.
-        await aiozc_loopback.async_update_interfaces(["127.0.0.1"])
+        await aiozc.async_update_interfaces(["127.0.0.1"])
 
     # The just-joined membership was dropped, the socket closed, no sender added.
     mock_drop.assert_called_once()
@@ -526,10 +526,10 @@ async def test_update_interfaces_rolls_back_membership_on_wrap_failure(
 
 
 @pytest.mark.asyncio
-async def test_add_interface_rollback_without_listen_socket(aiozc_loopback: AsyncZeroconf) -> None:
+async def test_add_interface_rollback_without_listen_socket(aiozc: AsyncZeroconf) -> None:
     """A wrap failure with no listen socket (unicast) closes the socket and drops no membership."""
-    engine = aiozc_loopback.zeroconf.engine
-    await aiozc_loopback.zeroconf.async_wait_for_start()
+    engine = aiozc.zeroconf.engine
+    await aiozc.zeroconf.async_wait_for_start()
 
     fake_socket = Mock()
     with (
@@ -545,10 +545,10 @@ async def test_add_interface_rollback_without_listen_socket(aiozc_loopback: Asyn
 
 
 @pytest.mark.asyncio
-async def test_add_interface_propagates_non_oserror(aiozc_loopback: AsyncZeroconf) -> None:
+async def test_add_interface_propagates_non_oserror(aiozc: AsyncZeroconf) -> None:
     """A non-OSError (a real bug) propagates after rollback, not downgraded to a warning."""
-    engine = aiozc_loopback.zeroconf.engine
-    await aiozc_loopback.zeroconf.async_wait_for_start()
+    engine = aiozc.zeroconf.engine
+    await aiozc.zeroconf.async_wait_for_start()
 
     fake_socket = Mock()
     listen_socket = Mock()
@@ -566,10 +566,10 @@ async def test_add_interface_propagates_non_oserror(aiozc_loopback: AsyncZerocon
 
 
 @pytest.mark.asyncio
-async def test_update_interfaces_keeps_dual_use_listen_socket(aiozc_loopback: AsyncZeroconf) -> None:
+async def test_update_interfaces_keeps_dual_use_listen_socket(aiozc: AsyncZeroconf) -> None:
     """A dual-use sender (the listen socket itself) is never torn down on rescan."""
-    engine = aiozc_loopback.zeroconf.engine
-    await aiozc_loopback.zeroconf.async_wait_for_start()
+    engine = aiozc.zeroconf.engine
+    await aiozc.zeroconf.async_wait_for_start()
     listen = engine._listen_transport
     assert listen is not None
     # Simulate a Default single-family instance: the listen socket is the sole sender.
@@ -579,10 +579,10 @@ async def test_update_interfaces_keeps_dual_use_listen_socket(aiozc_loopback: As
 
 
 @pytest.mark.asyncio
-async def test_update_interfaces_default_to_explicit_reconciles(aiozc_loopback: AsyncZeroconf) -> None:
+async def test_update_interfaces_default_to_explicit_reconciles(aiozc: AsyncZeroconf) -> None:
     """Moving a dual-use instance to an explicit set demotes its socket and rebuilds clean."""
-    engine = aiozc_loopback.zeroconf.engine
-    await aiozc_loopback.zeroconf.async_wait_for_start()
+    engine = aiozc.zeroconf.engine
+    await aiozc.zeroconf.async_wait_for_start()
     listen = engine._listen_transport
     assert listen is not None
     old_underlying = listen.transport
@@ -619,10 +619,10 @@ async def test_update_interfaces_default_to_explicit_reconciles(aiozc_loopback: 
 
 
 @pytest.mark.asyncio
-async def test_update_interfaces_default_to_explicit_real(aiozc_loopback: AsyncZeroconf) -> None:
+async def test_update_interfaces_default_to_explicit_real(aiozc: AsyncZeroconf) -> None:
     """A real dual-use socket with an overlapping membership reconciles without EADDRINUSE."""
-    engine = aiozc_loopback.zeroconf.engine
-    await aiozc_loopback.zeroconf.async_wait_for_start()
+    engine = aiozc.zeroconf.engine
+    await aiozc.zeroconf.async_wait_for_start()
     listen = engine._listen_transport
     assert listen is not None
     assert listen.sock.family == socket.AF_INET
@@ -648,27 +648,27 @@ async def test_update_interfaces_default_to_explicit_real(aiozc_loopback: AsyncZ
 
 @pytest.mark.asyncio
 async def test_update_interfaces_does_not_rebuild_when_family_supported(
-    aiozc_loopback: AsyncZeroconf,
+    aiozc: AsyncZeroconf,
 ) -> None:
     """Same-family rescans (and All/dual-stack) never rebuild the listen socket."""
-    zc = aiozc_loopback.zeroconf
+    zc = aiozc.zeroconf
     await zc.async_wait_for_start()
     listen = zc.engine._listen_transport
     with patch.object(_engine, "new_listen_socket") as mock_new_listen:
-        await aiozc_loopback.async_update_interfaces(["127.0.0.1"])
-        await aiozc_loopback.async_update_interfaces([])
+        await aiozc.async_update_interfaces(["127.0.0.1"])
+        await aiozc.async_update_interfaces([])
         await asyncio.sleep(0)
-        await aiozc_loopback.async_update_interfaces(["127.0.0.1"])
+        await aiozc.async_update_interfaces(["127.0.0.1"])
         await asyncio.sleep(0)
     mock_new_listen.assert_not_called()
     assert zc.engine._listen_transport is listen
 
 
 @pytest.mark.asyncio
-async def test_update_interfaces_rebuild_rejoins_kept_interfaces(aiozc_loopback: AsyncZeroconf) -> None:
+async def test_update_interfaces_rebuild_rejoins_kept_interfaces(aiozc: AsyncZeroconf) -> None:
     """On a family-change rebuild, interfaces that stay are re-joined on the new listen socket."""
-    engine = aiozc_loopback.zeroconf.engine
-    await aiozc_loopback.zeroconf.async_wait_for_start()
+    engine = aiozc.zeroconf.engine
+    await aiozc.zeroconf.async_wait_for_start()
 
     # Keep the existing IPv4 interface and add an IPv6 one (which the IPv4
     # listen socket can't join, forcing a rebuild).
@@ -700,11 +700,11 @@ async def test_update_interfaces_rebuild_rejoins_kept_interfaces(aiozc_loopback:
 
 @pytest.mark.asyncio
 async def test_update_interfaces_rebuild_rejoin_failure_warns(
-    aiozc_loopback: AsyncZeroconf, caplog: pytest.LogCaptureFixture
+    aiozc: AsyncZeroconf, caplog: pytest.LogCaptureFixture
 ) -> None:
     """A staying interface that fails to re-join on the rebuilt listen socket warns."""
-    engine = aiozc_loopback.zeroconf.engine
-    await aiozc_loopback.zeroconf.async_wait_for_start()
+    engine = aiozc.zeroconf.engine
+    await aiozc.zeroconf.async_wait_for_start()
     v6 = (("fe80::1", 0, 0), 1)
     new_listen_sock = Mock()
     new_listen_sock.family = socket.AF_INET6
@@ -730,11 +730,11 @@ async def test_update_interfaces_rebuild_rejoin_failure_warns(
 
 @pytest.mark.asyncio
 async def test_update_interfaces_rebuild_failure_is_noop(
-    aiozc_loopback: AsyncZeroconf, caplog: pytest.LogCaptureFixture
+    aiozc: AsyncZeroconf, caplog: pytest.LogCaptureFixture
 ) -> None:
     """If the replacement listen socket can't be created, the rescan logs and no-ops."""
-    engine = aiozc_loopback.zeroconf.engine
-    await aiozc_loopback.zeroconf.async_wait_for_start()
+    engine = aiozc.zeroconf.engine
+    await aiozc.zeroconf.async_wait_for_start()
     old_listen = engine._listen_transport
     before = (list(engine.senders), list(engine.readers))
     with (
@@ -753,11 +753,11 @@ async def test_update_interfaces_rebuild_failure_is_noop(
 
 @pytest.mark.asyncio
 async def test_update_interfaces_default_rebuild_failure_keeps_dual_use(
-    aiozc_loopback: AsyncZeroconf,
+    aiozc: AsyncZeroconf,
 ) -> None:
     """A failed rebuild during a dual-use conversion leaves the dual-use sender intact."""
-    engine = aiozc_loopback.zeroconf.engine
-    await aiozc_loopback.zeroconf.async_wait_for_start()
+    engine = aiozc.zeroconf.engine
+    await aiozc.zeroconf.async_wait_for_start()
     listen = engine._listen_transport
     assert listen is not None
     # Simulate a Default single-family instance: the listen socket is the sole sender.
@@ -777,11 +777,11 @@ async def test_update_interfaces_default_rebuild_failure_keeps_dual_use(
 
 @pytest.mark.asyncio
 async def test_update_interfaces_rebuild_closes_socket_on_wrap_failure(
-    aiozc_loopback: AsyncZeroconf,
+    aiozc: AsyncZeroconf,
 ) -> None:
     """If wrapping the new listen socket fails, it is closed rather than leaked."""
-    engine = aiozc_loopback.zeroconf.engine
-    await aiozc_loopback.zeroconf.async_wait_for_start()
+    engine = aiozc.zeroconf.engine
+    await aiozc.zeroconf.async_wait_for_start()
     old_listen = engine._listen_transport
     new_listen_sock = Mock()
     new_listen_sock.family = socket.AF_INET6
@@ -803,11 +803,11 @@ async def test_update_interfaces_rebuild_closes_socket_on_wrap_failure(
 
 @pytest.mark.asyncio
 async def test_update_interfaces_rebuild_family_matches_desired_set(
-    aiozc_loopback: AsyncZeroconf,
+    aiozc: AsyncZeroconf,
 ) -> None:
     """The rebuilt listen socket's family is derived from the desired set, not ip_version."""
-    engine = aiozc_loopback.zeroconf.engine
-    await aiozc_loopback.zeroconf.async_wait_for_start()
+    engine = aiozc.zeroconf.engine
+    await aiozc.zeroconf.async_wait_for_start()
     new_listen_sock = Mock()
     new_listen_sock.family = socket.AF_INET
 
@@ -834,10 +834,10 @@ async def test_update_interfaces_rebuild_family_matches_desired_set(
 
 
 @pytest.mark.asyncio
-async def test_update_interfaces_rebuilds_real_listen_socket(aiozc_loopback: AsyncZeroconf) -> None:
+async def test_update_interfaces_rebuilds_real_listen_socket(aiozc: AsyncZeroconf) -> None:
     """End to end: a family change builds a real dual-stack listen socket and closes the old one."""
-    engine = aiozc_loopback.zeroconf.engine
-    await aiozc_loopback.zeroconf.async_wait_for_start()
+    engine = aiozc.zeroconf.engine
+    await aiozc.zeroconf.async_wait_for_start()
     old_listen = engine._listen_transport
     assert old_listen is not None
     assert old_listen.sock.family == socket.AF_INET  # V4Only loopback instance
@@ -864,10 +864,10 @@ async def test_update_interfaces_rebuilds_real_listen_socket(aiozc_loopback: Asy
 
 
 @pytest.mark.asyncio
-async def test_close_sender_closes_transport_when_drop_raises(aiozc_loopback: AsyncZeroconf) -> None:
+async def test_close_sender_closes_transport_when_drop_raises(aiozc: AsyncZeroconf) -> None:
     """A non-benign group-leave error still releases the transport."""
-    engine = aiozc_loopback.zeroconf.engine
-    await aiozc_loopback.zeroconf.async_wait_for_start()
+    engine = aiozc.zeroconf.engine
+    await aiozc.zeroconf.async_wait_for_start()
     gone_transport = Mock()
     gone = _make_wrapped(("10.0.0.5", 5353), transport=gone_transport)
     listen_socket = Mock()
@@ -882,23 +882,23 @@ async def test_close_sender_closes_transport_when_drop_raises(aiozc_loopback: As
 
 
 @pytest.mark.asyncio
-async def test_update_interfaces_apple_p2p_non_darwin_raises(aiozc_loopback: AsyncZeroconf) -> None:
+async def test_update_interfaces_apple_p2p_non_darwin_raises(aiozc: AsyncZeroconf) -> None:
     """apple_p2p=True on a non-Apple platform raises, matching __init__."""
-    await aiozc_loopback.zeroconf.async_wait_for_start()
+    await aiozc.zeroconf.async_wait_for_start()
     with (
         patch("zeroconf._core.sys.platform", "linux"),
         pytest.raises(RuntimeError, match="apple_p2p"),
     ):
-        await aiozc_loopback.async_update_interfaces(apple_p2p=True)
+        await aiozc.async_update_interfaces(apple_p2p=True)
 
 
 @pytest.mark.asyncio
-async def test_update_interfaces_copies_interface_list(aiozc_loopback: AsyncZeroconf) -> None:
+async def test_update_interfaces_copies_interface_list(aiozc: AsyncZeroconf) -> None:
     """A mutable interfaces list is copied so later mutation doesn't change retained config."""
-    zc = aiozc_loopback.zeroconf
+    zc = aiozc.zeroconf
     await zc.async_wait_for_start()
     ifaces = ["127.0.0.1"]
-    await aiozc_loopback.async_update_interfaces(ifaces)
+    await aiozc.async_update_interfaces(ifaces)
     ifaces.append("10.0.0.1")
     assert zc._interfaces == ["127.0.0.1"]
 
@@ -931,27 +931,27 @@ async def test_update_interfaces_unicast_has_no_listen_socket() -> None:
 
 
 @pytest.mark.asyncio
-async def test_update_interfaces_serializes_concurrent_calls(aiozc_loopback: AsyncZeroconf) -> None:
+async def test_update_interfaces_serializes_concurrent_calls(aiozc: AsyncZeroconf) -> None:
     """Overlapping rescans are serialized so an interface is not added twice."""
-    zc = aiozc_loopback.zeroconf
+    zc = aiozc.zeroconf
     await zc.async_wait_for_start()
     engine = zc.engine
-    await aiozc_loopback.async_update_interfaces([])
+    await aiozc.async_update_interfaces([])
     await asyncio.sleep(0)
     assert engine.senders == []
 
     await asyncio.gather(
-        aiozc_loopback.async_update_interfaces(["127.0.0.1"]),
-        aiozc_loopback.async_update_interfaces(["127.0.0.1"]),
+        aiozc.async_update_interfaces(["127.0.0.1"]),
+        aiozc.async_update_interfaces(["127.0.0.1"]),
     )
     await asyncio.sleep(0)
     assert len(engine.senders) == 1
 
 
 @pytest.mark.asyncio
-async def test_update_interfaces_keeps_config_on_reconcile_failure(aiozc_loopback: AsyncZeroconf) -> None:
+async def test_update_interfaces_keeps_config_on_reconcile_failure(aiozc: AsyncZeroconf) -> None:
     """A failed engine reconcile leaves the retained interface config unchanged."""
-    zc = aiozc_loopback.zeroconf
+    zc = aiozc.zeroconf
     await zc.async_wait_for_start()
     original_interfaces = zc._interfaces
     original_ip_version = zc._ip_version
@@ -960,15 +960,15 @@ async def test_update_interfaces_keeps_config_on_reconcile_failure(aiozc_loopbac
         patch.object(_engine.AsyncEngine, "async_update_interfaces", new=AsyncMock(side_effect=OSError)),
         pytest.raises(OSError),
     ):
-        await aiozc_loopback.async_update_interfaces(["10.0.0.1"], ip_version=IPVersion.All)
+        await aiozc.async_update_interfaces(["10.0.0.1"], ip_version=IPVersion.All)
 
     assert zc._interfaces == original_interfaces
     assert zc._ip_version == original_ip_version
 
 
-def test_sync_update_interfaces(zc_loopback: Zeroconf) -> None:
+def test_sync_update_interfaces(zc: Zeroconf) -> None:
     """The sync wrapper drives a rescan through the loop without changing a stable set."""
-    engine = zc_loopback.engine
+    engine = zc.engine
     sender_count = len(engine.senders)
-    zc_loopback.update_interfaces(["127.0.0.1"])
+    zc.update_interfaces(["127.0.0.1"])
     assert len(engine.senders) == sender_count


### PR DESCRIPTION
## Summary
Second cleanup pass, unrelated to #1835. #1870 accidentally added a `zc` fixture alongside the pre existing `zc_loopback`; this consolidates to one implementation under the short names `zc` and `aiozc` and renames the call sites. Twelve async tests in test_asyncio adopt the `aiozc` fixture and drop their construct and close boilerplate; the tests whose explicit `async_close` is part of the behavior under test keep it, including the blockbuster xfail group, which silently masks name errors and needed originals restored during the conversion.

## Test plan
- [x] full suite passes, lint clean