### PR TITLE
chore: adopt the zc fixture across the remaining simple tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,12 +105,15 @@ def verify_threads_ended():
 
 
 @pytest.fixture
-def zc() -> Generator[Zeroconf]:
+def zc(verify_threads_ended: None) -> Generator[Zeroconf]:
     """Yield a loopback `Zeroconf` and close it on teardown.
 
     Replaces the inline `zc = Zeroconf(interfaces=["127.0.0.1"])` +
     explicit `zc.close()` pattern duplicated across the suite. Calling
     `zc.close()` inside a test is still safe — `close()` is idempotent.
+
+    Depends on `verify_threads_ended` so the instance is torn down before
+    the thread check runs.
     """
     zc = Zeroconf(interfaces=["127.0.0.1"])
     try:
@@ -120,7 +123,7 @@ def zc() -> Generator[Zeroconf]:
 
 
 @pytest_asyncio.fixture
-async def aiozc() -> AsyncGenerator[AsyncZeroconf]:
+async def aiozc(verify_threads_ended: None) -> AsyncGenerator[AsyncZeroconf]:
     """Yield a loopback `AsyncZeroconf` and close it on teardown.
 
     Replaces the inline `aiozc = AsyncZeroconf(interfaces=["127.0.0.1"])`

--- a/tests/services/test_browser.py
+++ b/tests/services/test_browser.py
@@ -54,11 +54,10 @@ def teardown_module():
         log.setLevel(original_logging_level)
 
 
-def test_service_browser_cancel_multiple_times():
+def test_service_browser_cancel_multiple_times(zc: Zeroconf) -> None:
     """Test we can cancel a ServiceBrowser multiple times before close."""
 
     # instantiate a zeroconf instance
-    zc = Zeroconf(interfaces=["127.0.0.1"])
     # start a browser
     type_ = "_hap._tcp.local."
 
@@ -73,14 +72,11 @@ def test_service_browser_cancel_multiple_times():
     browser.cancel()
     browser.cancel()
 
-    zc.close()
 
-
-def test_service_browser_cancel_context_manager():
+def test_service_browser_cancel_context_manager(zc: Zeroconf) -> None:
     """Test we can cancel a ServiceBrowser with it being used as a context manager."""
 
     # instantiate a zeroconf instance
-    zc = Zeroconf(interfaces=["127.0.0.1"])
     # start a browser
     type_ = "_hap._tcp.local."
 
@@ -101,8 +97,6 @@ def test_service_browser_cancel_context_manager():
     asyncio.run_coroutine_threadsafe(asyncio.sleep(0), zc.loop).result()
 
     assert cast(bool, browser.done) is True
-
-    zc.close()
 
 
 def test_service_browser_cancel_multiple_times_after_close():
@@ -834,12 +828,10 @@ async def test_asking_qu_questions():
             await aiozc.async_close()
 
 
-def test_legacy_record_update_listener(quick_timing: None) -> None:
+def test_legacy_record_update_listener(zc: Zeroconf, quick_timing: None) -> None:
     """Test a RecordUpdateListener that does not implement update_records."""
 
     # instantiate a zeroconf instance
-    zc = Zeroconf(interfaces=["127.0.0.1"])
-
     with pytest.raises(RuntimeError):
         r.RecordUpdateListener().update_record(
             zc,
@@ -892,14 +884,11 @@ def test_legacy_record_update_listener(quick_timing: None) -> None:
     # Removing a second time should not throw
     zc.remove_listener(listener)
 
-    zc.close()
 
-
-def test_service_browser_is_aware_of_port_changes():
+def test_service_browser_is_aware_of_port_changes(zc: Zeroconf) -> None:
     """Test that the ServiceBrowser is aware of port changes."""
 
     # instantiate a zeroconf instance
-    zc = Zeroconf(interfaces=["127.0.0.1"])
     # start a browser
     type_ = "_hap._tcp.local."
     registration_name = f"xxxyyy.{type_}"
@@ -955,14 +944,11 @@ def test_service_browser_is_aware_of_port_changes():
     assert service_info.port == 400
     browser.cancel()
 
-    zc.close()
 
-
-def test_service_browser_listeners_update_service():
+def test_service_browser_listeners_update_service(zc: Zeroconf) -> None:
     """Test that the ServiceBrowser ServiceListener that implements update_service."""
 
     # instantiate a zeroconf instance
-    zc = Zeroconf(interfaces=["127.0.0.1"])
     # start a browser
     type_ = "_hap._tcp.local."
     registration_name = f"xxxyyy.{type_}"
@@ -1017,14 +1003,11 @@ def test_service_browser_listeners_update_service():
     ]
     browser.cancel()
 
-    zc.close()
 
-
-def test_service_browser_listeners_no_update_service():
+def test_service_browser_listeners_no_update_service(zc: Zeroconf) -> None:
     """A listener that ignores update events records only add/remove callbacks."""
 
     # instantiate a zeroconf instance
-    zc = Zeroconf(interfaces=["127.0.0.1"])
     # start a browser
     type_ = "_hap._tcp.local."
     registration_name = f"xxxyyy.{type_}"
@@ -1077,12 +1060,9 @@ def test_service_browser_listeners_no_update_service():
     ]
     browser.cancel()
 
-    zc.close()
 
-
-def test_service_browser_nsec_record_does_not_trigger_update():
+def test_service_browser_nsec_record_does_not_trigger_update(zc: Zeroconf) -> None:
     """NSEC records assert non-existence and must not fire ServiceStateChange.Updated."""
-    zc = Zeroconf(interfaces=["127.0.0.1"])
     type_ = "_hap._tcp.local."
     registration_name = f"xxxyyy.{type_}"
     callbacks: list[tuple[str, str, str]] = []
@@ -1144,24 +1124,21 @@ def test_service_browser_nsec_record_does_not_trigger_update():
         assert callbacks == [("add", type_, registration_name)]
     finally:
         browser.cancel()
-        zc.close()
 
 
-def test_service_browser_uses_non_strict_names():
+def test_service_browser_uses_non_strict_names(zc: Zeroconf) -> None:
     """Verify we can look for technically invalid names as we cannot change what others do."""
 
     # dummy service callback
     def on_service_state_change(zeroconf, service_type, state_change, name):
         pass
 
-    zc = r.Zeroconf(interfaces=["127.0.0.1"])
     browser = ServiceBrowser(zc, ["_tivo-videostream._tcp.local."], [on_service_state_change])
     browser.cancel()
 
     # Still fail on completely invalid
     with pytest.raises(r.BadTypeInNameException):
         browser = ServiceBrowser(zc, ["tivo-videostream._tcp.local."], [on_service_state_change])
-    zc.close()
 
 
 def test_group_ptr_queries_with_known_answers():
@@ -1408,11 +1385,10 @@ async def test_query_scheduler_rescue_records():
     await aiozc.async_close()
 
 
-def test_service_browser_matching():
+def test_service_browser_matching(zc: Zeroconf) -> None:
     """Test that the ServiceBrowser matching does not match partial names."""
 
     # instantiate a zeroconf instance
-    zc = Zeroconf(interfaces=["127.0.0.1"])
     # start a browser
     type_ = "_http._tcp.local."
     registration_name = f"xxxyyy.{type_}"
@@ -1494,8 +1470,6 @@ def test_service_browser_matching():
         ("update", type_, registration_name),
     ]
     browser.cancel()
-
-    zc.close()
 
 
 @patch.object(_engine, "_CACHE_CLEANUP_INTERVAL", 0.01)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -181,13 +181,9 @@ def test_use_asyncio_true_requires_running_loop():
         r.Zeroconf(interfaces=["127.0.0.1"], use_asyncio=True)
 
 
-def test_use_asyncio_default_starts_thread_without_loop():
+def test_use_asyncio_default_starts_thread_without_loop(zc: Zeroconf) -> None:
     """use_asyncio=None (default) keeps the historic auto-detect behavior."""
-    zc = r.Zeroconf(interfaces=["127.0.0.1"])
-    try:
-        assert zc._loop_thread is not None
-    finally:
-        zc.close()
+    assert zc._loop_thread is not None
 
 
 def test_async_updates_from_response():
@@ -396,9 +392,8 @@ def test_invalid_packets_ignored_and_does_not_cause_loop_exception():
     assert zc.cache.get(entry) is not None
 
 
-def test_goodbye_all_services():
+def test_goodbye_all_services(zc: Zeroconf) -> None:
     """Verify generating the goodbye query does not change with time."""
-    zc = Zeroconf(interfaces=["127.0.0.1"])
     out = zc.generate_unregister_all_services()
     assert out is None
     type_ = "_http._tcp.local."
@@ -429,15 +424,11 @@ def test_goodbye_all_services():
     assert out3 is None
     assert zc.registry.async_get_service_infos() == []
 
-    zc.close()
 
-
-def test_register_service_with_custom_ttl(quick_timing: None) -> None:
+def test_register_service_with_custom_ttl(zc: Zeroconf, quick_timing: None) -> None:
     """Test a registering a service with a custom ttl."""
 
     # instantiate a zeroconf instance
-    zc = Zeroconf(interfaces=["127.0.0.1"])
-
     # start a browser
     type_ = "_homeassistant._tcp.local."
     name = "MyTestHome"
@@ -456,15 +447,12 @@ def test_register_service_with_custom_ttl(quick_timing: None) -> None:
     record = zc.cache.get(info_service.dns_pointer())
     assert record is not None
     assert record.ttl == 3000
-    zc.close()
 
 
-def test_logging_packets(caplog: pytest.LogCaptureFixture, quick_timing: None) -> None:
+def test_logging_packets(zc: Zeroconf, caplog: pytest.LogCaptureFixture, quick_timing: None) -> None:
     """Test packets are only logged with debug logging."""
 
     # instantiate a zeroconf instance
-    zc = Zeroconf(interfaces=["127.0.0.1"])
-
     # start a browser
     type_ = "_logging._tcp.local."
     name = "TLD"
@@ -492,23 +480,18 @@ def test_logging_packets(caplog: pytest.LogCaptureFixture, quick_timing: None) -
     assert "Sending to" not in caplog.text
     logging.getLogger("zeroconf").setLevel(logging.DEBUG)
 
-    zc.close()
 
-
-def test_get_service_info_failure_path():
+def test_get_service_info_failure_path(zc: Zeroconf) -> None:
     """Verify get_service_info return None when the underlying call returns False."""
-    zc = Zeroconf(interfaces=["127.0.0.1"])
     assert zc.get_service_info("_neverused._tcp.local.", "xneverused._neverused._tcp.local.", 10) is None
-    zc.close()
 
 
 @pytest.mark.skipif(
     sys.platform == "win32",
     reason="multicast loopback on the 127.0.0.1-only socket is unreliable on GH Actions Windows runners",
 )
-def test_sending_unicast():
+def test_sending_unicast(zc: Zeroconf) -> None:
     """Test sending unicast response."""
-    zc = Zeroconf(interfaces=["127.0.0.1"])
     generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
     entry = r.DNSText(
         "didnotcrashincoming._crash._tcp.local.",
@@ -534,11 +517,8 @@ def test_sending_unicast():
 
     assert zc.cache.get(entry) is not None
 
-    zc.close()
 
-
-def test_tc_bit_defers():
-    zc = Zeroconf(interfaces=["127.0.0.1"])
+def test_tc_bit_defers(zc: Zeroconf) -> None:
     _wait_for_start(zc)
     type_ = "_tcbitdefer._tcp.local."
     name = "knownname"
@@ -634,11 +614,9 @@ def test_tc_bit_defers():
 
     # unregister
     zc.unregister_service(info)
-    zc.close()
 
 
-def test_tc_bit_defers_last_response_missing():
-    zc = Zeroconf(interfaces=["127.0.0.1"])
+def test_tc_bit_defers_last_response_missing(zc: Zeroconf) -> None:
     _wait_for_start(zc)
     type_ = "_knowndefer._tcp.local."
     name = "knownname"
@@ -751,12 +729,10 @@ def test_tc_bit_defers_last_response_missing():
 
     # unregister
     zc.registry.async_remove(info)
-    zc.close()
 
 
-def test_tc_bit_defer_window_is_bounded():
+def test_tc_bit_defer_window_is_bounded(zc: Zeroconf) -> None:
     """TC-deferral assembly window must not slide past first_arrival + max delay."""
-    zc = Zeroconf(interfaces=["127.0.0.1"])
     _wait_for_start(zc)
     type_ = "_boundeddefer._tcp.local."
     registration_name = f"knownname.{type_}"
@@ -797,7 +773,6 @@ def test_tc_bit_defer_window_is_bounded():
             assert protocol._timers[source_ip].when() <= first_when
 
     zc.registry.async_remove(info)
-    zc.close()
 
 
 def _make_distinct_tc_packets(count: int, name_prefix: str = "q") -> list[bytes]:
@@ -819,9 +794,8 @@ def _synthetic_source_ip(i: int) -> str:
     return f"192.0.2.{i - 512}"
 
 
-def test_tc_bit_per_addr_queue_is_bounded(quick_timing: None) -> None:
+def test_tc_bit_per_addr_queue_is_bounded(zc: Zeroconf, quick_timing: None) -> None:
     """Per-addr deferred queue must not grow past ``_MAX_DEFERRED_PER_ADDR``."""
-    zc = Zeroconf(interfaces=["127.0.0.1"])
     _wait_for_start(zc)
     protocol = zc.engine.protocols[0]
     source_ip = "203.0.113.21"
@@ -841,12 +815,9 @@ def test_tc_bit_per_addr_queue_is_bounded(quick_timing: None) -> None:
         retained = [incoming.data for incoming in protocol._deferred[source_ip]]
         assert retained == packets[: const._MAX_DEFERRED_PER_ADDR]
 
-    zc.close()
 
-
-def test_tc_bit_total_addrs_is_bounded(quick_timing: None) -> None:
+def test_tc_bit_total_addrs_is_bounded(zc: Zeroconf, quick_timing: None) -> None:
     """Distinct addrs with deferred state must not exceed ``_MAX_DEFERRED_ADDRS``."""
-    zc = Zeroconf(interfaces=["127.0.0.1"])
     _wait_for_start(zc)
     protocol = zc.engine.protocols[0]
 
@@ -865,12 +836,9 @@ def test_tc_bit_total_addrs_is_bounded(quick_timing: None) -> None:
         assert len(protocol._deferred) == const._MAX_DEFERRED_ADDRS
         assert len(protocol._timers) == const._MAX_DEFERRED_ADDRS
 
-    zc.close()
 
-
-def test_tc_bit_eviction_drops_oldest_addr(quick_timing: None) -> None:
+def test_tc_bit_eviction_drops_oldest_addr(zc: Zeroconf, quick_timing: None) -> None:
     """Adding a new addr at capacity drops the oldest insertion (FIFO)."""
-    zc = Zeroconf(interfaces=["127.0.0.1"])
     _wait_for_start(zc)
     protocol = zc.engine.protocols[0]
 
@@ -891,8 +859,6 @@ def test_tc_bit_eviction_drops_oldest_addr(quick_timing: None) -> None:
         assert oldest not in protocol._timers
         assert new_addr in protocol._deferred
         assert len(protocol._deferred) == const._MAX_DEFERRED_ADDRS
-
-    zc.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -126,11 +126,10 @@ def test_guard_against_oversized_packets():
     zc.close()
 
 
-def test_guard_against_duplicate_packets():
+def test_guard_against_duplicate_packets(zc: Zeroconf) -> None:
     """Ensure we do not process duplicate packets.
     These packets can quickly overwhelm the system.
     """
-    zc = Zeroconf(interfaces=["127.0.0.1"])
     zc.registry.async_add(
         ServiceInfo(
             "_http._tcp.local.",
@@ -275,12 +274,9 @@ def test_guard_against_duplicate_packets():
         _handle_query_or_defer.assert_not_called()
         _handle_query_or_defer.reset_mock()
 
-    zc.close()
 
-
-def test_guard_against_alternating_duplicate_packets() -> None:
+def test_guard_against_alternating_duplicate_packets(zc: Zeroconf) -> None:
     """Alternating two distinct payloads must not bypass duplicate suppression."""
-    zc = Zeroconf(interfaces=["127.0.0.1"])
     zc.registry.async_add(
         ServiceInfo(
             "_http._tcp.local.",
@@ -331,12 +327,9 @@ def test_guard_against_alternating_duplicate_packets() -> None:
             listener._process_datagram_at_time(False, len(packet_b), now, packet_b, addrs)
         _handle_query_or_defer.assert_not_called()
 
-    zc.close()
 
-
-def test_recent_packets_window_is_bounded() -> None:
+def test_recent_packets_window_is_bounded(zc: Zeroconf) -> None:
     """Distinct payloads beyond the recency window evict oldest entries."""
-    zc = Zeroconf(interfaces=["127.0.0.1"])
     zc.registry.async_add(
         ServiceInfo(
             "_http._tcp.local.",
@@ -391,17 +384,14 @@ def test_recent_packets_window_is_bounded() -> None:
             listener._process_datagram_at_time(False, len(packet), now, packet, addrs)
         assert _handle_query_or_defer.call_count == len(evicted)
 
-    zc.close()
 
-
-def test_recent_packets_miss_with_small_now_is_not_suppressed() -> None:
+def test_recent_packets_miss_with_small_now_is_not_suppressed(zc: Zeroconf) -> None:
     """A cache miss must not trigger suppression when `now` is below the suppression interval."""
     # time.monotonic() can start near zero on freshly booted systems, so
     # `now - _DUPLICATE_PACKET_SUPPRESSION_INTERVAL` is negative for the
     # first second of process lifetime. A 0.0 default on the recency
     # dict would let any negative `now - INTERVAL` satisfy the compare
     # and suppress legitimate traffic.
-    zc = Zeroconf(interfaces=["127.0.0.1"])
     zc.registry.async_add(
         ServiceInfo(
             "_http._tcp.local.",
@@ -435,5 +425,3 @@ def test_recent_packets_miss_with_small_now_is_not_suppressed() -> None:
     with patch.object(listener, "handle_query_or_defer") as _handle_query_or_defer:
         listener._process_datagram_at_time(False, len(packet), 0.0, packet, addrs)
         _handle_query_or_defer.assert_called_once()
-
-    zc.close()

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -29,12 +29,10 @@ def teardown_module():
         log.setLevel(original_logging_level)
 
 
-def test_legacy_record_update_listener(quick_timing: None) -> None:
+def test_legacy_record_update_listener(zc: Zeroconf, quick_timing: None) -> None:
     """Test a RecordUpdateListener that does not implement update_records."""
 
     # instantiate a zeroconf instance
-    zc = Zeroconf(interfaces=["127.0.0.1"])
-
     with pytest.raises(RuntimeError):
         r.RecordUpdateListener().update_record(
             zc,
@@ -86,8 +84,6 @@ def test_legacy_record_update_listener(quick_timing: None) -> None:
     zc.remove_listener(listener)
     # Removing a second time should not throw
     zc.remove_listener(listener)
-
-    zc.close()
 
 
 def test_record_update_compat():


### PR DESCRIPTION
## Summary
Third cleanup pass. Twenty six more tests across test_core, test_listener, test_updates and services/test_browser drop their hand rolled loopback Zeroconf construct and close boilerplate for the `zc` fixture. Conversion is scoped per function and only applies where the construct and close pair is the whole lifecycle; tests whose close is mid behavior stay as they are, and one test that patches the cache cleanup interval at construction time was restored to inline construction since the fixture builds the instance before a decorator patch takes effect.

The fixtures now depend on `verify_threads_ended`, pinning teardown order so the instance always closes before the thread leak check runs.

## Test plan
- [x] full suite passes, lint clean