### PR TITLE
chore: per key txt display in the browser examples

### DIFF
--- a/examples/async_browser.py
+++ b/examples/async_browser.py
@@ -30,7 +30,9 @@ async def show_service_info(zeroconf: Zeroconf, service_type: str, name: str) ->
     if await info.async_request(zeroconf, 3000):
         print(f"  addresses: {', '.join(info.parsed_scoped_addresses())}")
         print(f"  server: {info.server} port: {info.port}")
-        print(f"  properties: {info.decoded_properties}")
+        for key, value in info.decoded_properties.items():
+            if key:
+                print(f"  txt {key} = {value}")
 
 
 async def main(ip_version: IPVersion) -> None:

--- a/examples/browser.py
+++ b/examples/browser.py
@@ -17,7 +17,9 @@ class PrintingListener(ServiceListener):
         if info is not None:
             print(f"  addresses: {', '.join(info.parsed_scoped_addresses())}")
             print(f"  server: {info.server} port: {info.port}")
-            print(f"  properties: {info.decoded_properties}")
+            for key, value in info.decoded_properties.items():
+                if key:
+                    print(f"  txt {key} = {value}")
 
     def remove_service(self, zc: Zeroconf, type_: str, name: str) -> None:
         print(f"removed: {name}")


### PR DESCRIPTION
## Summary
Live testing the recreated examples on a real network showed browser.py and async_browser.py print the raw decoded_properties dict, which renders as {'': None} for services with an empty TXT record. Both now use the same per key txt display as the newest examples, skipping the empty key. All four browse and registration examples were run against a live network with real services and exit cleanly.

## Test plan
- [x] browser.py, async_browser.py, registration.py and async_registration.py all live tested, clean output and exit codes