### PR TITLE
chore: extend the ordering convention to the remaining large classes

### DIFF
--- a/src/zeroconf/_cache.py
+++ b/src/zeroconf/_cache.py
@@ -61,6 +61,173 @@ class DNSCache:
     # Functions prefixed with async_ are NOT threadsafe and must
     # be run in the event loop.
 
+    def async_add_records(self, entries: Iterable[DNSRecord]) -> bool:
+        """Add multiple records.
+
+        Returns true if any of the records were not in the cache.
+
+        This function must be run in from event loop.
+        """
+        new = False
+        for entry in entries:
+            if self._async_add(entry):
+                new = True
+        return new
+
+    def async_all_by_details(self, name: _str, type_: _int, class_: _int) -> list[DNSRecord]:
+        """Gets all matching entries by details.
+
+        This function is not thread-safe and must be called from
+        the event loop.
+        """
+        key = name.lower()
+        records = self.cache.get(key)
+        matches: list[DNSRecord] = []
+        if records is None:
+            return matches
+        for record in records.values():
+            if type_ == record.type and class_ == record.class_:
+                matches.append(record)
+        return matches
+
+    def async_entries_with_name(self, name: str) -> list[DNSRecord]:
+        """All cached records for a name; event loop only, not threadsafe."""
+        return self.entries_with_name(name)
+
+    def async_entries_with_server(self, name: str) -> list[DNSRecord]:
+        """All cached records for a server name; event loop only, not threadsafe."""
+        return self.entries_with_server(name)
+
+    # The below functions are threadsafe and do not need to be run in the
+    # event loop, however they all make copies so they significantly
+    # inefficient.
+
+    def async_expire(self, now: _float) -> list[DNSRecord]:
+        """Purge expired entries from the cache.
+
+        This function must be run in from event loop.
+
+        :param now: The current time in milliseconds.
+        """
+        if not self._expire_heap:
+            return []
+
+        expired: list[DNSRecord] = []
+        while self._expire_heap:
+            when_record = self._expire_heap[0]
+            when = when_record[0]
+            if when > now:
+                break
+            heappop(self._expire_heap)
+            # Skip entries left behind by a TTL re-add; the live tuple is
+            # later in the heap and will be removed when it reaches the top.
+            record = when_record[1]
+            if self._expirations.get(record) == when:
+                expired.append(record)
+
+        self._maybe_rebuild_heap()
+        self.async_remove_records(expired)
+        return expired
+
+    def async_get_unique(self, entry: _UniqueRecordsType) -> DNSRecord | None:
+        """Look up the cached copy of a unique record, or None.
+
+        Event loop only; not threadsafe.
+        """
+        store = self.cache.get(entry.key)
+        if store is None:
+            return None
+        return store.get(entry)
+
+    def async_mark_unique_records_older_than_1s_to_expire(
+        self,
+        unique_types: set[_UniqueType],
+        answers: Iterable[DNSRecord],
+        now: _float,
+    ) -> None:
+        # rfc6762#section-10.2 para 2
+        # Since unique is set, all old records with that name, rrtype,
+        # and rrclass that were received more than one second ago are declared
+        # invalid, and marked to expire from the cache in one second.
+        answers_rrset = set(answers)
+        for name, type_, class_ in unique_types:
+            for record in self.async_all_by_details(name, type_, class_):
+                created_double = record.created
+                if (now - created_double > _ONE_SECOND) and record not in answers_rrset:
+                    # Expire in 1s
+                    self._async_set_created_ttl(record, now, 1)
+
+    def async_remove_records(self, entries: Iterable[DNSRecord]) -> None:
+        """Remove multiple records.
+
+        This function must be run in from event loop.
+        """
+        for entry in entries:
+            self._async_remove(entry)
+
+    def current_entry_with_name_and_alias(self, name: str, alias: str) -> DNSRecord | None:
+        now = current_time_millis()
+        for record in reversed(self.entries_with_name(name)):
+            if (
+                record.type == _TYPE_PTR
+                and not record.is_expired(now)
+                and cast(DNSPointer, record).alias == alias
+            ):
+                return record
+        return None
+
+    def entries_with_name(self, name: str) -> list[DNSRecord]:
+        if entries := self.cache.get(name.lower()):
+            return list(entries.values())
+        return []
+
+    def entries_with_server(self, server: str) -> list[DNSRecord]:
+        """All cached records whose server field matches."""
+        if entries := self.service_cache.get(server.lower()):
+            return list(entries.values())
+        return []
+
+    def get(self, entry: DNSEntry) -> DNSRecord | None:
+        if isinstance(entry, _UNIQUE_RECORD_TYPES):
+            return self.cache.get(entry.key, {}).get(entry)
+        for cached_entry in reversed(list(self.cache.get(entry.key, {}).values())):
+            if entry.__eq__(cached_entry):
+                return cached_entry
+        return None
+
+    def get_all_by_details(self, name: str, type_: _int, class_: _int) -> list[DNSRecord]:
+        """Gets all matching entries by details."""
+        key = name.lower()
+        records = self.cache.get(key)
+        if records is None:
+            return []
+        return [entry for entry in list(records.values()) if type_ == entry.type and class_ == entry.class_]
+
+    def get_by_details(self, name: str, type_: _int, class_: _int) -> DNSRecord | None:
+        """Gets the first matching entry by details. Returns None if no entries match.
+
+        Calling this function is not recommended as it will only
+        return one record even if there are multiple entries.
+
+        For example if there are multiple A or AAAA addresses this
+        function will return the last one that was added to the cache
+        which may not be the one you expect.
+
+        Use get_all_by_details instead.
+        """
+        key = name.lower()
+        records = self.cache.get(key)
+        if records is None:
+            return None
+        for cached_entry in reversed(list(records.values())):
+            if type_ == cached_entry.type and class_ == cached_entry.class_:
+                return cached_entry
+        return None
+
+    def names(self) -> list[str]:
+        """Return a copy of the list of current cache names."""
+        return list(self.cache)
+
     def _async_add(self, record: _DNSRecord) -> bool:
         """Store a record, returning True when it was not cached before.
 
@@ -118,6 +285,22 @@ class DNSCache:
             self._async_remove(record)
             return
 
+    def _async_remove(self, record: _DNSRecord) -> None:
+        """Drop a record from the cache. Event loop only; not threadsafe."""
+        if isinstance(record, DNSService):
+            service_record = record
+            _remove_key(self.service_cache, service_record.server_key, service_record)
+        _remove_key(self.cache, record.key, record)
+        self._expirations.pop(record, None)
+        self._total_records -= 1
+
+    def _async_set_created_ttl(self, record: DNSRecord, now: _float, ttl: _int) -> None:
+        """Stamp a record with a new ttl and creation moment, then cache it."""
+        # It would be better if we made a copy instead of mutating the record
+        # in place, but records currently don't have a copy method.
+        record._set_created_ttl(now, ttl)
+        self._async_add(record)
+
     def _maybe_rebuild_heap(self) -> None:
         """Rebuild ``_expire_heap`` when stale entries dominate live ones."""
         expire_heap_len = len(self._expire_heap)
@@ -129,186 +312,3 @@ class DNSCache:
                 entry for entry in self._expire_heap if self._expirations.get(entry[1]) == entry[0]
             ]
             heapify(self._expire_heap)
-
-    def async_add_records(self, entries: Iterable[DNSRecord]) -> bool:
-        """Add multiple records.
-
-        Returns true if any of the records were not in the cache.
-
-        This function must be run in from event loop.
-        """
-        new = False
-        for entry in entries:
-            if self._async_add(entry):
-                new = True
-        return new
-
-    def _async_remove(self, record: _DNSRecord) -> None:
-        """Drop a record from the cache. Event loop only; not threadsafe."""
-        if isinstance(record, DNSService):
-            service_record = record
-            _remove_key(self.service_cache, service_record.server_key, service_record)
-        _remove_key(self.cache, record.key, record)
-        self._expirations.pop(record, None)
-        self._total_records -= 1
-
-    def async_remove_records(self, entries: Iterable[DNSRecord]) -> None:
-        """Remove multiple records.
-
-        This function must be run in from event loop.
-        """
-        for entry in entries:
-            self._async_remove(entry)
-
-    def async_expire(self, now: _float) -> list[DNSRecord]:
-        """Purge expired entries from the cache.
-
-        This function must be run in from event loop.
-
-        :param now: The current time in milliseconds.
-        """
-        if not self._expire_heap:
-            return []
-
-        expired: list[DNSRecord] = []
-        while self._expire_heap:
-            when_record = self._expire_heap[0]
-            when = when_record[0]
-            if when > now:
-                break
-            heappop(self._expire_heap)
-            # Skip entries left behind by a TTL re-add; the live tuple is
-            # later in the heap and will be removed when it reaches the top.
-            record = when_record[1]
-            if self._expirations.get(record) == when:
-                expired.append(record)
-
-        self._maybe_rebuild_heap()
-        self.async_remove_records(expired)
-        return expired
-
-    def async_get_unique(self, entry: _UniqueRecordsType) -> DNSRecord | None:
-        """Look up the cached copy of a unique record, or None.
-
-        Event loop only; not threadsafe.
-        """
-        store = self.cache.get(entry.key)
-        if store is None:
-            return None
-        return store.get(entry)
-
-    def async_all_by_details(self, name: _str, type_: _int, class_: _int) -> list[DNSRecord]:
-        """Gets all matching entries by details.
-
-        This function is not thread-safe and must be called from
-        the event loop.
-        """
-        key = name.lower()
-        records = self.cache.get(key)
-        matches: list[DNSRecord] = []
-        if records is None:
-            return matches
-        for record in records.values():
-            if type_ == record.type and class_ == record.class_:
-                matches.append(record)
-        return matches
-
-    def async_entries_with_name(self, name: str) -> list[DNSRecord]:
-        """All cached records for a name; event loop only, not threadsafe."""
-        return self.entries_with_name(name)
-
-    def async_entries_with_server(self, name: str) -> list[DNSRecord]:
-        """All cached records for a server name; event loop only, not threadsafe."""
-        return self.entries_with_server(name)
-
-    # The below functions are threadsafe and do not need to be run in the
-    # event loop, however they all make copies so they significantly
-    # inefficient.
-
-    def get(self, entry: DNSEntry) -> DNSRecord | None:
-        if isinstance(entry, _UNIQUE_RECORD_TYPES):
-            return self.cache.get(entry.key, {}).get(entry)
-        for cached_entry in reversed(list(self.cache.get(entry.key, {}).values())):
-            if entry.__eq__(cached_entry):
-                return cached_entry
-        return None
-
-    def get_by_details(self, name: str, type_: _int, class_: _int) -> DNSRecord | None:
-        """Gets the first matching entry by details. Returns None if no entries match.
-
-        Calling this function is not recommended as it will only
-        return one record even if there are multiple entries.
-
-        For example if there are multiple A or AAAA addresses this
-        function will return the last one that was added to the cache
-        which may not be the one you expect.
-
-        Use get_all_by_details instead.
-        """
-        key = name.lower()
-        records = self.cache.get(key)
-        if records is None:
-            return None
-        for cached_entry in reversed(list(records.values())):
-            if type_ == cached_entry.type and class_ == cached_entry.class_:
-                return cached_entry
-        return None
-
-    def get_all_by_details(self, name: str, type_: _int, class_: _int) -> list[DNSRecord]:
-        """Gets all matching entries by details."""
-        key = name.lower()
-        records = self.cache.get(key)
-        if records is None:
-            return []
-        return [entry for entry in list(records.values()) if type_ == entry.type and class_ == entry.class_]
-
-    def entries_with_server(self, server: str) -> list[DNSRecord]:
-        """All cached records whose server field matches."""
-        if entries := self.service_cache.get(server.lower()):
-            return list(entries.values())
-        return []
-
-    def entries_with_name(self, name: str) -> list[DNSRecord]:
-        if entries := self.cache.get(name.lower()):
-            return list(entries.values())
-        return []
-
-    def current_entry_with_name_and_alias(self, name: str, alias: str) -> DNSRecord | None:
-        now = current_time_millis()
-        for record in reversed(self.entries_with_name(name)):
-            if (
-                record.type == _TYPE_PTR
-                and not record.is_expired(now)
-                and cast(DNSPointer, record).alias == alias
-            ):
-                return record
-        return None
-
-    def names(self) -> list[str]:
-        """Return a copy of the list of current cache names."""
-        return list(self.cache)
-
-    def async_mark_unique_records_older_than_1s_to_expire(
-        self,
-        unique_types: set[_UniqueType],
-        answers: Iterable[DNSRecord],
-        now: _float,
-    ) -> None:
-        # rfc6762#section-10.2 para 2
-        # Since unique is set, all old records with that name, rrtype,
-        # and rrclass that were received more than one second ago are declared
-        # invalid, and marked to expire from the cache in one second.
-        answers_rrset = set(answers)
-        for name, type_, class_ in unique_types:
-            for record in self.async_all_by_details(name, type_, class_):
-                created_double = record.created
-                if (now - created_double > _ONE_SECOND) and record not in answers_rrset:
-                    # Expire in 1s
-                    self._async_set_created_ttl(record, now, 1)
-
-    def _async_set_created_ttl(self, record: DNSRecord, now: _float, ttl: _int) -> None:
-        """Stamp a record with a new ttl and creation moment, then cache it."""
-        # It would be better if we made a copy instead of mutating the record
-        # in place, but records currently don't have a copy method.
-        record._set_created_ttl(now, ttl)
-        self._async_add(record)

--- a/src/zeroconf/_core.py
+++ b/src/zeroconf/_core.py
@@ -210,132 +210,105 @@ class Zeroconf(QuietLogger):
 
         self.start()
 
-    @property
-    def started(self) -> bool:
-        """Check if the instance has started."""
-        running_future = self.engine.running_future
-        return bool(
-            not self.done
-            and running_future
-            and running_future.done()
-            and not running_future.cancelled()
-            and not running_future.exception()
-            and running_future.result()
-        )
+    def __enter__(self) -> Zeroconf:
+        return self
 
-    def start(self) -> None:
-        """Start Zeroconf."""
-        self.loop = None if self._use_asyncio is False else get_running_loop()
-        if self.loop:
-            self.engine.setup(self.loop, None)
-            return
-        self._start_thread()
-
-    def _start_thread(self) -> None:
-        """Start a thread with a running event loop."""
-        loop_thread_ready = threading.Event()
-
-        def _run_loop() -> None:
-            self.loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(self.loop)
-            self.engine.setup(self.loop, loop_thread_ready)
-            self.loop.run_forever()
-
-        self._loop_thread = threading.Thread(target=_run_loop, daemon=True)
-        self._loop_thread.start()
-        loop_thread_ready.wait()
-
-    async def async_wait_for_start(self, timeout: float = _STARTUP_TIMEOUT) -> None:
-        """Wait for start up for actions that require a running Zeroconf instance.
-
-        Throws NotRunningException if the instance is not running or could
-        not be started.
-        """
-        if self.done:  # If the instance was shutdown from under us, raise immediately
-            raise NotRunningException
-        assert self.engine.running_future is not None
-        await wait_future_or_timeout(self.engine.running_future, timeout=timeout)
-        if not self.started:
-            raise NotRunningException
-
-    @property
-    def listeners(self) -> set[RecordUpdateListener]:
-        return self.record_manager.listeners
-
-    async def async_wait(self, timeout: float) -> None:
-        """Suspend the calling task for timeout milliseconds, or less when notified."""
-        loop = self.loop
-        assert loop is not None
-        await wait_for_future_set_or_timeout(loop, self._notify_futures, timeout)
-
-    def notify_all(self) -> None:
-        """Wake every waiter and fire the listeners, from any thread."""
-        assert self.loop is not None
-        self.loop.call_soon_threadsafe(self.async_notify_all)
-
-    def async_notify_all(self) -> None:
-        """Schedule an async_notify_all."""
-        notify_futures = self._notify_futures
-        if notify_futures:
-            _resolve_all_futures_to_none(notify_futures)
-
-    def get_service_info(
+    def __exit__(  # pylint: disable=useless-return
         self,
-        type_: str,
-        name: str,
-        timeout: int = 3000,
-        question_type: DNSQuestionType | None = None,
-    ) -> ServiceInfo | None:
-        """Look up details for a service on the network.
-
-        Queries for the given fully qualified type and name, waiting up to
-        timeout milliseconds, and returns a populated ServiceInfo or None
-        when nothing answered in time. question_type forces QM or QU
-        questions instead of the automatic choice.
-        """
-        info = ServiceInfo(type_, name)
-        if info.request(self, timeout, question_type):
-            return info
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> bool | None:
+        self.close()
         return None
+
+    def add_listener(
+        self,
+        listener: RecordUpdateListener,
+        question: DNSQuestion | list[DNSQuestion] | None,
+    ) -> None:
+        """Subscribe a record update listener, optionally scoped to questions; threadsafe."""
+        assert self.loop is not None
+        self.loop.call_soon_threadsafe(self.record_manager.async_add_listener, listener, question)
 
     def add_service_listener(self, type_: str, listener: ServiceListener) -> None:
         """Browse for a type and deliver add, remove, and update callbacks to the listener."""
         self.remove_service_listener(listener)
         self.browsers[listener] = ServiceBrowser(self, type_, listener)
 
-    def remove_service_listener(self, listener: ServiceListener) -> None:
-        """Stop the browser behind the given listener."""
-        if listener in self.browsers:
-            self.browsers[listener].cancel()
-            del self.browsers[listener]
+    def async_add_listener(
+        self,
+        listener: RecordUpdateListener,
+        question: DNSQuestion | list[DNSQuestion] | None,
+    ) -> None:
+        """Subscribe a record update listener, optionally scoped to questions; event loop only."""
+        self.record_manager.async_add_listener(listener, question)
 
-    def remove_all_service_listeners(self) -> None:
-        """Stop the browsers behind every registered listener."""
-        for listener in list(self.browsers):
-            self.remove_service_listener(listener)
-
-    def register_service(
+    async def async_check_service(
         self,
         info: ServiceInfo,
-        ttl: int | None = None,
-        allow_name_change: bool = False,
+        allow_name_change: bool,
         cooperating_responders: bool = False,
         strict: bool = True,
     ) -> None:
-        """Announce a service on the network.
+        """Probe the network for name uniqueness, renaming first when allowed."""
+        instance_name = instance_name_from_service_info(info, strict=strict)
+        if cooperating_responders:
+            return
 
-        Probes for conflicts first; with allow_name_change the instance
-        name is renamed until it is unique. May raise EventLoopBlocked
-        when the event loop cannot complete the registration in time.
+        # Wait a random amount of time up avoid collisions and avoid
+        # a thundering herd when multiple services are started on the network
+        await self.async_wait(random.randint(*_PROBE_RANDOM_DELAY_INTERVAL))  # noqa: S311
+
+        next_instance_number = 2
+        next_time = now = current_time_millis()
+        i = 0
+        while i < _REGISTER_BROADCASTS:
+            # check for a name conflict
+            while self.cache.current_entry_with_name_and_alias(info.type, info.name):
+                if not allow_name_change:
+                    raise NonUniqueNameException
+
+                # change the name and look for a conflict
+                info.name = f"{instance_name}-{next_instance_number}.{info.type}"
+                next_instance_number += 1
+                service_type_name(info.name, strict=strict)
+                next_time = now
+                i = 0
+
+            if now < next_time:
+                await self.async_wait(next_time - now)
+                now = current_time_millis()
+                continue
+
+            self.async_send(self.generate_service_query(info))
+            i += 1
+            next_time += _CHECK_TIME
+
+    async def async_get_service_info(
+        self,
+        type_: str,
+        name: str,
+        timeout: int = 3000,
+        question_type: DNSQuestionType | None = None,
+    ) -> AsyncServiceInfo | None:
+        """Look up details for a service on the network from the event loop.
+
+        Queries for the given fully qualified type and name, waiting up to
+        timeout milliseconds, and returns a populated AsyncServiceInfo or
+        None when nothing answered in time. question_type forces QM or QU
+        questions instead of the automatic choice.
         """
-        assert self.loop is not None
-        run_coro_with_timeout(
-            await_awaitable(
-                self.async_register_service(info, ttl, allow_name_change, cooperating_responders, strict)
-            ),
-            self.loop,
-            _REGISTER_TIME * _REGISTER_BROADCASTS,
-        )
+        info = AsyncServiceInfo(type_, name)
+        if await info.async_request(self, timeout, question_type):
+            return info
+        return None
+
+    def async_notify_all(self) -> None:
+        """Schedule an async_notify_all."""
+        notify_futures = self._notify_futures
+        if notify_futures:
+            _resolve_all_futures_to_none(notify_futures)
 
     async def async_register_service(
         self,
@@ -363,49 +336,75 @@ class Zeroconf(QuietLogger):
         self.registry.async_add(info)
         return asyncio.ensure_future(self._async_broadcast_service(info, _REGISTER_TIME, None))
 
-    def update_service(self, info: ServiceInfo) -> None:
-        """Publish updated records for an already registered service.
+    def async_remove_listener(self, listener: RecordUpdateListener) -> None:
+        """Detach a record listener; event loop only, not threadsafe."""
+        self.record_manager.async_remove_listener(listener)
 
-        May raise EventLoopBlocked when the event loop cannot complete
-        the update in time.
-        """
-        assert self.loop is not None
-        run_coro_with_timeout(
-            await_awaitable(self.async_update_service(info)),
-            self.loop,
-            _REGISTER_TIME * _REGISTER_BROADCASTS,
-        )
-
-    async def async_update_service(self, info: ServiceInfo) -> Awaitable:
-        """Publish updated records for an already registered service.
-
-        Returns an awaitable that completes once the rebroadcasts finish.
-        """
-        self.registry.async_update(info)
-        return asyncio.ensure_future(self._async_broadcast_service(info, _REGISTER_TIME, None))
-
-    def update_interfaces(
+    def async_send(
         self,
-        interfaces: InterfacesType | None = None,
-        ip_version: IPVersion | None = None,
-        apple_p2p: bool | None = None,
+        out: DNSOutgoing,
+        addr: str | None = None,
+        port: int = _MDNS_PORT,
+        v6_flow_scope: tuple[()] | tuple[int, int] = (),
+        transport: _WrappedTransport | None = None,
     ) -> None:
-        """Rescan network interfaces and reconcile the sockets in use.
+        """Transmit a packet from the event loop."""
+        if self.done:
+            return
 
-        While it is not expected during normal operation,
-        this function may raise EventLoopBlocked if the underlying
-        call to `async_update_interfaces` cannot be completed. Raises
-        RuntimeError if apple_p2p is set on a non-Apple platform.
+        # If no transport is specified, we send to all the ones
+        # with the same address family
+        transports = [transport] if transport else self.engine.senders
+        log_debug = log.isEnabledFor(logging.DEBUG)
+
+        for packet_num, packet in enumerate(out.packets()):
+            if len(packet) > _MAX_MSG_ABSOLUTE:
+                self.log_warning_once(
+                    "Dropping %r over-sized packet (%d bytes) %r",
+                    out,
+                    len(packet),
+                    packet,
+                )
+                return
+            for send_transport in transports:
+                async_send_with_transport(
+                    log_debug,
+                    send_transport,
+                    packet,
+                    packet_num,
+                    out,
+                    addr,
+                    port,
+                    v6_flow_scope,
+                )
+
+    async def async_unregister_all_services(self) -> None:
+        """Send goodbye packets for every registered service and drop them all.
+
+        Runs only at shutdown, so unlike the single service calls it
+        returns nothing to await separately.
         """
-        assert self.loop is not None
-        # Unlike register/update, the re-announce is awaited inline (to log
-        # per-service failures), so the budget must cover the full announce
-        # window ((_REGISTER_BROADCASTS - 1) * _REGISTER_TIME) plus the reconcile
-        # and wait-for-start overhead; double the register budget for headroom.
-        run_coro_with_timeout(
-            self.async_update_interfaces(interfaces, ip_version, apple_p2p),
-            self.loop,
-            _REGISTER_TIME * _REGISTER_BROADCASTS * 2,
+        # Send Goodbye packets https://datatracker.ietf.org/doc/html/rfc6762#section-10.1
+        out = self.generate_unregister_all_services()
+        if not out:
+            return
+        for i in range(_REGISTER_BROADCASTS):
+            if i != 0:
+                await asyncio.sleep(millis_to_seconds(_UNREGISTER_TIME))
+            self.async_send(out)
+
+    async def async_unregister_service(self, info: ServiceInfo) -> Awaitable:
+        """Withdraw a service from the event loop, broadcasting goodbyes."""
+        info.set_server_if_missing()
+        self.registry.async_remove(info)
+        # If another server uses the same addresses, we do not want to send
+        # goodbye packets for the address records
+
+        assert info.server_key is not None
+        entries = self.registry.async_get_infos_server(info.server_key)
+        broadcast_addresses = not bool(entries)
+        return asyncio.ensure_future(
+            self._async_broadcast_service(info, _UNREGISTER_TIME, 0, broadcast_addresses)
         )
 
     async def async_update_interfaces(
@@ -469,37 +468,46 @@ class Zeroconf(QuietLogger):
                 # such as CancelledError; don't swallow a cancellation/interrupt.
                 raise result
 
-    async def async_get_service_info(
-        self,
-        type_: str,
-        name: str,
-        timeout: int = 3000,
-        question_type: DNSQuestionType | None = None,
-    ) -> AsyncServiceInfo | None:
-        """Look up details for a service on the network from the event loop.
+    async def async_update_service(self, info: ServiceInfo) -> Awaitable:
+        """Publish updated records for an already registered service.
 
-        Queries for the given fully qualified type and name, waiting up to
-        timeout milliseconds, and returns a populated AsyncServiceInfo or
-        None when nothing answered in time. question_type forces QM or QU
-        questions instead of the automatic choice.
+        Returns an awaitable that completes once the rebroadcasts finish.
         """
-        info = AsyncServiceInfo(type_, name)
-        if await info.async_request(self, timeout, question_type):
-            return info
-        return None
+        self.registry.async_update(info)
+        return asyncio.ensure_future(self._async_broadcast_service(info, _REGISTER_TIME, None))
 
-    async def _async_broadcast_service(
-        self,
-        info: ServiceInfo,
-        interval: int,
-        ttl: int | None,
-        broadcast_addresses: bool = True,
-    ) -> None:
-        """Send a broadcasts to announce a service at intervals."""
-        for i in range(_REGISTER_BROADCASTS):
-            if i != 0:
-                await asyncio.sleep(millis_to_seconds(interval))
-            self.async_send(self.generate_service_broadcast(info, ttl, broadcast_addresses))
+    async def async_wait(self, timeout: float) -> None:
+        """Suspend the calling task for timeout milliseconds, or less when notified."""
+        loop = self.loop
+        assert loop is not None
+        await wait_for_future_set_or_timeout(loop, self._notify_futures, timeout)
+
+    async def async_wait_for_start(self, timeout: float = _STARTUP_TIMEOUT) -> None:
+        """Wait for start up for actions that require a running Zeroconf instance.
+
+        Throws NotRunningException if the instance is not running or could
+        not be started.
+        """
+        if self.done:  # If the instance was shutdown from under us, raise immediately
+            raise NotRunningException
+        assert self.engine.running_future is not None
+        await wait_future_or_timeout(self.engine.running_future, timeout=timeout)
+        if not self.started:
+            raise NotRunningException
+
+    def close(self) -> None:
+        """Shut down the sockets and engine for good; safe to call repeatedly."""
+        assert self.loop is not None
+        if self.loop.is_running():
+            if self.loop == get_running_loop():
+                log.warning(
+                    "unregister_all_services skipped as it does blocking i/o; use AsyncZeroconf with asyncio"
+                )
+            else:
+                self.unregister_all_services()
+        self._close()
+        self.engine.close()
+        self._shutdown_threads()
 
     def generate_service_broadcast(
         self,
@@ -527,6 +535,180 @@ class Zeroconf(QuietLogger):
         out.add_authorative_answer(info.dns_pointer())
         return out
 
+    def generate_unregister_all_services(self) -> DNSOutgoing | None:
+        """Generate a DNSOutgoing goodbye for all services and remove them from the registry."""
+        service_infos = self.registry.async_get_service_infos()
+        if not service_infos:
+            return None
+        out = DNSOutgoing(_FLAGS_QR_RESPONSE | _FLAGS_AA)
+        for info in service_infos:
+            self._add_broadcast_answer(out, info, 0)
+        self.registry.async_remove(service_infos)
+        return out
+
+    def get_service_info(
+        self,
+        type_: str,
+        name: str,
+        timeout: int = 3000,
+        question_type: DNSQuestionType | None = None,
+    ) -> ServiceInfo | None:
+        """Look up details for a service on the network.
+
+        Queries for the given fully qualified type and name, waiting up to
+        timeout milliseconds, and returns a populated ServiceInfo or None
+        when nothing answered in time. question_type forces QM or QU
+        questions instead of the automatic choice.
+        """
+        info = ServiceInfo(type_, name)
+        if info.request(self, timeout, question_type):
+            return info
+        return None
+
+    @property
+    def listeners(self) -> set[RecordUpdateListener]:
+        return self.record_manager.listeners
+
+    def notify_all(self) -> None:
+        """Wake every waiter and fire the listeners, from any thread."""
+        assert self.loop is not None
+        self.loop.call_soon_threadsafe(self.async_notify_all)
+
+    def register_service(
+        self,
+        info: ServiceInfo,
+        ttl: int | None = None,
+        allow_name_change: bool = False,
+        cooperating_responders: bool = False,
+        strict: bool = True,
+    ) -> None:
+        """Announce a service on the network.
+
+        Probes for conflicts first; with allow_name_change the instance
+        name is renamed until it is unique. May raise EventLoopBlocked
+        when the event loop cannot complete the registration in time.
+        """
+        assert self.loop is not None
+        run_coro_with_timeout(
+            await_awaitable(
+                self.async_register_service(info, ttl, allow_name_change, cooperating_responders, strict)
+            ),
+            self.loop,
+            _REGISTER_TIME * _REGISTER_BROADCASTS,
+        )
+
+    def remove_all_service_listeners(self) -> None:
+        """Stop the browsers behind every registered listener."""
+        for listener in list(self.browsers):
+            self.remove_service_listener(listener)
+
+    def remove_listener(self, listener: RecordUpdateListener) -> None:
+        """Detach a record listener from any thread."""
+        assert self.loop is not None
+        self.loop.call_soon_threadsafe(self.record_manager.async_remove_listener, listener)
+
+    def remove_service_listener(self, listener: ServiceListener) -> None:
+        """Stop the browser behind the given listener."""
+        if listener in self.browsers:
+            self.browsers[listener].cancel()
+            del self.browsers[listener]
+
+    def send(
+        self,
+        out: DNSOutgoing,
+        addr: str | None = None,
+        port: int = _MDNS_PORT,
+        v6_flow_scope: tuple[()] | tuple[int, int] = (),
+        transport: _WrappedTransport | None = None,
+    ) -> None:
+        """Queue a packet for transmission from any thread."""
+        assert self.loop is not None
+        self.loop.call_soon_threadsafe(self.async_send, out, addr, port, v6_flow_scope, transport)
+
+    def start(self) -> None:
+        """Start Zeroconf."""
+        self.loop = None if self._use_asyncio is False else get_running_loop()
+        if self.loop:
+            self.engine.setup(self.loop, None)
+            return
+        self._start_thread()
+
+    @property
+    def started(self) -> bool:
+        """Check if the instance has started."""
+        running_future = self.engine.running_future
+        return bool(
+            not self.done
+            and running_future
+            and running_future.done()
+            and not running_future.cancelled()
+            and not running_future.exception()
+            and running_future.result()
+        )
+
+    def unregister_all_services(self) -> None:
+        """Send goodbye packets for every registered service and drop them all.
+
+        May raise EventLoopBlocked when the event loop cannot finish the
+        shutdown broadcasts in time.
+        """
+        assert self.loop is not None
+        run_coro_with_timeout(
+            self.async_unregister_all_services(),
+            self.loop,
+            _UNREGISTER_TIME * _REGISTER_BROADCASTS,
+        )
+
+    def unregister_service(self, info: ServiceInfo) -> None:
+        """Withdraw a service by broadcasting goodbye records.
+
+        May raise EventLoopBlocked when the event loop cannot finish the
+        withdrawal in time.
+        """
+        assert self.loop is not None
+        run_coro_with_timeout(
+            self.async_unregister_service(info),
+            self.loop,
+            _UNREGISTER_TIME * _REGISTER_BROADCASTS,
+        )
+
+    def update_interfaces(
+        self,
+        interfaces: InterfacesType | None = None,
+        ip_version: IPVersion | None = None,
+        apple_p2p: bool | None = None,
+    ) -> None:
+        """Rescan network interfaces and reconcile the sockets in use.
+
+        While it is not expected during normal operation,
+        this function may raise EventLoopBlocked if the underlying
+        call to `async_update_interfaces` cannot be completed. Raises
+        RuntimeError if apple_p2p is set on a non-Apple platform.
+        """
+        assert self.loop is not None
+        # Unlike register/update, the re-announce is awaited inline (to log
+        # per-service failures), so the budget must cover the full announce
+        # window ((_REGISTER_BROADCASTS - 1) * _REGISTER_TIME) plus the reconcile
+        # and wait-for-start overhead; double the register budget for headroom.
+        run_coro_with_timeout(
+            self.async_update_interfaces(interfaces, ip_version, apple_p2p),
+            self.loop,
+            _REGISTER_TIME * _REGISTER_BROADCASTS * 2,
+        )
+
+    def update_service(self, info: ServiceInfo) -> None:
+        """Publish updated records for an already registered service.
+
+        May raise EventLoopBlocked when the event loop cannot complete
+        the update in time.
+        """
+        assert self.loop is not None
+        run_coro_with_timeout(
+            await_awaitable(self.async_update_service(info)),
+            self.loop,
+            _REGISTER_TIME * _REGISTER_BROADCASTS,
+        )
+
     def _add_broadcast_answer(  # pylint: disable=no-self-use
         self,
         out: DNSOutgoing,
@@ -545,188 +727,24 @@ class Zeroconf(QuietLogger):
             for record in info.get_address_and_nsec_records(override_ttl=host_ttl):
                 out.add_answer_at_time(record, 0)
 
-    def unregister_service(self, info: ServiceInfo) -> None:
-        """Withdraw a service by broadcasting goodbye records.
-
-        May raise EventLoopBlocked when the event loop cannot finish the
-        withdrawal in time.
-        """
-        assert self.loop is not None
-        run_coro_with_timeout(
-            self.async_unregister_service(info),
-            self.loop,
-            _UNREGISTER_TIME * _REGISTER_BROADCASTS,
-        )
-
-    async def async_unregister_service(self, info: ServiceInfo) -> Awaitable:
-        """Withdraw a service from the event loop, broadcasting goodbyes."""
-        info.set_server_if_missing()
-        self.registry.async_remove(info)
-        # If another server uses the same addresses, we do not want to send
-        # goodbye packets for the address records
-
-        assert info.server_key is not None
-        entries = self.registry.async_get_infos_server(info.server_key)
-        broadcast_addresses = not bool(entries)
-        return asyncio.ensure_future(
-            self._async_broadcast_service(info, _UNREGISTER_TIME, 0, broadcast_addresses)
-        )
-
-    def generate_unregister_all_services(self) -> DNSOutgoing | None:
-        """Generate a DNSOutgoing goodbye for all services and remove them from the registry."""
-        service_infos = self.registry.async_get_service_infos()
-        if not service_infos:
-            return None
-        out = DNSOutgoing(_FLAGS_QR_RESPONSE | _FLAGS_AA)
-        for info in service_infos:
-            self._add_broadcast_answer(out, info, 0)
-        self.registry.async_remove(service_infos)
-        return out
-
-    async def async_unregister_all_services(self) -> None:
-        """Send goodbye packets for every registered service and drop them all.
-
-        Runs only at shutdown, so unlike the single service calls it
-        returns nothing to await separately.
-        """
-        # Send Goodbye packets https://datatracker.ietf.org/doc/html/rfc6762#section-10.1
-        out = self.generate_unregister_all_services()
-        if not out:
-            return
-        for i in range(_REGISTER_BROADCASTS):
-            if i != 0:
-                await asyncio.sleep(millis_to_seconds(_UNREGISTER_TIME))
-            self.async_send(out)
-
-    def unregister_all_services(self) -> None:
-        """Send goodbye packets for every registered service and drop them all.
-
-        May raise EventLoopBlocked when the event loop cannot finish the
-        shutdown broadcasts in time.
-        """
-        assert self.loop is not None
-        run_coro_with_timeout(
-            self.async_unregister_all_services(),
-            self.loop,
-            _UNREGISTER_TIME * _REGISTER_BROADCASTS,
-        )
-
-    async def async_check_service(
+    async def _async_broadcast_service(
         self,
         info: ServiceInfo,
-        allow_name_change: bool,
-        cooperating_responders: bool = False,
-        strict: bool = True,
+        interval: int,
+        ttl: int | None,
+        broadcast_addresses: bool = True,
     ) -> None:
-        """Probe the network for name uniqueness, renaming first when allowed."""
-        instance_name = instance_name_from_service_info(info, strict=strict)
-        if cooperating_responders:
-            return
+        """Send a broadcasts to announce a service at intervals."""
+        for i in range(_REGISTER_BROADCASTS):
+            if i != 0:
+                await asyncio.sleep(millis_to_seconds(interval))
+            self.async_send(self.generate_service_broadcast(info, ttl, broadcast_addresses))
 
-        # Wait a random amount of time up avoid collisions and avoid
-        # a thundering herd when multiple services are started on the network
-        await self.async_wait(random.randint(*_PROBE_RANDOM_DELAY_INTERVAL))  # noqa: S311
-
-        next_instance_number = 2
-        next_time = now = current_time_millis()
-        i = 0
-        while i < _REGISTER_BROADCASTS:
-            # check for a name conflict
-            while self.cache.current_entry_with_name_and_alias(info.type, info.name):
-                if not allow_name_change:
-                    raise NonUniqueNameException
-
-                # change the name and look for a conflict
-                info.name = f"{instance_name}-{next_instance_number}.{info.type}"
-                next_instance_number += 1
-                service_type_name(info.name, strict=strict)
-                next_time = now
-                i = 0
-
-            if now < next_time:
-                await self.async_wait(next_time - now)
-                now = current_time_millis()
-                continue
-
-            self.async_send(self.generate_service_query(info))
-            i += 1
-            next_time += _CHECK_TIME
-
-    def add_listener(
-        self,
-        listener: RecordUpdateListener,
-        question: DNSQuestion | list[DNSQuestion] | None,
-    ) -> None:
-        """Subscribe a record update listener, optionally scoped to questions; threadsafe."""
-        assert self.loop is not None
-        self.loop.call_soon_threadsafe(self.record_manager.async_add_listener, listener, question)
-
-    def remove_listener(self, listener: RecordUpdateListener) -> None:
-        """Detach a record listener from any thread."""
-        assert self.loop is not None
-        self.loop.call_soon_threadsafe(self.record_manager.async_remove_listener, listener)
-
-    def async_add_listener(
-        self,
-        listener: RecordUpdateListener,
-        question: DNSQuestion | list[DNSQuestion] | None,
-    ) -> None:
-        """Subscribe a record update listener, optionally scoped to questions; event loop only."""
-        self.record_manager.async_add_listener(listener, question)
-
-    def async_remove_listener(self, listener: RecordUpdateListener) -> None:
-        """Detach a record listener; event loop only, not threadsafe."""
-        self.record_manager.async_remove_listener(listener)
-
-    def send(
-        self,
-        out: DNSOutgoing,
-        addr: str | None = None,
-        port: int = _MDNS_PORT,
-        v6_flow_scope: tuple[()] | tuple[int, int] = (),
-        transport: _WrappedTransport | None = None,
-    ) -> None:
-        """Queue a packet for transmission from any thread."""
-        assert self.loop is not None
-        self.loop.call_soon_threadsafe(self.async_send, out, addr, port, v6_flow_scope, transport)
-
-    def async_send(
-        self,
-        out: DNSOutgoing,
-        addr: str | None = None,
-        port: int = _MDNS_PORT,
-        v6_flow_scope: tuple[()] | tuple[int, int] = (),
-        transport: _WrappedTransport | None = None,
-    ) -> None:
-        """Transmit a packet from the event loop."""
-        if self.done:
-            return
-
-        # If no transport is specified, we send to all the ones
-        # with the same address family
-        transports = [transport] if transport else self.engine.senders
-        log_debug = log.isEnabledFor(logging.DEBUG)
-
-        for packet_num, packet in enumerate(out.packets()):
-            if len(packet) > _MAX_MSG_ABSOLUTE:
-                self.log_warning_once(
-                    "Dropping %r over-sized packet (%d bytes) %r",
-                    out,
-                    len(packet),
-                    packet,
-                )
-                return
-            for send_transport in transports:
-                async_send_with_transport(
-                    log_debug,
-                    send_transport,
-                    packet,
-                    packet_num,
-                    out,
-                    addr,
-                    port,
-                    v6_flow_scope,
-                )
+    async def _async_close(self) -> None:
+        """Shut down for AsyncZeroconf; callers unregister services first."""
+        self._close()
+        await self.engine._async_close()  # pylint: disable=protected-access
+        self._shutdown_threads()
 
     def _close(self) -> None:
         """Set global done and remove all service listeners."""
@@ -754,34 +772,16 @@ class Zeroconf(QuietLogger):
         # those file descriptors across Zeroconf() construct/close cycles.
         self.loop.close()
 
-    def close(self) -> None:
-        """Shut down the sockets and engine for good; safe to call repeatedly."""
-        assert self.loop is not None
-        if self.loop.is_running():
-            if self.loop == get_running_loop():
-                log.warning(
-                    "unregister_all_services skipped as it does blocking i/o; use AsyncZeroconf with asyncio"
-                )
-            else:
-                self.unregister_all_services()
-        self._close()
-        self.engine.close()
-        self._shutdown_threads()
+    def _start_thread(self) -> None:
+        """Start a thread with a running event loop."""
+        loop_thread_ready = threading.Event()
 
-    async def _async_close(self) -> None:
-        """Shut down for AsyncZeroconf; callers unregister services first."""
-        self._close()
-        await self.engine._async_close()  # pylint: disable=protected-access
-        self._shutdown_threads()
+        def _run_loop() -> None:
+            self.loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(self.loop)
+            self.engine.setup(self.loop, loop_thread_ready)
+            self.loop.run_forever()
 
-    def __enter__(self) -> Zeroconf:
-        return self
-
-    def __exit__(  # pylint: disable=useless-return
-        self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
-    ) -> bool | None:
-        self.close()
-        return None
+        self._loop_thread = threading.Thread(target=_run_loop, daemon=True)
+        self._loop_thread.start()
+        loop_thread_ready.wait()

--- a/src/zeroconf/_protocol/incoming.py
+++ b/src/zeroconf/_protocol/incoming.py
@@ -122,6 +122,45 @@ class DNSIncoming:
         # cannot survive pickling.
         raise TypeError(f"cannot pickle {type(self).__name__!r} object")
 
+    def __repr__(self) -> str:
+        return "<DNSIncoming:{}>".format(
+            ", ".join(
+                [
+                    f"id={self.id}",
+                    f"flags={self.flags}",
+                    f"truncated={self.truncated}",
+                    f"n_q={self._num_questions}",
+                    f"n_ans={self._num_answers}",
+                    f"n_auth={self._num_authorities}",
+                    f"n_add={self._num_additionals}",
+                    f"questions={self._questions}",
+                    f"answers={self.answers()}",
+                ]
+            )
+        )
+
+    def answers(self) -> list[DNSRecord]:
+        """Answers in the packet."""
+        if not self._did_read_others:
+            try:
+                self._read_others()
+            except DECODE_EXCEPTIONS:
+                self._log_exception_debug(
+                    "Received invalid packet from %s at offset %d while unpacking %r",
+                    self.source,
+                    self.offset,
+                    self.data,
+                )
+        return self._answers
+
+    def has_qu_question(self) -> bool:
+        """True when at least one question requests a unicast response."""
+        return self._has_qu_question
+
+    def is_probe(self) -> bool:
+        """True when the message carries authority records, marking a probe."""
+        return self._num_authorities > 0
+
     def is_query(self) -> bool:
         """True when the QR flag marks the message as a query."""
         return (self.flags & _FLAGS_QR_MASK) == _FLAGS_QR_QUERY
@@ -130,24 +169,10 @@ class DNSIncoming:
         """True when the QR flag marks the message as a response."""
         return (self.flags & _FLAGS_QR_MASK) == _FLAGS_QR_RESPONSE
 
-    def has_qu_question(self) -> bool:
-        """True when at least one question requests a unicast response."""
-        return self._has_qu_question
-
     @property
-    def truncated(self) -> bool:
-        """True when the TC bit is set."""
-        return (self.flags & _FLAGS_TC) == _FLAGS_TC
-
-    @property
-    def questions(self) -> list[DNSQuestion]:
-        """Questions in the packet."""
-        return self._questions
-
-    @property
-    def num_questions(self) -> int:
-        """Number of questions in the packet."""
-        return self._num_questions
+    def num_additionals(self) -> int:
+        """Number of additionals in the packet."""
+        return self._num_additionals
 
     @property
     def num_answers(self) -> int:
@@ -160,9 +185,83 @@ class DNSIncoming:
         return self._num_authorities
 
     @property
-    def num_additionals(self) -> int:
-        """Number of additionals in the packet."""
-        return self._num_additionals
+    def num_questions(self) -> int:
+        """Number of questions in the packet."""
+        return self._num_questions
+
+    @property
+    def questions(self) -> list[DNSQuestion]:
+        """Questions in the packet."""
+        return self._questions
+
+    @property
+    def truncated(self) -> bool:
+        """True when the TC bit is set."""
+        return (self.flags & _FLAGS_TC) == _FLAGS_TC
+
+    def _decode_labels_at_offset(
+        self, off: _int, labels: list[_str], seen_pointers: set[_int] | None, depth: _int
+    ) -> int:
+        # This is a tight loop that is called frequently, small optimizations can make a difference.
+        if depth > MAX_DNS_LABELS:
+            raise IncomingDecodeError(
+                f"DNS compression pointer chain exceeds {MAX_DNS_LABELS} at {off} from {self.source}"
+            )
+        buf = self._buf
+        while off < self._data_len:
+            length = buf[off]
+            if length == 0:
+                return off + DNS_COMPRESSION_HEADER_LEN
+
+            if length < 0x40:
+                label_idx = off + DNS_COMPRESSION_HEADER_LEN
+                # Sliced from `data`, not `_buf`: a label running past the end
+                # truncates here and the loop raises corrupt-packet below.
+                labels.append(self.data[label_idx : label_idx + length].decode("utf-8", "replace"))
+                off += DNS_COMPRESSION_HEADER_LEN + length
+                continue
+
+            if length < 0xC0:
+                raise IncomingDecodeError(
+                    f"DNS compression type {length} is unknown at {off} from {self.source}"
+                )
+
+            # We have a DNS compression pointer
+            if off + 1 >= self._data_len:
+                raise IncomingDecodeError(f"DNS compression pointer at {off} is truncated from {self.source}")
+            link_data = buf[off + 1]
+            link = (length & 0x3F) * 256 + link_data
+            link_py_int = link
+            if link >= self._data_len:
+                raise IncomingDecodeError(
+                    f"DNS compression pointer at {off} points to {link} beyond packet from {self.source}"
+                )
+            if link == off:
+                raise IncomingDecodeError(
+                    f"DNS compression pointer at {off} points to itself from {self.source}"
+                )
+            if seen_pointers is not None and link_py_int in seen_pointers:
+                raise IncomingDecodeError(
+                    f"DNS compression pointer at {off} was seen again from {self.source}"
+                )
+            linked_labels = self._name_cache.get(link_py_int)
+            if not linked_labels:
+                if seen_pointers is None:
+                    # Deferred allocation: only names that follow an
+                    # uncached pointer pay for loop detection.
+                    seen_pointers = set()
+                seen_pointers.add(link_py_int)
+                linked_labels = []
+                self._decode_labels_at_offset(link, linked_labels, seen_pointers, depth + 1)
+                self._name_cache[link_py_int] = linked_labels
+            labels.extend(linked_labels)
+            if len(labels) > MAX_DNS_LABELS:
+                raise IncomingDecodeError(
+                    f"Maximum dns labels reached while processing pointer at {off} from {self.source}"
+                )
+            return off + DNS_COMPRESSION_POINTER_LEN
+
+        raise IncomingDecodeError(f"Corrupt packet received while decoding name from {self.source}")
 
     def _initial_parse(self) -> None:
         """Parse the data needed to initialize the packet object."""
@@ -182,79 +281,45 @@ class DNSIncoming:
         log_exc_info = _mark_seen(_seen_logs, str(sys.exc_info()[1]))
         log.debug(*(logger_data or ["Exception occurred"]), exc_info=log_exc_info)
 
-    def answers(self) -> list[DNSRecord]:
-        """Answers in the packet."""
-        if not self._did_read_others:
-            try:
-                self._read_others()
-            except DECODE_EXCEPTIONS:
-                self._log_exception_debug(
-                    "Received invalid packet from %s at offset %d while unpacking %r",
-                    self.source,
-                    self.offset,
-                    self.data,
-                )
-        return self._answers
-
-    def is_probe(self) -> bool:
-        """True when the message carries authority records, marking a probe."""
-        return self._num_authorities > 0
-
-    def __repr__(self) -> str:
-        return "<DNSIncoming:{}>".format(
-            ", ".join(
-                [
-                    f"id={self.id}",
-                    f"flags={self.flags}",
-                    f"truncated={self.truncated}",
-                    f"n_q={self._num_questions}",
-                    f"n_ans={self._num_answers}",
-                    f"n_auth={self._num_authorities}",
-                    f"n_add={self._num_additionals}",
-                    f"questions={self._questions}",
-                    f"answers={self.answers()}",
-                ]
-            )
-        )
-
-    def _read_header(self) -> None:
-        """Unpack the fixed twelve byte message header."""
-        offset = self.offset
-        if offset + 12 > self._data_len:
+    def _read_bitmap(self, end: _int) -> list[int]:
+        """Decode the NSEC type bitmap."""
+        rdtypes = []
+        if end > self._data_len:
             raise IncomingDecodeError(
-                f"DNS header at offset {offset} overruns packet of {self._data_len} bytes from {self.source}"
+                f"NSEC record end {end} overruns packet of {self._data_len} bytes from {self.source}"
             )
         buf = self._buf
-        self.offset += 12
-        # The header has 6 unsigned shorts in network order
-        self.id = buf[offset] << 8 | buf[offset + 1]
-        self.flags = buf[offset + 2] << 8 | buf[offset + 3]
-        self._num_questions = buf[offset + 4] << 8 | buf[offset + 5]
-        self._num_answers = buf[offset + 6] << 8 | buf[offset + 7]
-        self._num_authorities = buf[offset + 8] << 8 | buf[offset + 9]
-        self._num_additionals = buf[offset + 10] << 8 | buf[offset + 11]
-
-    def _read_questions(self) -> None:
-        """Parse the question entries."""
-        buf = self._buf
-        questions = self._questions
-        for _ in range(self._num_questions):
-            name = self._read_name()
+        while self.offset < end:
             offset = self.offset
-            if offset + 4 > self._data_len:
+            offset_plus_one = offset + 1
+            offset_plus_two = offset + 2
+            # RFC 4034 §4.1.2: each window block is window-number byte +
+            # bitmap-length byte (1..32) + bitmap. A bitmap_length that walks
+            # past the record's declared end would otherwise leave self.offset
+            # pointing inside (or past) the next record header, corrupting
+            # every subsequent record in the same packet.
+            if offset_plus_two > end:
                 raise IncomingDecodeError(
-                    f"Question at offset {offset} overruns packet of "
-                    f"{self._data_len} bytes from {self.source}"
+                    f"NSEC bitmap window header truncated at offset {offset} from {self.source}"
                 )
-            self.offset += 4
-            # The question has 2 unsigned shorts in network order
-            type_ = buf[offset] << 8 | buf[offset + 1]
-            class_ = buf[offset + 2] << 8 | buf[offset + 3]
-            question = DNSQuestion.__new__(DNSQuestion)
-            question._fast_init(name, type_, class_)
-            if question.unique:  # QU questions use the same bit as unique
-                self._has_qu_question = True
-            questions.append(question)
+            bitmap_length = buf[offset_plus_one]
+            bitmap_end = offset_plus_two + bitmap_length
+            if bitmap_length == 0 or bitmap_length > 32 or bitmap_end > end:
+                raise IncomingDecodeError(
+                    f"NSEC bitmap length {bitmap_length} invalid or overruns record end "
+                    f"at offset {offset} from {self.source}"
+                )
+            window_base = buf[offset] * 256
+            for i in range(bitmap_length):
+                byte = buf[offset_plus_two + i]
+                if byte == 0:
+                    continue
+                bit_base = window_base + i * 8
+                for bit in range(8):
+                    if byte & (0x80 >> bit):
+                        rdtypes.append(bit_base + bit)
+            self.offset = bitmap_end
+        return rdtypes
 
     def _read_character_string(self) -> str:
         """Decode a length prefixed character string."""
@@ -280,18 +345,56 @@ class DNSIncoming:
         self.offset = end
         return info
 
-    def _read_string(self, length: _int) -> bytes:
-        """Slice the next length bytes out of the buffer."""
-        start = self.offset
-        end = start + length
-        if end > self._data_len:
+    def _read_header(self) -> None:
+        """Unpack the fixed twelve byte message header."""
+        offset = self.offset
+        if offset + 12 > self._data_len:
             raise IncomingDecodeError(
-                f"String length {length} at offset {start} overruns "
-                f"packet of {self._data_len} bytes from {self.source}"
+                f"DNS header at offset {offset} overruns packet of {self._data_len} bytes from {self.source}"
             )
-        info = self._buf[start:end]
-        self.offset = end
-        return info
+        buf = self._buf
+        self.offset += 12
+        # The header has 6 unsigned shorts in network order
+        self.id = buf[offset] << 8 | buf[offset + 1]
+        self.flags = buf[offset + 2] << 8 | buf[offset + 3]
+        self._num_questions = buf[offset + 4] << 8 | buf[offset + 5]
+        self._num_answers = buf[offset + 6] << 8 | buf[offset + 7]
+        self._num_authorities = buf[offset + 8] << 8 | buf[offset + 9]
+        self._num_additionals = buf[offset + 10] << 8 | buf[offset + 11]
+
+    def _read_name(self) -> str:
+        """Decode a possibly compressed domain name at the current offset."""
+        original_offset = self.offset
+        name_str_cache = self._name_str_cache
+        is_pure_pointer = False
+        link = 0
+        # A cache hit needs no re-validation because entries are only
+        # written after a decode passed every check (bounds, loops, depth,
+        # name length), and only at offsets inside the packet, so an
+        # out-of-range link can only miss.
+        if original_offset + DNS_COMPRESSION_POINTER_LEN <= self._data_len:
+            length = self._buf[original_offset]
+            if length >= 0xC0:
+                is_pure_pointer = True
+                link = (length & 0x3F) * 256 + self._buf[original_offset + 1]
+                cached_name = name_str_cache.get(link)
+                if cached_name is not None:
+                    self.offset = original_offset + DNS_COMPRESSION_POINTER_LEN
+                    return cached_name
+        labels: list[str] = []
+        self.offset = self._decode_labels_at_offset(original_offset, labels, None, 0)
+        self._name_cache[original_offset] = labels
+        name = ".".join(labels) + "."
+        if len(name) > MAX_NAME_LENGTH:
+            raise IncomingDecodeError(
+                f"DNS name {name} exceeds maximum length of {MAX_NAME_LENGTH} from {self.source}"
+            )
+        name_str_cache[original_offset] = name
+        if is_pure_pointer:
+            # The whole name was one pointer, so the finished string is
+            # also the name that starts at the pointer target.
+            name_str_cache[link] = name
+        return name
 
     def _read_others(self) -> None:
         """Read the answer, authority and additional sections."""
@@ -346,6 +449,28 @@ class DNSIncoming:
                 rec = None
             if rec is not None:
                 answers.append(rec)
+
+    def _read_questions(self) -> None:
+        """Parse the question entries."""
+        buf = self._buf
+        questions = self._questions
+        for _ in range(self._num_questions):
+            name = self._read_name()
+            offset = self.offset
+            if offset + 4 > self._data_len:
+                raise IncomingDecodeError(
+                    f"Question at offset {offset} overruns packet of "
+                    f"{self._data_len} bytes from {self.source}"
+                )
+            self.offset += 4
+            # The question has 2 unsigned shorts in network order
+            type_ = buf[offset] << 8 | buf[offset + 1]
+            class_ = buf[offset + 2] << 8 | buf[offset + 3]
+            question = DNSQuestion.__new__(DNSQuestion)
+            question._fast_init(name, type_, class_)
+            if question.unique:  # QU questions use the same bit as unique
+                self._has_qu_question = True
+            questions.append(question)
 
     def _read_record(
         self, domain: _str, type_: _int, class_: _int, ttl: _int, length: _int
@@ -429,140 +554,15 @@ class DNSIncoming:
         self.offset += length
         return None
 
-    def _read_bitmap(self, end: _int) -> list[int]:
-        """Decode the NSEC type bitmap."""
-        rdtypes = []
+    def _read_string(self, length: _int) -> bytes:
+        """Slice the next length bytes out of the buffer."""
+        start = self.offset
+        end = start + length
         if end > self._data_len:
             raise IncomingDecodeError(
-                f"NSEC record end {end} overruns packet of {self._data_len} bytes from {self.source}"
+                f"String length {length} at offset {start} overruns "
+                f"packet of {self._data_len} bytes from {self.source}"
             )
-        buf = self._buf
-        while self.offset < end:
-            offset = self.offset
-            offset_plus_one = offset + 1
-            offset_plus_two = offset + 2
-            # RFC 4034 §4.1.2: each window block is window-number byte +
-            # bitmap-length byte (1..32) + bitmap. A bitmap_length that walks
-            # past the record's declared end would otherwise leave self.offset
-            # pointing inside (or past) the next record header, corrupting
-            # every subsequent record in the same packet.
-            if offset_plus_two > end:
-                raise IncomingDecodeError(
-                    f"NSEC bitmap window header truncated at offset {offset} from {self.source}"
-                )
-            bitmap_length = buf[offset_plus_one]
-            bitmap_end = offset_plus_two + bitmap_length
-            if bitmap_length == 0 or bitmap_length > 32 or bitmap_end > end:
-                raise IncomingDecodeError(
-                    f"NSEC bitmap length {bitmap_length} invalid or overruns record end "
-                    f"at offset {offset} from {self.source}"
-                )
-            window_base = buf[offset] * 256
-            for i in range(bitmap_length):
-                byte = buf[offset_plus_two + i]
-                if byte == 0:
-                    continue
-                bit_base = window_base + i * 8
-                for bit in range(8):
-                    if byte & (0x80 >> bit):
-                        rdtypes.append(bit_base + bit)
-            self.offset = bitmap_end
-        return rdtypes
-
-    def _read_name(self) -> str:
-        """Decode a possibly compressed domain name at the current offset."""
-        original_offset = self.offset
-        name_str_cache = self._name_str_cache
-        is_pure_pointer = False
-        link = 0
-        # A cache hit needs no re-validation because entries are only
-        # written after a decode passed every check (bounds, loops, depth,
-        # name length), and only at offsets inside the packet, so an
-        # out-of-range link can only miss.
-        if original_offset + DNS_COMPRESSION_POINTER_LEN <= self._data_len:
-            length = self._buf[original_offset]
-            if length >= 0xC0:
-                is_pure_pointer = True
-                link = (length & 0x3F) * 256 + self._buf[original_offset + 1]
-                cached_name = name_str_cache.get(link)
-                if cached_name is not None:
-                    self.offset = original_offset + DNS_COMPRESSION_POINTER_LEN
-                    return cached_name
-        labels: list[str] = []
-        self.offset = self._decode_labels_at_offset(original_offset, labels, None, 0)
-        self._name_cache[original_offset] = labels
-        name = ".".join(labels) + "."
-        if len(name) > MAX_NAME_LENGTH:
-            raise IncomingDecodeError(
-                f"DNS name {name} exceeds maximum length of {MAX_NAME_LENGTH} from {self.source}"
-            )
-        name_str_cache[original_offset] = name
-        if is_pure_pointer:
-            # The whole name was one pointer, so the finished string is
-            # also the name that starts at the pointer target.
-            name_str_cache[link] = name
-        return name
-
-    def _decode_labels_at_offset(
-        self, off: _int, labels: list[_str], seen_pointers: set[_int] | None, depth: _int
-    ) -> int:
-        # This is a tight loop that is called frequently, small optimizations can make a difference.
-        if depth > MAX_DNS_LABELS:
-            raise IncomingDecodeError(
-                f"DNS compression pointer chain exceeds {MAX_DNS_LABELS} at {off} from {self.source}"
-            )
-        buf = self._buf
-        while off < self._data_len:
-            length = buf[off]
-            if length == 0:
-                return off + DNS_COMPRESSION_HEADER_LEN
-
-            if length < 0x40:
-                label_idx = off + DNS_COMPRESSION_HEADER_LEN
-                # Sliced from `data`, not `_buf`: a label running past the end
-                # truncates here and the loop raises corrupt-packet below.
-                labels.append(self.data[label_idx : label_idx + length].decode("utf-8", "replace"))
-                off += DNS_COMPRESSION_HEADER_LEN + length
-                continue
-
-            if length < 0xC0:
-                raise IncomingDecodeError(
-                    f"DNS compression type {length} is unknown at {off} from {self.source}"
-                )
-
-            # We have a DNS compression pointer
-            if off + 1 >= self._data_len:
-                raise IncomingDecodeError(f"DNS compression pointer at {off} is truncated from {self.source}")
-            link_data = buf[off + 1]
-            link = (length & 0x3F) * 256 + link_data
-            link_py_int = link
-            if link >= self._data_len:
-                raise IncomingDecodeError(
-                    f"DNS compression pointer at {off} points to {link} beyond packet from {self.source}"
-                )
-            if link == off:
-                raise IncomingDecodeError(
-                    f"DNS compression pointer at {off} points to itself from {self.source}"
-                )
-            if seen_pointers is not None and link_py_int in seen_pointers:
-                raise IncomingDecodeError(
-                    f"DNS compression pointer at {off} was seen again from {self.source}"
-                )
-            linked_labels = self._name_cache.get(link_py_int)
-            if not linked_labels:
-                if seen_pointers is None:
-                    # Deferred allocation: only names that follow an
-                    # uncached pointer pay for loop detection.
-                    seen_pointers = set()
-                seen_pointers.add(link_py_int)
-                linked_labels = []
-                self._decode_labels_at_offset(link, linked_labels, seen_pointers, depth + 1)
-                self._name_cache[link_py_int] = linked_labels
-            labels.extend(linked_labels)
-            if len(labels) > MAX_DNS_LABELS:
-                raise IncomingDecodeError(
-                    f"Maximum dns labels reached while processing pointer at {off} from {self.source}"
-                )
-            return off + DNS_COMPRESSION_POINTER_LEN
-
-        raise IncomingDecodeError(f"Corrupt packet received while decoding name from {self.source}")
+        info = self._buf[start:end]
+        self.offset = end
+        return info

--- a/src/zeroconf/_services/browser.py
+++ b/src/zeroconf/_services/browser.py
@@ -601,45 +601,6 @@ class _ServiceBrowserBase(RecordUpdateListener):
         for h in handlers:
             self.service_state_changed.register_handler(h)
 
-    def _async_start(self) -> None:
-        """Generate the next time and setup listeners.
-
-        Must be called by uses of this base class after they
-        have finished setting their properties.
-        """
-        self.zc.async_add_listener(self, [DNSQuestion(type_, _TYPE_PTR, _CLASS_IN) for type_ in self.types])
-        # Only start queries after the listener is installed
-        self._query_sender_task = asyncio.ensure_future(self._async_start_query_sender())
-
-    @property
-    def service_state_changed(self) -> SignalRegistrationInterface:
-        return self._service_state_changed.registration_interface
-
-    def _names_matching_types(self, names: Iterable[str]) -> list[tuple[str, str]]:
-        """Return the type and name for records matching the types we are browsing."""
-        return [
-            (type_, name) for name in names for type_ in self.types.intersection(cached_possible_types(name))
-        ]
-
-    def _enqueue_callback(
-        self,
-        state_change: ServiceStateChange,
-        type_: str_,
-        name: str_,
-    ) -> None:
-        # Code to ensure we only do a single update message
-        # Precedence is; Added, Remove, Update
-        key = (name, type_)
-        if (
-            state_change is SERVICE_STATE_CHANGE_ADDED
-            or (
-                state_change is SERVICE_STATE_CHANGE_REMOVED
-                and self._pending_handlers.get(key) is not SERVICE_STATE_CHANGE_ADDED
-            )
-            or (state_change is SERVICE_STATE_CHANGE_UPDATED and key not in self._pending_handlers)
-        ):
-            self._pending_handlers[key] = state_change
-
     def async_update_records(self, zc: Zeroconf, now: float_, records: list[RecordUpdate_]) -> None:
         """Handle record updates for the browsed types inside the event loop."""
         for record_update in records:
@@ -695,6 +656,54 @@ class _ServiceBrowserBase(RecordUpdateListener):
             self._fire_service_state_changed_event(pending)
         self._pending_handlers.clear()
 
+    @property
+    def service_state_changed(self) -> SignalRegistrationInterface:
+        return self._service_state_changed.registration_interface
+
+    def _async_cancel(self) -> None:
+        """Cancel the browser."""
+        self.done = True
+        self.query_scheduler.stop()
+        self.zc.async_remove_listener(self)
+        assert self._query_sender_task is not None, "Attempted to cancel a browser that was not started"
+        self._query_sender_task.cancel()
+        self._query_sender_task = None
+
+    def _async_start(self) -> None:
+        """Generate the next time and setup listeners.
+
+        Must be called by uses of this base class after they
+        have finished setting their properties.
+        """
+        self.zc.async_add_listener(self, [DNSQuestion(type_, _TYPE_PTR, _CLASS_IN) for type_ in self.types])
+        # Only start queries after the listener is installed
+        self._query_sender_task = asyncio.ensure_future(self._async_start_query_sender())
+
+    async def _async_start_query_sender(self) -> None:
+        """Start scheduling queries."""
+        if not self.zc.started:
+            await self.zc.async_wait_for_start()
+        self.query_scheduler.start(self._loop)
+
+    def _enqueue_callback(
+        self,
+        state_change: ServiceStateChange,
+        type_: str_,
+        name: str_,
+    ) -> None:
+        # Code to ensure we only do a single update message
+        # Precedence is; Added, Remove, Update
+        key = (name, type_)
+        if (
+            state_change is SERVICE_STATE_CHANGE_ADDED
+            or (
+                state_change is SERVICE_STATE_CHANGE_REMOVED
+                and self._pending_handlers.get(key) is not SERVICE_STATE_CHANGE_ADDED
+            )
+            or (state_change is SERVICE_STATE_CHANGE_UPDATED and key not in self._pending_handlers)
+        ):
+            self._pending_handlers[key] = state_change
+
     def _fire_service_state_changed_event(self, event: tuple[tuple[str, str], ServiceStateChange]) -> None:
         """Fire a service state changed event.
 
@@ -712,20 +721,11 @@ class _ServiceBrowserBase(RecordUpdateListener):
             state_change=state_change,
         )
 
-    def _async_cancel(self) -> None:
-        """Cancel the browser."""
-        self.done = True
-        self.query_scheduler.stop()
-        self.zc.async_remove_listener(self)
-        assert self._query_sender_task is not None, "Attempted to cancel a browser that was not started"
-        self._query_sender_task.cancel()
-        self._query_sender_task = None
-
-    async def _async_start_query_sender(self) -> None:
-        """Start scheduling queries."""
-        if not self.zc.started:
-            await self.zc.async_wait_for_start()
-        self.query_scheduler.start(self._loop)
+    def _names_matching_types(self, names: Iterable[str]) -> list[tuple[str, str]]:
+        """Return the type and name for records matching the types we are browsing."""
+        return [
+            (type_, name) for name in names for type_ in self.types.intersection(cached_possible_types(name))
+        ]
 
 
 class ServiceBrowser(_ServiceBrowserBase, threading.Thread):
@@ -760,6 +760,29 @@ class ServiceBrowser(_ServiceBrowserBase, threading.Thread):
             getattr(self, "native_id", self.ident),
         )
 
+    def __enter__(self) -> ServiceBrowser:
+        return self
+
+    def __exit__(  # pylint: disable=useless-return
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> bool | None:
+        self.cancel()
+        return None
+
+    def async_update_records_complete(self) -> None:
+        """Called when a record update has completed for all handlers.
+
+        At this point the cache will have the new records.
+
+        This method will be run in the event loop.
+        """
+        for pending in self._pending_handlers.items():
+            self.queue.put(pending)
+        self._pending_handlers.clear()
+
     def cancel(self) -> None:
         """Cancel the browser."""
         assert self.zc.loop is not None
@@ -783,26 +806,3 @@ class ServiceBrowser(_ServiceBrowserBase, threading.Thread):
             if event is None:
                 return
             self._fire_service_state_changed_event(event)
-
-    def async_update_records_complete(self) -> None:
-        """Called when a record update has completed for all handlers.
-
-        At this point the cache will have the new records.
-
-        This method will be run in the event loop.
-        """
-        for pending in self._pending_handlers.items():
-            self.queue.put(pending)
-        self._pending_handlers.clear()
-
-    def __enter__(self) -> ServiceBrowser:
-        return self
-
-    def __exit__(  # pylint: disable=useless-return
-        self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
-    ) -> bool | None:
-        self.cancel()
-        return None

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -233,19 +233,24 @@ class ServiceInfo(RecordUpdateListener):
         self._get_address_and_nsec_records_cache: set[DNSRecord] | None = None
         self._query_record_types = {_TYPE_SRV, _TYPE_TXT, _TYPE_A, _TYPE_AAAA}
 
-    @property
-    def name(self) -> str:
-        """Fully qualified name of this service instance."""
-        return self._name
-
-    @name.setter
-    def name(self, name: str) -> None:
-        """Replace the name and reset the key."""
-        self._name = name
-        self.key = name.lower()
-        self._dns_service_cache = None
-        self._dns_pointer_cache = None
-        self._dns_text_cache = None
+    def __repr__(self) -> str:
+        return "{}({})".format(
+            type(self).__name__,
+            ", ".join(
+                f"{name}={getattr(self, name)!r}"
+                for name in (
+                    "type",
+                    "name",
+                    "addresses",
+                    "port",
+                    "weight",
+                    "priority",
+                    "server",
+                    "properties",
+                    "interface_index",
+                )
+            ),
+        )
 
     @property
     def addresses(self) -> list[bytes]:
@@ -288,41 +293,6 @@ class ServiceInfo(RecordUpdateListener):
                     assert isinstance(addr, ZeroconfIPv6Address)
                 self._ipv6_addresses.append(addr)
 
-    @property
-    def properties(self) -> dict[bytes, bytes | None]:
-        """Return properties as bytes."""
-        if self._properties is None:
-            self._unpack_text_into_properties()
-        if TYPE_CHECKING:
-            assert self._properties is not None
-        return self._properties
-
-    @property
-    def decoded_properties(self) -> dict[str, str | None]:
-        """Return properties as strings."""
-        if self._decoded_properties is None:
-            self._generate_decoded_properties()
-        if TYPE_CHECKING:
-            assert self._decoded_properties is not None
-        return self._decoded_properties
-
-    def async_clear_cache(self) -> None:
-        """Clear the cache for this service info."""
-        self._dns_address_cache = None
-        self._dns_address_nsec_cache = None
-        self._dns_pointer_cache = None
-        self._dns_service_cache = None
-        self._dns_text_cache = None
-        self._get_address_and_nsec_records_cache = None
-
-    async def async_wait(self, timeout: float, loop: asyncio.AbstractEventLoop | None = None) -> None:
-        """Suspend the calling task for timeout milliseconds, or less when new records arrive."""
-        if not self._new_records_futures:
-            self._new_records_futures = set()
-        await wait_for_future_set_or_timeout(
-            loop or asyncio.get_running_loop(), self._new_records_futures, timeout
-        )
-
     def addresses_by_version(self, version: IPVersion) -> list[bytes]:
         """List addresses matching IP version.
 
@@ -341,6 +311,158 @@ class ServiceInfo(RecordUpdateListener):
             return [addr.packed for addr in self._ipv4_addresses]
         return [addr.packed for addr in self._ipv6_addresses]
 
+    def async_clear_cache(self) -> None:
+        """Clear the cache for this service info."""
+        self._dns_address_cache = None
+        self._dns_address_nsec_cache = None
+        self._dns_pointer_cache = None
+        self._dns_service_cache = None
+        self._dns_text_cache = None
+        self._get_address_and_nsec_records_cache = None
+
+    async def async_request(
+        self,
+        zc: Zeroconf,
+        timeout: float,
+        question_type: DNSQuestionType | None = None,
+        addr: str | None = None,
+        port: int = _MDNS_PORT,
+    ) -> bool:
+        """Populate this object from the network, returning True on success.
+
+        Event loop flavor of request; waits up to timeout milliseconds
+        for the answers to arrive, and addr and port direct the queries
+        at a specific responder instead of the multicast group.
+        """
+        if not zc.started:
+            await zc.async_wait_for_start()
+
+        now = current_time_millis()
+
+        if self._load_from_cache(zc, now):
+            return True
+
+        if TYPE_CHECKING:
+            assert zc.loop is not None
+
+        first_request = True
+        delay = self._get_initial_delay()
+        next_ = now
+        last = now + timeout
+        try:
+            zc.async_add_listener(self, None)
+            while not self._is_complete:
+                if last <= now or self._is_denied:
+                    return False
+                if next_ <= now:
+                    this_question_type = question_type or (QU_QUESTION if first_request else QM_QUESTION)
+                    out = self._generate_request_query(zc, now, this_question_type)
+                    first_request = False
+                    if out.questions:
+                        # All questions may have been suppressed
+                        # by the question history, so nothing to send,
+                        # but keep waiting for answers in case another
+                        # client on the network is asking the same
+                        # question or they have not arrived yet.
+                        zc.async_send(out, addr, port)
+                    next_ = now + delay
+                    next_ += self._get_random_delay()
+                    if this_question_type is QM_QUESTION and delay < _DUPLICATE_QUESTION_INTERVAL:
+                        # If we just asked a QM question, we need to
+                        # wait at least the duplicate question interval
+                        # before asking another QM question otherwise
+                        # its likely to be suppressed by the question
+                        # history of the remote responder.
+                        delay = _DUPLICATE_QUESTION_INTERVAL
+
+                await self.async_wait(min(next_, last) - now, zc.loop)
+                now = current_time_millis()
+        finally:
+            zc.async_remove_listener(self)
+
+        return True
+
+    def async_update_records(self, zc: Zeroconf, now: float_, records: list[RecordUpdate_]) -> None:
+        """Merge a batch of record updates into this object and wake any waiters."""
+        new_records_futures = self._new_records_futures
+        updated: bool = False
+        nsec_records = None
+        for record_update in records:
+            record = record_update.new
+            # NSEC records are processed last so a denial for an SRV target
+            # learned later in the same batch is not discarded (wire order of
+            # records in a response is not guaranteed).
+            if type(record) is DNSNsec:
+                if nsec_records is None:
+                    nsec_records = []
+                nsec_records.append(record)
+                continue
+            updated |= self._process_record_threadsafe(zc, record, now)
+        if nsec_records is not None:
+            for record in nsec_records:
+                updated |= self._process_record_threadsafe(zc, record, now)
+        if updated and new_records_futures:
+            _resolve_all_futures_to_none(new_records_futures)
+
+    async def async_wait(self, timeout: float, loop: asyncio.AbstractEventLoop | None = None) -> None:
+        """Suspend the calling task for timeout milliseconds, or less when new records arrive."""
+        if not self._new_records_futures:
+            self._new_records_futures = set()
+        await wait_for_future_set_or_timeout(
+            loop or asyncio.get_running_loop(), self._new_records_futures, timeout
+        )
+
+    @property
+    def decoded_properties(self) -> dict[str, str | None]:
+        """Return properties as strings."""
+        if self._decoded_properties is None:
+            self._generate_decoded_properties()
+        if TYPE_CHECKING:
+            assert self._decoded_properties is not None
+        return self._decoded_properties
+
+    def dns_address_nsec(self, override_ttl: int_ | None = None) -> DNSNsec | None:
+        """Return DNSNsec asserting which address types exist, or None if not applicable."""
+        return self._dns_address_nsec(override_ttl)
+
+    def dns_addresses(
+        self,
+        override_ttl: int_ | None = None,
+        version: IPVersion = IPVersion.All,
+    ) -> list[DNSAddress]:
+        """Return matching DNSAddress from ServiceInfo."""
+        return self._dns_addresses(override_ttl, version)
+
+    def dns_nsec(self, missing_types: list[int], override_ttl: int_ | None = None) -> DNSNsec | None:
+        """Deprecated: use dns_address_nsec instead; missing_types is ignored."""
+        warnings.warn(
+            "dns_nsec is deprecated, and will be removed in a future version. "
+            "Use dns_address_nsec instead; missing_types is ignored.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._dns_address_nsec(override_ttl)
+
+    def dns_pointer(self, override_ttl: int_ | None = None) -> DNSPointer:
+        """Return DNSPointer from ServiceInfo."""
+        return self._dns_pointer(override_ttl)
+
+    def dns_service(self, override_ttl: int_ | None = None) -> DNSService:
+        """Return DNSService from ServiceInfo."""
+        return self._dns_service(override_ttl)
+
+    def dns_text(self, override_ttl: int_ | None = None) -> DNSText:
+        """Return DNSText from ServiceInfo."""
+        return self._dns_text(override_ttl)
+
+    def get_address_and_nsec_records(self, override_ttl: int_ | None = None) -> set[DNSRecord]:
+        """Build a set of address records plus an NSEC asserting which address types exist."""
+        return self._get_address_and_nsec_records(override_ttl)
+
+    def get_name(self) -> str:
+        """Instance name with the service type stripped."""
+        return self._name[: len(self._name) - len(self.type) - 1]
+
     def ip_addresses_by_version(
         self, version: IPVersion
     ) -> list[ZeroconfIPv4Address] | list[ZeroconfIPv6Address]:
@@ -354,15 +476,26 @@ class ServiceInfo(RecordUpdateListener):
         """
         return self._ip_addresses_by_version_value(version.value)
 
-    def _ip_addresses_by_version_value(
-        self, version_value: int_
-    ) -> list[ZeroconfIPv4Address] | list[ZeroconfIPv6Address]:
-        """Backend for addresses_by_version that uses the raw value."""
-        if version_value == _IPVersion_All_value:
-            return [*self._ipv4_addresses, *self._ipv6_addresses]  # type: ignore[return-value]
-        if version_value == _IPVersion_V4Only_value:
-            return self._ipv4_addresses
-        return self._ipv6_addresses
+    def load_from_cache(self, zc: Zeroconf, now: float_ | None = None) -> bool:
+        """Populate the service info from the cache.
+
+        This method is designed to be threadsafe.
+        """
+        return self._load_from_cache(zc, now or current_time_millis())
+
+    @property
+    def name(self) -> str:
+        """Fully qualified name of this service instance."""
+        return self._name
+
+    @name.setter
+    def name(self, name: str) -> None:
+        """Replace the name and reset the key."""
+        self._name = name
+        self.key = name.lower()
+        self._dns_service_cache = None
+        self._dns_pointer_cache = None
+        self._dns_text_cache = None
 
     def parsed_addresses(self, version: IPVersion = IPVersion.All) -> list[str]:
         """List addresses in their parsed string form.
@@ -387,41 +520,188 @@ class ServiceInfo(RecordUpdateListener):
         """
         return [str(addr) for addr in self._ip_addresses_by_version_value(version.value)]
 
-    def _set_properties(self, properties: dict[str | bytes, str | bytes | None]) -> None:
-        list_: list[bytes] = []
-        properties_contain_str = False
-        result = b""
-        for key, value in properties.items():
-            if isinstance(key, str):
-                key = key.encode("utf-8")  # noqa: PLW2901
-                properties_contain_str = True
+    @property
+    def properties(self) -> dict[bytes, bytes | None]:
+        """Return properties as bytes."""
+        if self._properties is None:
+            self._unpack_text_into_properties()
+        if TYPE_CHECKING:
+            assert self._properties is not None
+        return self._properties
 
-            record = key
-            if value is not None:
-                if not isinstance(value, bytes):
-                    value = str(value).encode("utf-8")  # noqa: PLW2901
-                    properties_contain_str = True
-                record += b"=" + value
-            list_.append(record)
-        for item in list_:
-            result = b"".join((result, bytes((len(item),)), item))
-        if not properties_contain_str:
-            # If there are no str keys or values, we can use the properties
-            # as-is, without decoding them, otherwise calling
-            # self.properties will lazy decode them, which is expensive.
-            if TYPE_CHECKING:
-                self._properties = cast(dict[bytes, bytes | None], properties)
-            else:
-                self._properties = properties
-        self.text = result
+    def request(
+        self,
+        zc: Zeroconf,
+        timeout: float,
+        question_type: DNSQuestionType | None = None,
+        addr: str | None = None,
+        port: int = _MDNS_PORT,
+    ) -> bool:
+        """Populate this object from the network, returning True on success.
 
-    def _set_text(self, text: bytes) -> None:
-        if text == self.text:
+        Waits up to timeout milliseconds for the answers to arrive; addr
+        and port direct the queries at a specific responder instead of
+        the multicast group.
+        """
+        assert zc.loop is not None, "Zeroconf instance must have a loop, was it not started?"
+        assert zc.loop.is_running(), "Zeroconf instance loop must be running, was it already stopped?"
+        if zc.loop == get_running_loop():
+            raise RuntimeError("Use AsyncServiceInfo.async_request from the event loop")
+        return bool(
+            run_coro_with_timeout(
+                self.async_request(zc, timeout, question_type, addr, port),
+                zc.loop,
+                timeout,
+            )
+        )
+
+    def set_server_if_missing(self) -> None:
+        """Set the server if it is missing.
+
+        This function is for backwards compatibility.
+        """
+        if self.server is None:
+            self.server = self._name
+            self.server_key = self.key
+
+    def _add_question_with_known_answers(
+        self,
+        out: DNSOutgoing,
+        qu_question: bool,
+        question_history: QuestionHistory,
+        cache: DNSCache,
+        now: float_,
+        name: str_,
+        type_: int_,
+        class_: int_,
+        skip_if_known_answers: bool,
+    ) -> None:
+        """Add a question with known answers if its not suppressed."""
+        known_answers = {
+            answer for answer in cache.get_all_by_details(name, type_, class_) if not answer.is_stale(now)
+        }
+        if skip_if_known_answers and known_answers:
             return
-        self.text = text
-        # Clear the properties cache
-        self._properties = None
-        self._decoded_properties = None
+        question = DNSQuestion(name, type_, class_)
+        if qu_question:
+            question.unicast = True
+        elif question_history.suppresses(question, now, known_answers):
+            return
+        else:
+            question_history.add_question_at_time(question, now, known_answers)
+        out.add_question(question)
+        for answer in known_answers:
+            out.add_answer_at_time(answer, now)
+
+    def _dns_address_nsec(self, override_ttl: int_ | None) -> DNSNsec | None:
+        cacheable = override_ttl is None
+        if self._dns_address_nsec_cache is not None and cacheable:
+            return self._dns_address_nsec_cache
+        # RFC 6762 §6.1: the type bitmap lists the rrtypes that exist at the
+        # name. Both families present leaves nothing to deny; neither leaves
+        # nothing to assert (an empty bitmap is unencodable).
+        has_v4 = bool(self._ipv4_addresses)
+        has_v6 = bool(self._ipv6_addresses)
+        if has_v4 == has_v6:
+            return None
+        assert self.server is not None, "Service server must be set for NSEC record."
+        record = DNSNsec(
+            self.server,
+            _TYPE_NSEC,
+            _CLASS_IN_UNIQUE,
+            override_ttl if override_ttl is not None else self.host_ttl,
+            self.server,
+            [_TYPE_A] if has_v4 else [_TYPE_AAAA],
+            0.0,
+        )
+        if cacheable:
+            self._dns_address_nsec_cache = record
+        return record
+
+    def _dns_addresses(
+        self,
+        override_ttl: int_ | None,
+        version: IPVersion,
+    ) -> list[DNSAddress]:
+        """Return matching DNSAddress from ServiceInfo."""
+        cacheable = version is IPVersion.All and override_ttl is None
+        if self._dns_address_cache is not None and cacheable:
+            return self._dns_address_cache
+        name = self.server or self._name
+        ttl = override_ttl if override_ttl is not None else self.host_ttl
+        class_ = _CLASS_IN_UNIQUE
+        version_value = version.value
+        records = [
+            DNSAddress(
+                name,
+                _TYPE_AAAA if ip_addr.version == 6 else _TYPE_A,
+                class_,
+                ttl,
+                ip_addr.packed,
+                created=0.0,
+            )
+            for ip_addr in self._ip_addresses_by_version_value(version_value)
+        ]
+        if cacheable:
+            self._dns_address_cache = records
+        return records
+
+    def _dns_pointer(self, override_ttl: int_ | None) -> DNSPointer:
+        """Return DNSPointer from ServiceInfo."""
+        cacheable = override_ttl is None
+        if self._dns_pointer_cache is not None and cacheable:
+            return self._dns_pointer_cache
+        record = DNSPointer(
+            self.type,
+            _TYPE_PTR,
+            _CLASS_IN,
+            override_ttl if override_ttl is not None else self.other_ttl,
+            self._name,
+            0.0,
+        )
+        if cacheable:
+            self._dns_pointer_cache = record
+        return record
+
+    def _dns_service(self, override_ttl: int_ | None) -> DNSService:
+        """Return DNSService from ServiceInfo."""
+        cacheable = override_ttl is None
+        if self._dns_service_cache is not None and cacheable:
+            return self._dns_service_cache
+        port = self.port
+        if TYPE_CHECKING:
+            assert isinstance(port, int)
+        record = DNSService(
+            self._name,
+            _TYPE_SRV,
+            _CLASS_IN_UNIQUE,
+            override_ttl if override_ttl is not None else self.host_ttl,
+            self.priority,
+            self.weight,
+            port,
+            self.server or self._name,
+            0.0,
+        )
+        if cacheable:
+            self._dns_service_cache = record
+        return record
+
+    def _dns_text(self, override_ttl: int_ | None) -> DNSText:
+        """Return DNSText from ServiceInfo."""
+        cacheable = override_ttl is None
+        if self._dns_text_cache is not None and cacheable:
+            return self._dns_text_cache
+        record = DNSText(
+            self._name,
+            _TYPE_TXT,
+            _CLASS_IN_UNIQUE,
+            override_ttl if override_ttl is not None else self.other_ttl,
+            self.text,
+            0.0,
+        )
+        if cacheable:
+            self._dns_text_cache = record
+        return record
 
     def _generate_decoded_properties(self) -> None:
         """Generates decoded properties from the properties"""
@@ -430,35 +710,63 @@ class ServiceInfo(RecordUpdateListener):
             for k, v in self.properties.items()
         }
 
-    def _unpack_text_into_properties(self) -> None:
-        """Unpacks the text field into properties"""
-        text = self.text
-        end = len(text)
-        if end == 0:
-            # Properties should be set atomically
-            # in case another thread is reading them
-            self._properties = {}
-            return
+    def _generate_request_query(
+        self, zc: Zeroconf, now: float_, question_type: DNSQuestionType
+    ) -> DNSOutgoing:
+        """Generate the request query."""
+        out = DNSOutgoing(_FLAGS_QR_QUERY)
+        name = self._name
+        server = self.server or name
+        cache = zc.cache
+        history = zc.question_history
+        qu_question = question_type is QU_QUESTION
+        if _TYPE_SRV in self._query_record_types:
+            self._add_question_with_known_answers(
+                out, qu_question, history, cache, now, name, _TYPE_SRV, _CLASS_IN, True
+            )
+        if _TYPE_TXT in self._query_record_types:
+            self._add_question_with_known_answers(
+                out, qu_question, history, cache, now, name, _TYPE_TXT, _CLASS_IN, True
+            )
+        if _TYPE_A in self._query_record_types:
+            self._add_question_with_known_answers(
+                out, qu_question, history, cache, now, server, _TYPE_A, _CLASS_IN, False
+            )
+        if _TYPE_AAAA in self._query_record_types:
+            self._add_question_with_known_answers(
+                out, qu_question, history, cache, now, server, _TYPE_AAAA, _CLASS_IN, False
+            )
+        return out
 
-        index = 0
-        properties: dict[bytes, bytes | None] = {}
-        while index < end:
-            length = text[index]
-            index += 1
-            key_value = text[index : index + length]
-            key, sep, value = key_value.partition(b"=")
-            if key not in properties:
-                # RFC 6763 section 6.4 distinguishes a key with no '=' (a
-                # boolean attribute: present, no value) from `key=` (present
-                # with an empty value), so test the separator, not the value.
-                properties[key] = value if sep else None
-            index += length
+    def _get_address_and_nsec_records(self, override_ttl: int_ | None) -> set[DNSRecord]:
+        """Build a set of address records plus an NSEC asserting which address types exist."""
+        cacheable = override_ttl is None
+        if self._get_address_and_nsec_records_cache is not None and cacheable:
+            return self._get_address_and_nsec_records_cache
+        records: set[DNSRecord] = set(self._dns_addresses(override_ttl, IPVersion.All))
+        nsec = self._dns_address_nsec(override_ttl)
+        if nsec is not None:
+            records.add(nsec)
+        if cacheable:
+            self._get_address_and_nsec_records_cache = records
+        return records
 
-        self._properties = properties
+    def _get_address_records_from_cache_by_type(self, zc: Zeroconf, _type: int_) -> list[DNSAddress]:
+        """Get the addresses from the cache."""
+        if self.server_key is None:
+            return []
+        cache = zc.cache
+        if TYPE_CHECKING:
+            records = cast(
+                list[DNSAddress],
+                cache.get_all_by_details(self.server_key, _type, _CLASS_IN),
+            )
+        else:
+            records = cache.get_all_by_details(self.server_key, _type, _CLASS_IN)
+        return records
 
-    def get_name(self) -> str:
-        """Instance name with the service type stripped."""
-        return self._name[: len(self._name) - len(self.type) - 1]
+    def _get_initial_delay(self) -> float_:
+        return _LISTENER_TIME
 
     def _get_ip_addresses_from_cache_lifo(
         self, zc: Zeroconf, now: float_, type: int_
@@ -488,71 +796,109 @@ class ServiceInfo(RecordUpdateListener):
         address_list.reverse()  # Reverse to get LIFO order
         return address_list
 
-    def _upsert_ipv6_address(self, ip_addr: ZeroconfIPv6Address) -> bool:
-        """Insert or update an IPv6 address in LIFO order.
+    def _get_random_delay(self) -> int_:
+        return randint(*_AVOID_SYNC_DELAY_RANDOM_INTERVAL)
 
-        Compares by integer (not IPv6Address equality, which respects
-        scope_id) so the same link-local address received first without
-        scope (IPv4 socket) and then with scope (IPv6 socket) collapses
-        to one entry. The scoped variant wins so parsed_scoped_addresses()
-        can return a qualified address.
+    def _ip_addresses_by_version_value(
+        self, version_value: int_
+    ) -> list[ZeroconfIPv4Address] | list[ZeroconfIPv6Address]:
+        """Backend for addresses_by_version that uses the raw value."""
+        if version_value == _IPVersion_All_value:
+            return [*self._ipv4_addresses, *self._ipv6_addresses]  # type: ignore[return-value]
+        if version_value == _IPVersion_V4Only_value:
+            return self._ipv4_addresses
+        return self._ipv6_addresses
+
+    @property
+    def _is_complete(self) -> bool:
+        """The ServiceInfo has all expected properties.
+
+        RFC 6763 section 6 requires every DNS-SD service to have a TXT record,
+        so a service is not complete until one has been seen. An empty TXT
+        record counts as seen, as does an NSEC record denying its existence
+        (RFC 6762 section 6.1); a missing one does not.
         """
-        ipv6_addresses = self._ipv6_addresses
-        existing_idx = _index_of_same_address(ipv6_addresses, ip_addr)
-        if existing_idx == -1:
-            ipv6_addresses.insert(0, ip_addr)
-            return True
-        existing = ipv6_addresses[existing_idx]
-        if _has_more_scope_info(ip_addr, existing):
-            ipv6_addresses.pop(existing_idx)
-            ipv6_addresses.insert(0, ip_addr)
-            return True
-        if existing_idx != 0:
-            ipv6_addresses.pop(existing_idx)
-            ipv6_addresses.insert(0, existing)
-        return False
+        return bool(self._txt_seen and (self._ipv4_addresses or self._ipv6_addresses))
 
-    def _set_ipv6_addresses_from_cache(self, zc: Zeroconf, now: float_) -> None:
-        """Set IPv6 addresses from the cache."""
+    @property
+    def _is_denied(self) -> bool:
+        """Every address type this request needs was denied via NSEC (RFC 6762 section 6.1)."""
+        query_types = self._query_record_types
+        return (_TYPE_A not in query_types or (self._ipv4_denied and not self._ipv4_addresses)) and (
+            _TYPE_AAAA not in query_types or (self._ipv6_denied and not self._ipv6_addresses)
+        )
+
+    def _load_from_cache(self, zc: Zeroconf, now: float_) -> bool:
+        """Populate the service info from the cache.
+
+        This method is designed to be threadsafe.
+        """
+        cache = zc.cache
+        original_server_key = self.server_key
+        # Denials are only trusted until the next cache load re-derives them.
+        self._ipv4_denied = False
+        self._ipv6_denied = False
+        cached_srv_record = cache.get_by_details(self._name, _TYPE_SRV, _CLASS_IN)
+        if cached_srv_record:
+            self._process_record_threadsafe(zc, cached_srv_record, now)
+        cached_txt_record = cache.get_by_details(self._name, _TYPE_TXT, _CLASS_IN)
+        if cached_txt_record:
+            self._process_record_threadsafe(zc, cached_txt_record, now)
+        if not self._txt_seen:
+            cached_nsec_record = cache.get_by_details(self._name, _TYPE_NSEC, _CLASS_IN)
+            if cached_nsec_record:
+                self._process_record_threadsafe(zc, cached_nsec_record, now)
+        if original_server_key == self.server_key:
+            # If there is a srv which changes the server_key,
+            # A, AAAA, and the server NSEC will already be loaded
+            # from the cache and we do not want to do it twice
+            for record in self._get_address_records_from_cache_by_type(zc, _TYPE_A):
+                self._process_record_threadsafe(zc, record, now)
+            for record in self._get_address_records_from_cache_by_type(zc, _TYPE_AAAA):
+                self._process_record_threadsafe(zc, record, now)
+            if self.server_key and not self._is_complete:
+                cached_server_nsec_record = cache.get_by_details(self.server_key, _TYPE_NSEC, _CLASS_IN)
+                if cached_server_nsec_record:
+                    self._process_record_threadsafe(zc, cached_server_nsec_record, now)
+        return self._is_complete
+
+    def _load_records_for_new_server_from_cache(self, zc: Zeroconf, now: float_) -> None:
+        """Re-derive per-host state, denials included, after the SRV target changed."""
+        self._ipv4_denied = False
+        self._ipv6_denied = False
+        self._set_ipv4_addresses_from_cache(zc, now)
+        self._set_ipv6_addresses_from_cache(zc, now)
         if TYPE_CHECKING:
-            self._ipv6_addresses = cast(
-                list[ZeroconfIPv6Address],
-                self._get_ip_addresses_from_cache_lifo(zc, now, _TYPE_AAAA),
-            )
-        else:
-            self._ipv6_addresses = self._get_ip_addresses_from_cache_lifo(zc, now, _TYPE_AAAA)
+            assert self.server_key is not None
+        cache = zc.cache
+        cached_server_nsec_record = cache.get_by_details(self.server_key, _TYPE_NSEC, _CLASS_IN)
+        if cached_server_nsec_record:
+            self._process_record_threadsafe(zc, cached_server_nsec_record, now)
 
-    def _set_ipv4_addresses_from_cache(self, zc: Zeroconf, now: float_) -> None:
-        """Set IPv4 addresses from the cache."""
-        if TYPE_CHECKING:
-            self._ipv4_addresses = cast(
-                list[ZeroconfIPv4Address],
-                self._get_ip_addresses_from_cache_lifo(zc, now, _TYPE_A),
-            )
-        else:
-            self._ipv4_addresses = self._get_ip_addresses_from_cache_lifo(zc, now, _TYPE_A)
-
-    def async_update_records(self, zc: Zeroconf, now: float_, records: list[RecordUpdate_]) -> None:
-        """Merge a batch of record updates into this object and wake any waiters."""
-        new_records_futures = self._new_records_futures
-        updated: bool = False
-        nsec_records = None
-        for record_update in records:
-            record = record_update.new
-            # NSEC records are processed last so a denial for an SRV target
-            # learned later in the same batch is not discarded (wire order of
-            # records in a response is not guaranteed).
-            if type(record) is DNSNsec:
-                if nsec_records is None:
-                    nsec_records = []
-                nsec_records.append(record)
-                continue
-            updated |= self._process_record_threadsafe(zc, record, now)
-        if nsec_records is not None:
-            for record in nsec_records:
-                updated |= self._process_record_threadsafe(zc, record, now)
-        if updated and new_records_futures:
-            _resolve_all_futures_to_none(new_records_futures)
+    def _process_nsec_record(self, record: DNSNsec, record_key: str_) -> bool:
+        """Record the denials asserted by an NSEC record (RFC 6762 §6.1)."""
+        rdtypes = record.rdtypes
+        updated = False
+        if record_key == self.server_key:
+            # Each NSEC is an authoritative snapshot of what exists at the
+            # host, so recompute both flags instead of accumulating denials.
+            ipv4_denied = _TYPE_A not in rdtypes
+            ipv6_denied = _TYPE_AAAA not in rdtypes
+            if ipv4_denied != self._ipv4_denied or ipv6_denied != self._ipv6_denied:
+                self._ipv4_denied = ipv4_denied
+                self._ipv6_denied = ipv6_denied
+                updated = True
+        if (
+            record_key == self.key
+            and not self._txt_seen
+            and _TYPE_SRV in rdtypes
+            and _TYPE_TXT not in rdtypes
+        ):
+            # Requiring the SRV bit keeps older python-zeroconf NSECs, which listed the
+            # missing address types, from being misread as a TXT denial.
+            self._txt_seen = True
+            updated = True
+        return updated
 
     def _process_record_threadsafe(self, zc: Zeroconf, record: DNSRecord, now: float_) -> bool:
         """Thread safe record updating.
@@ -635,457 +981,111 @@ class ServiceInfo(RecordUpdateListener):
 
         return False
 
-    def _load_records_for_new_server_from_cache(self, zc: Zeroconf, now: float_) -> None:
-        """Re-derive per-host state, denials included, after the SRV target changed."""
-        self._ipv4_denied = False
-        self._ipv6_denied = False
-        self._set_ipv4_addresses_from_cache(zc, now)
-        self._set_ipv6_addresses_from_cache(zc, now)
+    def _set_ipv4_addresses_from_cache(self, zc: Zeroconf, now: float_) -> None:
+        """Set IPv4 addresses from the cache."""
         if TYPE_CHECKING:
-            assert self.server_key is not None
-        cache = zc.cache
-        cached_server_nsec_record = cache.get_by_details(self.server_key, _TYPE_NSEC, _CLASS_IN)
-        if cached_server_nsec_record:
-            self._process_record_threadsafe(zc, cached_server_nsec_record, now)
-
-    def _process_nsec_record(self, record: DNSNsec, record_key: str_) -> bool:
-        """Record the denials asserted by an NSEC record (RFC 6762 §6.1)."""
-        rdtypes = record.rdtypes
-        updated = False
-        if record_key == self.server_key:
-            # Each NSEC is an authoritative snapshot of what exists at the
-            # host, so recompute both flags instead of accumulating denials.
-            ipv4_denied = _TYPE_A not in rdtypes
-            ipv6_denied = _TYPE_AAAA not in rdtypes
-            if ipv4_denied != self._ipv4_denied or ipv6_denied != self._ipv6_denied:
-                self._ipv4_denied = ipv4_denied
-                self._ipv6_denied = ipv6_denied
-                updated = True
-        if (
-            record_key == self.key
-            and not self._txt_seen
-            and _TYPE_SRV in rdtypes
-            and _TYPE_TXT not in rdtypes
-        ):
-            # Requiring the SRV bit keeps older python-zeroconf NSECs, which listed the
-            # missing address types, from being misread as a TXT denial.
-            self._txt_seen = True
-            updated = True
-        return updated
-
-    def dns_addresses(
-        self,
-        override_ttl: int_ | None = None,
-        version: IPVersion = IPVersion.All,
-    ) -> list[DNSAddress]:
-        """Return matching DNSAddress from ServiceInfo."""
-        return self._dns_addresses(override_ttl, version)
-
-    def _dns_addresses(
-        self,
-        override_ttl: int_ | None,
-        version: IPVersion,
-    ) -> list[DNSAddress]:
-        """Return matching DNSAddress from ServiceInfo."""
-        cacheable = version is IPVersion.All and override_ttl is None
-        if self._dns_address_cache is not None and cacheable:
-            return self._dns_address_cache
-        name = self.server or self._name
-        ttl = override_ttl if override_ttl is not None else self.host_ttl
-        class_ = _CLASS_IN_UNIQUE
-        version_value = version.value
-        records = [
-            DNSAddress(
-                name,
-                _TYPE_AAAA if ip_addr.version == 6 else _TYPE_A,
-                class_,
-                ttl,
-                ip_addr.packed,
-                created=0.0,
-            )
-            for ip_addr in self._ip_addresses_by_version_value(version_value)
-        ]
-        if cacheable:
-            self._dns_address_cache = records
-        return records
-
-    def dns_pointer(self, override_ttl: int_ | None = None) -> DNSPointer:
-        """Return DNSPointer from ServiceInfo."""
-        return self._dns_pointer(override_ttl)
-
-    def _dns_pointer(self, override_ttl: int_ | None) -> DNSPointer:
-        """Return DNSPointer from ServiceInfo."""
-        cacheable = override_ttl is None
-        if self._dns_pointer_cache is not None and cacheable:
-            return self._dns_pointer_cache
-        record = DNSPointer(
-            self.type,
-            _TYPE_PTR,
-            _CLASS_IN,
-            override_ttl if override_ttl is not None else self.other_ttl,
-            self._name,
-            0.0,
-        )
-        if cacheable:
-            self._dns_pointer_cache = record
-        return record
-
-    def dns_service(self, override_ttl: int_ | None = None) -> DNSService:
-        """Return DNSService from ServiceInfo."""
-        return self._dns_service(override_ttl)
-
-    def _dns_service(self, override_ttl: int_ | None) -> DNSService:
-        """Return DNSService from ServiceInfo."""
-        cacheable = override_ttl is None
-        if self._dns_service_cache is not None and cacheable:
-            return self._dns_service_cache
-        port = self.port
-        if TYPE_CHECKING:
-            assert isinstance(port, int)
-        record = DNSService(
-            self._name,
-            _TYPE_SRV,
-            _CLASS_IN_UNIQUE,
-            override_ttl if override_ttl is not None else self.host_ttl,
-            self.priority,
-            self.weight,
-            port,
-            self.server or self._name,
-            0.0,
-        )
-        if cacheable:
-            self._dns_service_cache = record
-        return record
-
-    def dns_text(self, override_ttl: int_ | None = None) -> DNSText:
-        """Return DNSText from ServiceInfo."""
-        return self._dns_text(override_ttl)
-
-    def _dns_text(self, override_ttl: int_ | None) -> DNSText:
-        """Return DNSText from ServiceInfo."""
-        cacheable = override_ttl is None
-        if self._dns_text_cache is not None and cacheable:
-            return self._dns_text_cache
-        record = DNSText(
-            self._name,
-            _TYPE_TXT,
-            _CLASS_IN_UNIQUE,
-            override_ttl if override_ttl is not None else self.other_ttl,
-            self.text,
-            0.0,
-        )
-        if cacheable:
-            self._dns_text_cache = record
-        return record
-
-    def dns_nsec(self, missing_types: list[int], override_ttl: int_ | None = None) -> DNSNsec | None:
-        """Deprecated: use dns_address_nsec instead; missing_types is ignored."""
-        warnings.warn(
-            "dns_nsec is deprecated, and will be removed in a future version. "
-            "Use dns_address_nsec instead; missing_types is ignored.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self._dns_address_nsec(override_ttl)
-
-    def dns_address_nsec(self, override_ttl: int_ | None = None) -> DNSNsec | None:
-        """Return DNSNsec asserting which address types exist, or None if not applicable."""
-        return self._dns_address_nsec(override_ttl)
-
-    def _dns_address_nsec(self, override_ttl: int_ | None) -> DNSNsec | None:
-        cacheable = override_ttl is None
-        if self._dns_address_nsec_cache is not None and cacheable:
-            return self._dns_address_nsec_cache
-        # RFC 6762 §6.1: the type bitmap lists the rrtypes that exist at the
-        # name. Both families present leaves nothing to deny; neither leaves
-        # nothing to assert (an empty bitmap is unencodable).
-        has_v4 = bool(self._ipv4_addresses)
-        has_v6 = bool(self._ipv6_addresses)
-        if has_v4 == has_v6:
-            return None
-        assert self.server is not None, "Service server must be set for NSEC record."
-        record = DNSNsec(
-            self.server,
-            _TYPE_NSEC,
-            _CLASS_IN_UNIQUE,
-            override_ttl if override_ttl is not None else self.host_ttl,
-            self.server,
-            [_TYPE_A] if has_v4 else [_TYPE_AAAA],
-            0.0,
-        )
-        if cacheable:
-            self._dns_address_nsec_cache = record
-        return record
-
-    def get_address_and_nsec_records(self, override_ttl: int_ | None = None) -> set[DNSRecord]:
-        """Build a set of address records plus an NSEC asserting which address types exist."""
-        return self._get_address_and_nsec_records(override_ttl)
-
-    def _get_address_and_nsec_records(self, override_ttl: int_ | None) -> set[DNSRecord]:
-        """Build a set of address records plus an NSEC asserting which address types exist."""
-        cacheable = override_ttl is None
-        if self._get_address_and_nsec_records_cache is not None and cacheable:
-            return self._get_address_and_nsec_records_cache
-        records: set[DNSRecord] = set(self._dns_addresses(override_ttl, IPVersion.All))
-        nsec = self._dns_address_nsec(override_ttl)
-        if nsec is not None:
-            records.add(nsec)
-        if cacheable:
-            self._get_address_and_nsec_records_cache = records
-        return records
-
-    def _get_address_records_from_cache_by_type(self, zc: Zeroconf, _type: int_) -> list[DNSAddress]:
-        """Get the addresses from the cache."""
-        if self.server_key is None:
-            return []
-        cache = zc.cache
-        if TYPE_CHECKING:
-            records = cast(
-                list[DNSAddress],
-                cache.get_all_by_details(self.server_key, _type, _CLASS_IN),
+            self._ipv4_addresses = cast(
+                list[ZeroconfIPv4Address],
+                self._get_ip_addresses_from_cache_lifo(zc, now, _TYPE_A),
             )
         else:
-            records = cache.get_all_by_details(self.server_key, _type, _CLASS_IN)
-        return records
+            self._ipv4_addresses = self._get_ip_addresses_from_cache_lifo(zc, now, _TYPE_A)
 
-    def set_server_if_missing(self) -> None:
-        """Set the server if it is missing.
-
-        This function is for backwards compatibility.
-        """
-        if self.server is None:
-            self.server = self._name
-            self.server_key = self.key
-
-    def load_from_cache(self, zc: Zeroconf, now: float_ | None = None) -> bool:
-        """Populate the service info from the cache.
-
-        This method is designed to be threadsafe.
-        """
-        return self._load_from_cache(zc, now or current_time_millis())
-
-    def _load_from_cache(self, zc: Zeroconf, now: float_) -> bool:
-        """Populate the service info from the cache.
-
-        This method is designed to be threadsafe.
-        """
-        cache = zc.cache
-        original_server_key = self.server_key
-        # Denials are only trusted until the next cache load re-derives them.
-        self._ipv4_denied = False
-        self._ipv6_denied = False
-        cached_srv_record = cache.get_by_details(self._name, _TYPE_SRV, _CLASS_IN)
-        if cached_srv_record:
-            self._process_record_threadsafe(zc, cached_srv_record, now)
-        cached_txt_record = cache.get_by_details(self._name, _TYPE_TXT, _CLASS_IN)
-        if cached_txt_record:
-            self._process_record_threadsafe(zc, cached_txt_record, now)
-        if not self._txt_seen:
-            cached_nsec_record = cache.get_by_details(self._name, _TYPE_NSEC, _CLASS_IN)
-            if cached_nsec_record:
-                self._process_record_threadsafe(zc, cached_nsec_record, now)
-        if original_server_key == self.server_key:
-            # If there is a srv which changes the server_key,
-            # A, AAAA, and the server NSEC will already be loaded
-            # from the cache and we do not want to do it twice
-            for record in self._get_address_records_from_cache_by_type(zc, _TYPE_A):
-                self._process_record_threadsafe(zc, record, now)
-            for record in self._get_address_records_from_cache_by_type(zc, _TYPE_AAAA):
-                self._process_record_threadsafe(zc, record, now)
-            if self.server_key and not self._is_complete:
-                cached_server_nsec_record = cache.get_by_details(self.server_key, _TYPE_NSEC, _CLASS_IN)
-                if cached_server_nsec_record:
-                    self._process_record_threadsafe(zc, cached_server_nsec_record, now)
-        return self._is_complete
-
-    @property
-    def _is_complete(self) -> bool:
-        """The ServiceInfo has all expected properties.
-
-        RFC 6763 section 6 requires every DNS-SD service to have a TXT record,
-        so a service is not complete until one has been seen. An empty TXT
-        record counts as seen, as does an NSEC record denying its existence
-        (RFC 6762 section 6.1); a missing one does not.
-        """
-        return bool(self._txt_seen and (self._ipv4_addresses or self._ipv6_addresses))
-
-    @property
-    def _is_denied(self) -> bool:
-        """Every address type this request needs was denied via NSEC (RFC 6762 section 6.1)."""
-        query_types = self._query_record_types
-        return (_TYPE_A not in query_types or (self._ipv4_denied and not self._ipv4_addresses)) and (
-            _TYPE_AAAA not in query_types or (self._ipv6_denied and not self._ipv6_addresses)
-        )
-
-    def request(
-        self,
-        zc: Zeroconf,
-        timeout: float,
-        question_type: DNSQuestionType | None = None,
-        addr: str | None = None,
-        port: int = _MDNS_PORT,
-    ) -> bool:
-        """Populate this object from the network, returning True on success.
-
-        Waits up to timeout milliseconds for the answers to arrive; addr
-        and port direct the queries at a specific responder instead of
-        the multicast group.
-        """
-        assert zc.loop is not None, "Zeroconf instance must have a loop, was it not started?"
-        assert zc.loop.is_running(), "Zeroconf instance loop must be running, was it already stopped?"
-        if zc.loop == get_running_loop():
-            raise RuntimeError("Use AsyncServiceInfo.async_request from the event loop")
-        return bool(
-            run_coro_with_timeout(
-                self.async_request(zc, timeout, question_type, addr, port),
-                zc.loop,
-                timeout,
+    def _set_ipv6_addresses_from_cache(self, zc: Zeroconf, now: float_) -> None:
+        """Set IPv6 addresses from the cache."""
+        if TYPE_CHECKING:
+            self._ipv6_addresses = cast(
+                list[ZeroconfIPv6Address],
+                self._get_ip_addresses_from_cache_lifo(zc, now, _TYPE_AAAA),
             )
-        )
+        else:
+            self._ipv6_addresses = self._get_ip_addresses_from_cache_lifo(zc, now, _TYPE_AAAA)
 
-    def _get_initial_delay(self) -> float_:
-        return _LISTENER_TIME
+    def _set_properties(self, properties: dict[str | bytes, str | bytes | None]) -> None:
+        list_: list[bytes] = []
+        properties_contain_str = False
+        result = b""
+        for key, value in properties.items():
+            if isinstance(key, str):
+                key = key.encode("utf-8")  # noqa: PLW2901
+                properties_contain_str = True
 
-    def _get_random_delay(self) -> int_:
-        return randint(*_AVOID_SYNC_DELAY_RANDOM_INTERVAL)
+            record = key
+            if value is not None:
+                if not isinstance(value, bytes):
+                    value = str(value).encode("utf-8")  # noqa: PLW2901
+                    properties_contain_str = True
+                record += b"=" + value
+            list_.append(record)
+        for item in list_:
+            result = b"".join((result, bytes((len(item),)), item))
+        if not properties_contain_str:
+            # If there are no str keys or values, we can use the properties
+            # as-is, without decoding them, otherwise calling
+            # self.properties will lazy decode them, which is expensive.
+            if TYPE_CHECKING:
+                self._properties = cast(dict[bytes, bytes | None], properties)
+            else:
+                self._properties = properties
+        self.text = result
 
-    async def async_request(
-        self,
-        zc: Zeroconf,
-        timeout: float,
-        question_type: DNSQuestionType | None = None,
-        addr: str | None = None,
-        port: int = _MDNS_PORT,
-    ) -> bool:
-        """Populate this object from the network, returning True on success.
+    def _set_text(self, text: bytes) -> None:
+        if text == self.text:
+            return
+        self.text = text
+        # Clear the properties cache
+        self._properties = None
+        self._decoded_properties = None
 
-        Event loop flavor of request; waits up to timeout milliseconds
-        for the answers to arrive, and addr and port direct the queries
-        at a specific responder instead of the multicast group.
+    def _unpack_text_into_properties(self) -> None:
+        """Unpacks the text field into properties"""
+        text = self.text
+        end = len(text)
+        if end == 0:
+            # Properties should be set atomically
+            # in case another thread is reading them
+            self._properties = {}
+            return
+
+        index = 0
+        properties: dict[bytes, bytes | None] = {}
+        while index < end:
+            length = text[index]
+            index += 1
+            key_value = text[index : index + length]
+            key, sep, value = key_value.partition(b"=")
+            if key not in properties:
+                # RFC 6763 section 6.4 distinguishes a key with no '=' (a
+                # boolean attribute: present, no value) from `key=` (present
+                # with an empty value), so test the separator, not the value.
+                properties[key] = value if sep else None
+            index += length
+
+        self._properties = properties
+
+    def _upsert_ipv6_address(self, ip_addr: ZeroconfIPv6Address) -> bool:
+        """Insert or update an IPv6 address in LIFO order.
+
+        Compares by integer (not IPv6Address equality, which respects
+        scope_id) so the same link-local address received first without
+        scope (IPv4 socket) and then with scope (IPv6 socket) collapses
+        to one entry. The scoped variant wins so parsed_scoped_addresses()
+        can return a qualified address.
         """
-        if not zc.started:
-            await zc.async_wait_for_start()
-
-        now = current_time_millis()
-
-        if self._load_from_cache(zc, now):
+        ipv6_addresses = self._ipv6_addresses
+        existing_idx = _index_of_same_address(ipv6_addresses, ip_addr)
+        if existing_idx == -1:
+            ipv6_addresses.insert(0, ip_addr)
             return True
-
-        if TYPE_CHECKING:
-            assert zc.loop is not None
-
-        first_request = True
-        delay = self._get_initial_delay()
-        next_ = now
-        last = now + timeout
-        try:
-            zc.async_add_listener(self, None)
-            while not self._is_complete:
-                if last <= now or self._is_denied:
-                    return False
-                if next_ <= now:
-                    this_question_type = question_type or (QU_QUESTION if first_request else QM_QUESTION)
-                    out = self._generate_request_query(zc, now, this_question_type)
-                    first_request = False
-                    if out.questions:
-                        # All questions may have been suppressed
-                        # by the question history, so nothing to send,
-                        # but keep waiting for answers in case another
-                        # client on the network is asking the same
-                        # question or they have not arrived yet.
-                        zc.async_send(out, addr, port)
-                    next_ = now + delay
-                    next_ += self._get_random_delay()
-                    if this_question_type is QM_QUESTION and delay < _DUPLICATE_QUESTION_INTERVAL:
-                        # If we just asked a QM question, we need to
-                        # wait at least the duplicate question interval
-                        # before asking another QM question otherwise
-                        # its likely to be suppressed by the question
-                        # history of the remote responder.
-                        delay = _DUPLICATE_QUESTION_INTERVAL
-
-                await self.async_wait(min(next_, last) - now, zc.loop)
-                now = current_time_millis()
-        finally:
-            zc.async_remove_listener(self)
-
-        return True
-
-    def _add_question_with_known_answers(
-        self,
-        out: DNSOutgoing,
-        qu_question: bool,
-        question_history: QuestionHistory,
-        cache: DNSCache,
-        now: float_,
-        name: str_,
-        type_: int_,
-        class_: int_,
-        skip_if_known_answers: bool,
-    ) -> None:
-        """Add a question with known answers if its not suppressed."""
-        known_answers = {
-            answer for answer in cache.get_all_by_details(name, type_, class_) if not answer.is_stale(now)
-        }
-        if skip_if_known_answers and known_answers:
-            return
-        question = DNSQuestion(name, type_, class_)
-        if qu_question:
-            question.unicast = True
-        elif question_history.suppresses(question, now, known_answers):
-            return
-        else:
-            question_history.add_question_at_time(question, now, known_answers)
-        out.add_question(question)
-        for answer in known_answers:
-            out.add_answer_at_time(answer, now)
-
-    def _generate_request_query(
-        self, zc: Zeroconf, now: float_, question_type: DNSQuestionType
-    ) -> DNSOutgoing:
-        """Generate the request query."""
-        out = DNSOutgoing(_FLAGS_QR_QUERY)
-        name = self._name
-        server = self.server or name
-        cache = zc.cache
-        history = zc.question_history
-        qu_question = question_type is QU_QUESTION
-        if _TYPE_SRV in self._query_record_types:
-            self._add_question_with_known_answers(
-                out, qu_question, history, cache, now, name, _TYPE_SRV, _CLASS_IN, True
-            )
-        if _TYPE_TXT in self._query_record_types:
-            self._add_question_with_known_answers(
-                out, qu_question, history, cache, now, name, _TYPE_TXT, _CLASS_IN, True
-            )
-        if _TYPE_A in self._query_record_types:
-            self._add_question_with_known_answers(
-                out, qu_question, history, cache, now, server, _TYPE_A, _CLASS_IN, False
-            )
-        if _TYPE_AAAA in self._query_record_types:
-            self._add_question_with_known_answers(
-                out, qu_question, history, cache, now, server, _TYPE_AAAA, _CLASS_IN, False
-            )
-        return out
-
-    def __repr__(self) -> str:
-        return "{}({})".format(
-            type(self).__name__,
-            ", ".join(
-                f"{name}={getattr(self, name)!r}"
-                for name in (
-                    "type",
-                    "name",
-                    "addresses",
-                    "port",
-                    "weight",
-                    "priority",
-                    "server",
-                    "properties",
-                    "interface_index",
-                )
-            ),
-        )
+        existing = ipv6_addresses[existing_idx]
+        if _has_more_scope_info(ip_addr, existing):
+            ipv6_addresses.pop(existing_idx)
+            ipv6_addresses.insert(0, ip_addr)
+            return True
+        if existing_idx != 0:
+            ipv6_addresses.pop(existing_idx)
+            ipv6_addresses.insert(0, existing)
+        return False
 
 
 class AsyncServiceInfo(ServiceInfo):


### PR DESCRIPTION
## Summary
The second independent audit showed #1867 missed the classes outside `_dns.py` and the protocol writers; `Zeroconf` in particular kept the 2009 public method sequence intact. This applies the same stated rule (dunders first with `__init__` pinned, public alphabetical, private alphabetical) to `Zeroconf`, `DNSCache`, `ServiceInfo`, `ServiceBrowser`, `_ServiceBrowserBase` and `DNSIncoming`.

Measured with the auditor's metric (ordered LCS over shared snake cased method names vs the 2009 monolith): Zeroconf 0.92 to 0.23, ServiceInfo 1.00 to 0.50, DNSIncoming 0.78 to 0.44, DNSCache 1.00 to 0.75. ServiceBrowser stays at 1.00 because its three shared names happen to sort alphabetically into the 2009 order; the arrangement is rule generated either way.

No behavior changes; pure declaration reordering. pxd files untouched.

## Test plan
- [x] full suite passes against a REQUIRE_CYTHON rebuild
- [ ] CodSpeed should be flat