### PR TITLE
chore: convert the remaining canonical service info builds to the helper

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -12,6 +12,7 @@ import sys
 import time
 from collections.abc import Iterable
 from functools import cache
+from typing import Any
 from unittest import mock
 
 import ifaddr
@@ -67,8 +68,23 @@ def make_service_info(
     properties: dict | bytes | None = None,
     server: str = "spare-rig.local.",
     addresses: list[bytes] | None = None,
+    parsed_addresses: list[str] | None = None,
+    interface_index: int | None = None,
+    host_ttl: int | None = None,
+    other_ttl: int | None = None,
 ) -> ServiceInfo:
     """Build a ServiceInfo with the suite's canonical fixture values."""
+    kwargs: dict[str, Any] = {}
+    if parsed_addresses is not None:
+        kwargs["parsed_addresses"] = parsed_addresses
+    else:
+        kwargs["addresses"] = [socket.inet_aton("10.7.4.2")] if addresses is None else addresses
+    if interface_index is not None:
+        kwargs["interface_index"] = interface_index
+    if host_ttl is not None:
+        kwargs["host_ttl"] = host_ttl
+    if other_ttl is not None:
+        kwargs["other_ttl"] = other_ttl
     return ServiceInfo(
         type_,
         name,
@@ -77,7 +93,7 @@ def make_service_info(
         0,
         {"path": "/healthz/"} if properties is None else properties,
         server,
-        addresses=[socket.inet_aton("10.7.4.2")] if addresses is None else addresses,
+        **kwargs,
     )
 
 

--- a/tests/services/test_browser.py
+++ b/tests/services/test_browser.py
@@ -27,7 +27,6 @@ from zeroconf import (
 )
 from zeroconf._services import ServiceStateChange
 from zeroconf._services.browser import ServiceBrowser, _ScheduledPTRQuery
-from zeroconf._services.info import ServiceInfo
 from zeroconf.asyncio import AsyncServiceBrowser, AsyncZeroconf
 
 from .. import (
@@ -35,6 +34,7 @@ from .. import (
     _inject_response,
     _wait_for_start,
     has_working_ipv6,
+    make_service_info,
     mock_incoming_msg,
     time_changed_millis,
 )
@@ -589,16 +589,7 @@ async def test_asking_default_is_asking_qm_questions_after_the_first_qu(quick_ti
         service_removed = asyncio.Event()
 
         browser = AsyncServiceBrowser(zeroconf_browser, type_, [on_service_state_change])
-        info = ServiceInfo(
-            type_,
-            registration_name,
-            80,
-            0,
-            0,
-            {"path": "/healthz/"},
-            "spare-rig.local.",
-            addresses=[socket.inet_aton("10.7.4.2")],
-        )
+        info = make_service_info(type_, registration_name, properties={"path": "/healthz/"})
         task = await aio_zeroconf_registrar.async_register_service(info)
         await task
         loop = asyncio.get_running_loop()
@@ -690,16 +681,7 @@ async def test_ttl_refresh_cancelled_rescue_query(quick_timing: None) -> None:
         service_removed = asyncio.Event()
 
         browser = AsyncServiceBrowser(zeroconf_browser, type_, [on_service_state_change])
-        info = ServiceInfo(
-            type_,
-            registration_name,
-            80,
-            0,
-            0,
-            {"path": "/healthz/"},
-            "spare-rig.local.",
-            addresses=[socket.inet_aton("10.7.4.2")],
-        )
+        info = make_service_info(type_, registration_name, properties={"path": "/healthz/"})
         task = await aio_zeroconf_registrar.async_register_service(info)
         await task
         loop = asyncio.get_running_loop()
@@ -860,16 +842,7 @@ def test_legacy_record_update_listener(zc: Zeroconf, quick_timing: None) -> None
     name = "MyTestHome"
     browser = ServiceBrowser(zc, type_, [on_service_state_change])
 
-    info_service = ServiceInfo(
-        type_,
-        f"{name}.{type_}",
-        80,
-        0,
-        0,
-        {"path": "/healthz/"},
-        "spare-rig.local.",
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
+    info_service = make_service_info(type_, f"{name}.{type_}", properties={"path": "/healthz/"})
 
     zc.register_service(info_service)
 
@@ -906,7 +879,7 @@ def test_service_browser_is_aware_of_port_changes(zc: Zeroconf) -> None:
     desc = {"path": "/healthz/"}
     address_parsed = "10.7.4.2"
     address = socket.inet_aton(address_parsed)
-    info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, "spare-rig.local.", addresses=[address])
+    info = make_service_info(type_, registration_name, properties=desc, addresses=[address])
 
     _inject_response(
         zc,
@@ -974,7 +947,7 @@ def test_service_browser_listeners_update_service(zc: Zeroconf) -> None:
     desc = {"path": "/healthz/"}
     address_parsed = "10.7.4.2"
     address = socket.inet_aton(address_parsed)
-    info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, "spare-rig.local.", addresses=[address])
+    info = make_service_info(type_, registration_name, properties=desc, addresses=[address])
 
     _inject_response(
         zc,
@@ -1032,7 +1005,7 @@ def test_service_browser_listeners_no_update_service(zc: Zeroconf) -> None:
     desc = {"path": "/healthz/"}
     address_parsed = "10.7.4.2"
     address = socket.inet_aton(address_parsed)
-    info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, "spare-rig.local.", addresses=[address])
+    info = make_service_info(type_, registration_name, properties=desc, addresses=[address])
 
     _inject_response(
         zc,
@@ -1087,7 +1060,7 @@ def test_service_browser_nsec_record_does_not_trigger_update(zc: Zeroconf) -> No
     try:
         desc = {"path": "/healthz/"}
         address = socket.inet_aton("10.7.4.2")
-        info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, "spare-rig.local.", addresses=[address])
+        info = make_service_info(type_, registration_name, properties=desc, addresses=[address])
 
         _inject_response(
             zc,
@@ -1416,16 +1389,9 @@ def test_service_browser_matching(zc: Zeroconf) -> None:
     desc = {"path": "/healthz/"}
     address_parsed = "10.7.4.2"
     address = socket.inet_aton(address_parsed)
-    info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, "spare-rig.local.", addresses=[address])
-    should_not_match = ServiceInfo(
-        not_match_type_,
-        not_match_registration_name,
-        80,
-        0,
-        0,
-        desc,
-        "spare-rig.local.",
-        addresses=[address],
+    info = make_service_info(type_, registration_name, properties=desc, addresses=[address])
+    should_not_match = make_service_info(
+        not_match_type_, not_match_registration_name, properties=desc, addresses=[address]
     )
 
     _inject_response(
@@ -1502,17 +1468,14 @@ def test_service_browser_expire_callbacks():
     desc = {"path": "/status1/"}
     address_parsed = "10.7.4.3"
     address = socket.inet_aton(address_parsed)
-    info = ServiceInfo(
+    info = make_service_info(
         type_,
         registration_name,
-        80,
-        0,
-        0,
-        desc,
-        "newname-2.local.",
+        properties=desc,
+        server="newname-2.local.",
+        addresses=[address],
         host_ttl=1,
         other_ttl=1,
-        addresses=[address],
     )
 
     _inject_response(
@@ -1646,16 +1609,7 @@ async def test_close_zeroconf_without_browser_before_start_up_queries(quick_timi
         service_added = asyncio.Event()
 
         browser = AsyncServiceBrowser(zeroconf_browser, type_, [on_service_state_change])
-        info = ServiceInfo(
-            type_,
-            registration_name,
-            80,
-            0,
-            0,
-            {"path": "/healthz/"},
-            "spare-rig.local.",
-            addresses=[socket.inet_aton("10.7.4.2")],
-        )
+        info = make_service_info(type_, registration_name, properties={"path": "/healthz/"})
         task = await aio_zeroconf_registrar.async_register_service(info)
         await task
         loop = asyncio.get_running_loop()
@@ -1713,16 +1667,7 @@ async def test_close_zeroconf_without_browser_after_start_up_queries(quick_timin
         service_added = asyncio.Event()
         browser = AsyncServiceBrowser(zeroconf_browser, type_, [on_service_state_change])
         expected_ttl = const._DNS_OTHER_TTL
-        info = ServiceInfo(
-            type_,
-            registration_name,
-            80,
-            0,
-            0,
-            {"path": "/healthz/"},
-            "spare-rig.local.",
-            addresses=[socket.inet_aton("10.7.4.2")],
-        )
+        info = make_service_info(type_, registration_name, properties={"path": "/healthz/"})
         task = await aio_zeroconf_registrar.async_register_service(info)
         await task
         loop = asyncio.get_running_loop()

--- a/tests/services/test_info.py
+++ b/tests/services/test_info.py
@@ -25,7 +25,13 @@ from zeroconf._utils.ipaddress import ZeroconfIPv4Address
 from zeroconf._utils.net import IPVersion
 from zeroconf.asyncio import AsyncZeroconf
 
-from .. import QUICK_REQUEST_TIMEOUT_MS, _inject_response, has_working_ipv6, mock_incoming_msg
+from .. import (
+    QUICK_REQUEST_TIMEOUT_MS,
+    _inject_response,
+    has_working_ipv6,
+    make_service_info,
+    mock_incoming_msg,
+)
 
 log = logging.getLogger("zeroconf")
 original_logging_level = logging.NOTSET
@@ -702,29 +708,16 @@ def test_multiple_addresses():
     address = socket.inet_aton(address_parsed)
 
     # New kwarg way
-    info = ServiceInfo(
-        type_,
-        registration_name,
-        80,
-        0,
-        0,
-        desc,
-        "spare-rig.local.",
-        addresses=[address, address],
-    )
+    info = make_service_info(type_, registration_name, properties=desc, addresses=[address, address])
 
     assert info.addresses == [address, address]
     assert info.parsed_addresses() == [address_parsed, address_parsed]
     assert info.parsed_scoped_addresses() == [address_parsed, address_parsed]
 
-    info = ServiceInfo(
+    info = make_service_info(
         type_,
         registration_name,
-        80,
-        0,
-        0,
-        desc,
-        "spare-rig.local.",
+        properties=desc,
         parsed_addresses=[address_parsed, address_parsed],
     )
     assert info.addresses == [address, address]
@@ -739,30 +732,19 @@ def test_multiple_addresses():
         address_v6_ll = socket.inet_pton(socket.AF_INET6, address_v6_ll_parsed)
         interface_index = 12
         infos = [
-            ServiceInfo(
+            make_service_info(
                 type_,
                 registration_name,
-                80,
-                0,
-                0,
-                desc,
-                "spare-rig.local.",
+                properties=desc,
                 addresses=[address, address_v6, address_v6_ll],
                 interface_index=interface_index,
             ),
-            ServiceInfo(
+            make_service_info(
                 type_,
                 registration_name,
-                80,
-                0,
-                0,
-                desc,
-                "spare-rig.local.",
-                parsed_addresses=[
-                    address_parsed,
-                    address_v6_parsed,
-                    address_v6_ll_parsed,
-                ],
+                properties=desc,
+                addresses=[],
+                parsed_addresses=[address_parsed, address_v6_parsed, address_v6_ll_parsed],
                 interface_index=interface_index,
             ),
         ]
@@ -1086,7 +1068,7 @@ async def test_multiple_a_addresses_newest_address_first():
     cache.async_add_records([record1, record2])
 
     # New kwarg way
-    info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, host)
+    info = make_service_info(type_, registration_name, properties=desc, server=host, addresses=[])
     info.load_from_cache(aiozc.zeroconf)
     assert info.addresses == [b"\x7f\x00\x00\x02", b"\x7f\x00\x00\x01"]
     await aiozc.async_close()
@@ -1105,7 +1087,7 @@ async def test_invalid_a_addresses(caplog):
     cache.async_add_records([record1, record2])
 
     # New kwarg way
-    info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, host)
+    info = make_service_info(type_, registration_name, properties=desc, server=host, addresses=[])
     info.load_from_cache(aiozc.zeroconf)
     assert not info.addresses
     assert "Encountered invalid address while processing record" in caplog.text
@@ -1123,7 +1105,7 @@ def test_filter_address_by_type_from_service_info():
     registration_name = f"{name}.{type_}"
     ipv4 = socket.inet_aton("10.7.4.2")
     ipv6 = socket.inet_pton(socket.AF_INET6, "2001:db8::1")
-    info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, "spare-rig.local.", addresses=[ipv4, ipv6])
+    info = make_service_info(type_, registration_name, properties=desc, addresses=[ipv4, ipv6])
 
     def dns_addresses_to_addresses(dns_address: list[DNSAddress]) -> list[bytes]:
         return [address.address for address in dns_address]
@@ -1141,16 +1123,7 @@ def test_changing_name_updates_serviceinfo_key():
     """Verify a name change will adjust the underlying key value."""
     type_ = "_homeassistant._tcp.local."
     name = "MyTestHome"
-    info_service = ServiceInfo(
-        type_,
-        f"{name}.{type_}",
-        80,
-        0,
-        0,
-        {"path": "/healthz/"},
-        "spare-rig.local.",
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
+    info_service = make_service_info(type_, f"{name}.{type_}", properties={"path": "/healthz/"})
     assert info_service.key == "mytesthome._homeassistant._tcp.local."
     info_service.name = "YourTestHome._homeassistant._tcp.local."
     assert info_service.key == "yourtesthome._homeassistant._tcp.local."
@@ -1175,16 +1148,7 @@ def test_serviceinfo_address_updates():
             parsed_addresses=["10.7.4.2"],
         )
 
-    info_service = ServiceInfo(
-        type_,
-        f"{name}.{type_}",
-        80,
-        0,
-        0,
-        {"path": "/healthz/"},
-        "spare-rig.local.",
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
+    info_service = make_service_info(type_, f"{name}.{type_}", properties={"path": "/healthz/"})
     info_service.addresses = [socket.inet_aton("10.7.4.3")]
     assert info_service.addresses == [socket.inet_aton("10.7.4.3")]
 
@@ -1195,48 +1159,20 @@ def test_serviceinfo_accepts_bytes_or_string_dict():
     name = "MyTestHome"
     addresses = [socket.inet_aton("10.7.4.2")]
     server_name = "spare-rig.local."
-    info_service = ServiceInfo(
-        type_,
-        f"{name}.{type_}",
-        80,
-        0,
-        0,
-        {b"path": b"/healthz/"},
-        server_name,
-        addresses=addresses,
+    info_service = make_service_info(
+        type_, f"{name}.{type_}", properties={b"path": b"/healthz/"}, server=server_name, addresses=addresses
     )
     assert info_service.dns_text().text == b"\x0epath=/healthz/"
-    info_service = ServiceInfo(
-        type_,
-        f"{name}.{type_}",
-        80,
-        0,
-        0,
-        {"path": "/healthz/"},
-        server_name,
-        addresses=addresses,
+    info_service = make_service_info(
+        type_, f"{name}.{type_}", properties={"path": "/healthz/"}, server=server_name, addresses=addresses
     )
     assert info_service.dns_text().text == b"\x0epath=/healthz/"
-    info_service = ServiceInfo(
-        type_,
-        f"{name}.{type_}",
-        80,
-        0,
-        0,
-        {b"path": "/healthz/"},
-        server_name,
-        addresses=addresses,
+    info_service = make_service_info(
+        type_, f"{name}.{type_}", properties={b"path": "/healthz/"}, server=server_name, addresses=addresses
     )
     assert info_service.dns_text().text == b"\x0epath=/healthz/"
-    info_service = ServiceInfo(
-        type_,
-        f"{name}.{type_}",
-        80,
-        0,
-        0,
-        {"path": b"/healthz/"},
-        server_name,
-        addresses=addresses,
+    info_service = make_service_info(
+        type_, f"{name}.{type_}", properties={"path": b"/healthz/"}, server=server_name, addresses=addresses
     )
     assert info_service.dns_text().text == b"\x0epath=/healthz/"
 
@@ -1335,7 +1271,7 @@ async def test_release_wait_when_new_recorded_added():
     host = "multahost.local."
 
     # New kwarg way
-    info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, host)
+    info = make_service_info(type_, registration_name, properties=desc, server=host, addresses=[])
     task = asyncio.create_task(info.async_request(aiozc.zeroconf, timeout=200))
     generated = r.DNSOutgoing(const._FLAGS_QR_RESPONSE)
     generated.add_answer_at_time(
@@ -1970,7 +1906,7 @@ async def test_release_wait_when_new_recorded_added_concurrency():
     await aiozc.zeroconf.async_wait_for_start()
 
     # New kwarg way
-    info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, host)
+    info = make_service_info(type_, registration_name, properties=desc, server=host, addresses=[])
     tasks = [asyncio.create_task(info.async_request(aiozc.zeroconf, timeout=200000)) for _ in range(10)]
     await asyncio.sleep(0.1)
     for task in tasks:
@@ -2037,7 +1973,9 @@ async def test_service_info_address_nsec_records() -> None:
     registration_name = f"multiareccon.{type_}"
     desc = {"path": "/healthz/"}
     host = "multahostcon.local."
-    info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, host, addresses=[b"\x7f\x00\x00\x01"])
+    info = make_service_info(
+        type_, registration_name, properties=desc, server=host, addresses=[b"\x7f\x00\x00\x01"]
+    )
     nsec_record = info.dns_address_nsec(50)
     assert nsec_record is not None
     assert nsec_record.name == host
@@ -2062,8 +2000,12 @@ def test_service_info_dns_nsec_deprecated() -> None:
     type_ = "_http._tcp.local."
     registration_name = f"depnsec.{type_}"
     host = "depnsec-host.local."
-    info = ServiceInfo(
-        type_, registration_name, 80, 0, 0, {"path": "/healthz/"}, host, addresses=[b"\x7f\x00\x00\x01"]
+    info = make_service_info(
+        type_,
+        registration_name,
+        properties={"path": "/healthz/"},
+        server=host,
+        addresses=[b"\x7f\x00\x00\x01"],
     )
     with pytest.warns(DeprecationWarning, match="dns_address_nsec"):
         record = info.dns_nsec([const._TYPE_AAAA], 50)
@@ -2261,7 +2203,9 @@ def test_load_from_cache_complete_with_locally_set_properties():
         ]
     )
 
-    info = ServiceInfo(type_, registration_name, 80, 0, 0, {"path": "/healthz/"}, host)
+    info = make_service_info(
+        type_, registration_name, properties={"path": "/healthz/"}, server=host, addresses=[]
+    )
     assert info.load_from_cache(zc) is True
     zc.close()
 
@@ -2284,7 +2228,7 @@ def test_load_from_cache_complete_with_empty_locally_set_properties():
         ]
     )
 
-    info = ServiceInfo(type_, registration_name, 80, 0, 0, {}, host)
+    info = make_service_info(type_, registration_name, properties={}, server=host, addresses=[])
     assert info.load_from_cache(zc) is True
     assert info.properties == {}
     zc.close()
@@ -2308,7 +2252,7 @@ def test_load_from_cache_complete_with_empty_locally_set_text():
         ]
     )
 
-    info = ServiceInfo(type_, registration_name, 80, 0, 0, b"", host)
+    info = make_service_info(type_, registration_name, properties=b"", server=host, addresses=[])
     assert info.load_from_cache(zc) is True
     assert info.properties == {}
     zc.close()
@@ -2574,16 +2518,7 @@ async def test_own_nsec_response_does_not_complete_service(aiozc: AsyncZeroconf)
     await aiozc.zeroconf.async_wait_for_start()
     zc = aiozc.zeroconf
 
-    registered = ServiceInfo(
-        type_,
-        registration_name,
-        80,
-        0,
-        0,
-        {"path": "/healthz/"},
-        host,
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
+    registered = make_service_info(type_, registration_name, properties={"path": "/healthz/"}, server=host)
     zc.record_manager.async_updates_from_response(
         mock_incoming_msg([registered.dns_service(), *registered.get_address_and_nsec_records()])
     )

--- a/tests/services/test_registry.py
+++ b/tests/services/test_registry.py
@@ -34,26 +34,8 @@ class TestServiceRegistry(unittest.TestCase):
         registration_name2 = f"{name2}.{type_}"
 
         desc = {"path": "/healthz/"}
-        info = ServiceInfo(
-            type_,
-            registration_name,
-            80,
-            0,
-            0,
-            desc,
-            "same.local.",
-            addresses=[socket.inet_aton("10.7.4.2")],
-        )
-        info2 = ServiceInfo(
-            type_,
-            registration_name2,
-            80,
-            0,
-            0,
-            desc,
-            "same.local.",
-            addresses=[socket.inet_aton("10.7.4.2")],
-        )
+        info = make_service_info(type_, registration_name, properties=desc, server="same.local.")
+        info2 = make_service_info(type_, registration_name2, properties=desc, server="same.local.")
         registry = r.ServiceRegistry()
         registry.async_add(info)
         registry.async_add(info2)
@@ -107,16 +89,7 @@ class TestServiceRegistry(unittest.TestCase):
         registration_name = f"{name}.{type_}"
 
         desc = {"path": "/healthz/"}
-        info = ServiceInfo(
-            type_,
-            registration_name,
-            80,
-            0,
-            0,
-            desc,
-            "SPARE-RIG.local.",
-            addresses=[socket.inet_aton("10.7.4.2")],
-        )
+        info = make_service_info(type_, registration_name, properties=desc, server="SPARE-RIG.local.")
 
         registry = r.ServiceRegistry()
         registry.async_add(info)
@@ -146,17 +119,7 @@ class TestServiceRegistry(unittest.TestCase):
         server = "shared.local."
         desc = {"path": "/healthz/"}
         infos = [
-            ServiceInfo(
-                type_,
-                f"svc{i}.{type_}",
-                80,
-                0,
-                0,
-                desc,
-                server,
-                addresses=[socket.inet_aton("10.7.4.2")],
-            )
-            for i in range(20)
+            make_service_info(type_, f"svc{i}.{type_}", properties=desc, server=server) for i in range(20)
         ]
 
         registry = r.ServiceRegistry()
@@ -176,16 +139,7 @@ class TestServiceRegistry(unittest.TestCase):
         type_ = "_test-srvc-type._tcp.local."
         server = "spare-rig.local."
         desc = {"path": "/healthz/"}
-        info = ServiceInfo(
-            type_,
-            f"only.{type_}",
-            80,
-            0,
-            0,
-            desc,
-            server,
-            addresses=[socket.inet_aton("10.7.4.2")],
-        )
+        info = make_service_info(type_, f"only.{type_}", properties=desc, server=server)
 
         registry = r.ServiceRegistry()
         registry.async_add(info)
@@ -199,16 +153,7 @@ class TestServiceRegistry(unittest.TestCase):
         type_ = "_test-srvc-type._tcp.local."
         server = "spare-rig.local."
         registration_name = f"xxxyyy.{type_}"
-        info = ServiceInfo(
-            type_,
-            registration_name,
-            80,
-            0,
-            0,
-            {"path": "/healthz/"},
-            server,
-            addresses=[socket.inet_aton("10.7.4.2")],
-        )
+        info = make_service_info(type_, registration_name, properties={"path": "/healthz/"}, server=server)
         updated = ServiceInfo(
             type_,
             registration_name,

--- a/tests/services/test_types.py
+++ b/tests/services/test_types.py
@@ -9,7 +9,7 @@ import sys
 import unittest
 
 import zeroconf as r
-from zeroconf import ServiceInfo, Zeroconf, ZeroconfServiceTypes
+from zeroconf import Zeroconf, ZeroconfServiceTypes
 
 from .. import (
     IPV6_LOOPBACK_FIND_TIMEOUT,
@@ -64,15 +64,8 @@ def test_integration_with_listener_v6_records(quick_timing, disable_duplicate_pa
 
     zeroconf_registrar = Zeroconf(interfaces=["127.0.0.1"])
     desc = {"path": "/healthz/"}
-    info = ServiceInfo(
-        type_,
-        registration_name,
-        80,
-        0,
-        0,
-        desc,
-        "spare-rig.local.",
-        addresses=[socket.inet_pton(socket.AF_INET6, addr)],
+    info = make_service_info(
+        type_, registration_name, properties=desc, addresses=[socket.inet_pton(socket.AF_INET6, addr)]
     )
     zeroconf_registrar.registry.async_add(info)
     try:
@@ -100,15 +93,8 @@ def test_integration_with_listener_ipv6(quick_timing, disable_duplicate_packet_s
 
     zeroconf_registrar = Zeroconf(ip_version=r.IPVersion.V6Only)
     desc = {"path": "/healthz/"}
-    info = ServiceInfo(
-        type_,
-        registration_name,
-        80,
-        0,
-        0,
-        desc,
-        "spare-rig.local.",
-        addresses=[socket.inet_pton(socket.AF_INET6, addr)],
+    info = make_service_info(
+        type_, registration_name, properties=desc, addresses=[socket.inet_pton(socket.AF_INET6, addr)]
     )
     zeroconf_registrar.registry.async_add(info)
     try:

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -156,15 +156,8 @@ async def test_async_service_registration(quick_timing: None) -> None:
     info = make_service_info(type_, registration_name, properties=desc)
     task = await aiozc.async_register_service(info)
     await task
-    new_info = ServiceInfo(
-        type_,
-        registration_name,
-        80,
-        0,
-        0,
-        desc,
-        "spare-rig.local.",
-        addresses=[socket.inet_aton("10.7.4.3")],
+    new_info = make_service_info(
+        type_, registration_name, properties=desc, addresses=[socket.inet_aton("10.7.4.3")]
     )
     task = await aiozc.async_update_service(new_info)
     await task
@@ -229,15 +222,8 @@ async def test_async_service_registration_with_server_missing(quick_timing: None
 
     assert info.server == registration_name
     assert info.server_key == registration_name
-    new_info = ServiceInfo(
-        type_,
-        registration_name,
-        80,
-        0,
-        0,
-        desc,
-        "spare-rig.local.",
-        addresses=[socket.inet_aton("10.7.4.3")],
+    new_info = make_service_info(
+        type_, registration_name, properties=desc, addresses=[socket.inet_aton("10.7.4.3")]
     )
     task = await aiozc.async_update_service(new_info)
     await task
@@ -380,14 +366,11 @@ async def test_async_service_registration_name_conflict(aiozc: AsyncZeroconf, qu
         task = await aiozc.async_register_service(info, cooperating_responders=True)
         await task
 
-    conflicting_info = ServiceInfo(
+    conflicting_info = make_service_info(
         type_,
         registration_name,
-        80,
-        0,
-        0,
-        desc,
-        "ash-3.local.",
+        properties=desc,
+        server="ash-3.local.",
         addresses=[socket.inet_aton("10.7.4.3")],
     )
 
@@ -468,15 +451,8 @@ async def test_async_tasks(quick_timing: None) -> None:
     assert isinstance(task, asyncio.Task)
     await task
 
-    new_info = ServiceInfo(
-        type_,
-        registration_name,
-        80,
-        0,
-        0,
-        desc,
-        "spare-rig.local.",
-        addresses=[socket.inet_aton("10.7.4.3")],
+    new_info = make_service_info(
+        type_, registration_name, properties=desc, addresses=[socket.inet_aton("10.7.4.3")]
     )
     task = await aiozc.async_update_service(new_info)
     assert isinstance(task, asyncio.Task)
@@ -540,24 +516,12 @@ async def test_service_info_async_request(
     get_service_info_task2 = asyncio.ensure_future(aiozc.async_get_service_info(type_, registration_name))
 
     desc = {"path": "/healthz/"}
-    info = ServiceInfo(
-        type_,
-        registration_name,
-        80,
-        0,
-        0,
-        desc,
-        "ash-1.local.",
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
-    info2 = ServiceInfo(
+    info = make_service_info(type_, registration_name, properties=desc, server="ash-1.local.")
+    info2 = make_service_info(
         type_,
         registration_name2,
-        80,
-        0,
-        0,
-        desc,
-        "ash-5.local.",
+        properties=desc,
+        server="ash-5.local.",
         addresses=[socket.inet_aton("10.7.4.5")],
     )
     tasks = []
@@ -577,18 +541,11 @@ async def test_service_info_async_request(
     assert aiosinfo is not None
     assert aiosinfo.addresses == [socket.inet_aton("10.7.4.2")]
 
-    new_info = ServiceInfo(
+    new_info = make_service_info(
         type_,
         registration_name,
-        80,
-        0,
-        0,
-        desc,
-        "spare-rig.local.",
-        addresses=[
-            socket.inet_aton("10.7.4.3"),
-            socket.inet_pton(socket.AF_INET6, "6001:db8::1"),
-        ],
+        properties=desc,
+        addresses=[socket.inet_aton("10.7.4.3"), socket.inet_pton(socket.AF_INET6, "6001:db8::1")],
     )
 
     task = await aiozc.async_update_service(new_info)
@@ -669,15 +626,8 @@ async def test_async_service_browser(quick_timing: None) -> None:
     info = make_service_info(type_, registration_name, properties=desc)
     task = await aiozc.async_register_service(info)
     await task
-    new_info = ServiceInfo(
-        type_,
-        registration_name,
-        80,
-        0,
-        0,
-        desc,
-        "spare-rig.local.",
-        addresses=[socket.inet_aton("10.7.4.3")],
+    new_info = make_service_info(
+        type_, registration_name, properties=desc, addresses=[socket.inet_aton("10.7.4.3")]
     )
     task = await aiozc.async_update_service(new_info)
     await task
@@ -701,16 +651,7 @@ async def test_async_context_manager(quick_timing: None) -> None:
     registration_name = f"{name}.{type_}"
 
     async with AsyncZeroconf(interfaces=["127.0.0.1"]) as aiozc:
-        info = ServiceInfo(
-            type_,
-            registration_name,
-            80,
-            0,
-            0,
-            {"path": "/healthz/"},
-            "spare-rig.local.",
-            addresses=[socket.inet_aton("10.7.4.2")],
-        )
+        info = make_service_info(type_, registration_name, properties={"path": "/healthz/"})
         task = await aiozc.async_register_service(info)
         await task
         aiosinfo = await aiozc.async_get_service_info(type_, registration_name)
@@ -750,24 +691,12 @@ async def test_async_unregister_all_services(aiozc: AsyncZeroconf, quick_timing:
     registration_name2 = f"{name2}.{type_}"
 
     desc = {"path": "/healthz/"}
-    info = ServiceInfo(
-        type_,
-        registration_name,
-        80,
-        0,
-        0,
-        desc,
-        "ash-1.local.",
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
-    info2 = ServiceInfo(
+    info = make_service_info(type_, registration_name, properties=desc, server="ash-1.local.")
+    info2 = make_service_info(
         type_,
         registration_name2,
-        80,
-        0,
-        0,
-        desc,
-        "ash-5.local.",
+        properties=desc,
+        server="ash-5.local.",
         addresses=[socket.inet_aton("10.7.4.5")],
     )
     tasks = []
@@ -863,7 +792,7 @@ async def test_service_browser_instantiation_generates_add_events_from_cache(aio
     desc = {"path": "/healthz/"}
     address_parsed = "10.7.4.2"
     address = socket.inet_aton(address_parsed)
-    info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, "spare-rig.local.", addresses=[address])
+    info = make_service_info(type_, registration_name, properties=desc, addresses=[address])
     zc.cache.async_add_records(
         [info.dns_pointer(), info.dns_service(), *info.dns_addresses(), info.dns_text()]
     )
@@ -937,16 +866,7 @@ async def test_integration(quick_timing: None) -> None:
         service_removed = asyncio.Event()
 
         browser = AsyncServiceBrowser(zeroconf_browser, type_, [on_service_state_change])
-        info = ServiceInfo(
-            type_,
-            registration_name,
-            80,
-            0,
-            0,
-            {"path": "/healthz/"},
-            "spare-rig.local.",
-            addresses=[socket.inet_aton("10.7.4.2")],
-        )
+        info = make_service_info(type_, registration_name, properties={"path": "/healthz/"})
         # Wait for the browser's first startup query to land (with an empty
         # cache) before registering — otherwise on fast loopback the register
         # may finish before the first query fires, and answers[0] picks up
@@ -1117,7 +1037,7 @@ async def test_service_browser_ignores_unrelated_updates(aiozc: AsyncZeroconf) -
     desc = {"path": "/healthz/"}
     address_parsed = "10.7.4.2"
     address = socket.inet_aton(address_parsed)
-    info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, "spare-rig.local.", addresses=[address])
+    info = make_service_info(type_, registration_name, properties=desc, addresses=[address])
     zc.cache.async_add_records(
         [
             info.dns_pointer(),

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -281,7 +281,9 @@ def test_any_query_for_ptr(zc: Zeroconf) -> None:
     desc = {"path": "/healthz/"}
     server_name = "spare-rig.local."
     ipv6_address = socket.inet_pton(socket.AF_INET6, "2001:db8::1")
-    info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, server_name, addresses=[ipv6_address])
+    info = make_service_info(
+        type_, registration_name, properties=desc, server=server_name, addresses=[ipv6_address]
+    )
     zc.registry.async_add(info)
 
     _clear_cache(zc)
@@ -308,7 +310,9 @@ def test_aaaa_query(zc: Zeroconf) -> None:
     desc = {"path": "/healthz/"}
     server_name = "spare-rig.local."
     ipv6_address = socket.inet_pton(socket.AF_INET6, "2001:db8::1")
-    info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, server_name, addresses=[ipv6_address])
+    info = make_service_info(
+        type_, registration_name, properties=desc, server=server_name, addresses=[ipv6_address]
+    )
     zc.registry.async_add(info)
 
     generated = r.DNSOutgoing(const._FLAGS_QR_QUERY)
@@ -333,7 +337,9 @@ def test_aaaa_query_upper_case(zc: Zeroconf) -> None:
     desc = {"path": "/healthz/"}
     server_name = "spare-rig.local."
     ipv6_address = socket.inet_pton(socket.AF_INET6, "2001:db8::1")
-    info = ServiceInfo(type_, registration_name, 80, 0, 0, desc, server_name, addresses=[ipv6_address])
+    info = make_service_info(
+        type_, registration_name, properties=desc, server=server_name, addresses=[ipv6_address]
+    )
     zc.registry.async_add(info)
 
     generated = r.DNSOutgoing(const._FLAGS_QR_QUERY)
@@ -359,15 +365,8 @@ def test_a_and_aaaa_record_fate_sharing(zc: Zeroconf) -> None:
     server_name = "spare-rig.local."
     ipv6_address = socket.inet_pton(socket.AF_INET6, "2001:db8::1")
     ipv4_address = socket.inet_aton("10.7.4.2")
-    info = ServiceInfo(
-        type_,
-        registration_name,
-        80,
-        0,
-        0,
-        desc,
-        server_name,
-        addresses=[ipv6_address, ipv4_address],
+    info = make_service_info(
+        type_, registration_name, properties=desc, server=server_name, addresses=[ipv6_address, ipv4_address]
     )
     aaaa_record = info.dns_addresses(version=r.IPVersion.V6Only)[0]
     a_record = info.dns_addresses(version=r.IPVersion.V4Only)[0]
@@ -535,14 +534,11 @@ def test_qu_response(zc: Zeroconf, quick_timing: None) -> None:
     registration_name2 = f"{name}.{other_type_}"
     desc = {"path": "/healthz/"}
     info = make_service_info(type_, registration_name, properties=desc)
-    info2 = ServiceInfo(
+    info2 = make_service_info(
         other_type_,
         registration_name2,
-        80,
-        0,
-        0,
-        desc,
-        "ash-other.local.",
+        properties=desc,
+        server="ash-other.local.",
         addresses=[socket.inet_aton("10.0.4.2")],
     )
     # Register and inject the announcement directly so the cache state is
@@ -646,16 +642,7 @@ def test_known_answer_supression(zc: Zeroconf) -> None:
     registration_name = f"{name}.{type_}"
     desc = {"path": "/healthz/"}
     server_name = "spare-rig.local."
-    info = ServiceInfo(
-        type_,
-        registration_name,
-        80,
-        0,
-        0,
-        desc,
-        server_name,
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
+    info = make_service_info(type_, registration_name, properties=desc, server=server_name)
     zc.registry.async_add(info)
 
     now = current_time_millis()
@@ -786,7 +773,9 @@ def test_no_nsec_answer_for_service_without_addresses(zc: Zeroconf) -> None:
     type_ = "_noaddrnsec._tcp.local."
     registration_name = f"noaddr.{type_}"
     server_name = "noaddr-host.local."
-    info = ServiceInfo(type_, registration_name, 80, 0, 0, {"path": "/healthz/"}, server_name)
+    info = make_service_info(
+        type_, registration_name, properties={"path": "/healthz/"}, server=server_name, addresses=[]
+    )
     zc.registry.async_add(info)
     _clear_cache(zc)
 
@@ -819,36 +808,9 @@ def test_multi_packet_known_answer_supression(zc: Zeroconf) -> None:
     server_name2 = "ash-3.local."
     server_name3 = "ash-4.local."
 
-    info = ServiceInfo(
-        type_,
-        registration_name,
-        80,
-        0,
-        0,
-        desc,
-        server_name,
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
-    info2 = ServiceInfo(
-        type_,
-        registration2_name,
-        80,
-        0,
-        0,
-        desc,
-        server_name2,
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
-    info3 = ServiceInfo(
-        type_,
-        registration3_name,
-        80,
-        0,
-        0,
-        desc,
-        server_name3,
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
+    info = make_service_info(type_, registration_name, properties=desc, server=server_name)
+    info2 = make_service_info(type_, registration2_name, properties=desc, server=server_name2)
+    info3 = make_service_info(type_, registration3_name, properties=desc, server=server_name3)
     zc.registry.async_add(info)
     zc.registry.async_add(info2)
     zc.registry.async_add(info3)
@@ -884,16 +846,7 @@ def test_known_answer_supression_service_type_enumeration_query(zc: Zeroconf) ->
     registration_name = f"{name}.{type_}"
     desc = {"path": "/healthz/"}
     server_name = "spare-rig.local."
-    info = ServiceInfo(
-        type_,
-        registration_name,
-        80,
-        0,
-        0,
-        desc,
-        server_name,
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
+    info = make_service_info(type_, registration_name, properties=desc, server=server_name)
     zc.registry.async_add(info)
 
     type_2 = "_otherknown2._tcp.local."
@@ -901,16 +854,7 @@ def test_known_answer_supression_service_type_enumeration_query(zc: Zeroconf) ->
     registration_name2 = f"{name}.{type_2}"
     desc = {"path": "/healthz/"}
     server_name2 = "ash-3.local."
-    info2 = ServiceInfo(
-        type_2,
-        registration_name2,
-        80,
-        0,
-        0,
-        desc,
-        server_name2,
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
+    info2 = make_service_info(type_2, registration_name2, properties=desc, server=server_name2)
     zc.registry.async_add(info2)
     now = current_time_millis()
     _clear_cache(zc)
@@ -969,16 +913,7 @@ def test_upper_case_enumeration_query(zc: Zeroconf) -> None:
     registration_name = f"{name}.{type_}"
     desc = {"path": "/healthz/"}
     server_name = "spare-rig.local."
-    info = ServiceInfo(
-        type_,
-        registration_name,
-        80,
-        0,
-        0,
-        desc,
-        server_name,
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
+    info = make_service_info(type_, registration_name, properties=desc, server=server_name)
     zc.registry.async_add(info)
 
     type_2 = "_otherknown2._tcp.local."
@@ -986,16 +921,7 @@ def test_upper_case_enumeration_query(zc: Zeroconf) -> None:
     registration_name2 = f"{name}.{type_2}"
     desc = {"path": "/healthz/"}
     server_name2 = "ash-3.local."
-    info2 = ServiceInfo(
-        type_2,
-        registration_name2,
-        80,
-        0,
-        0,
-        desc,
-        server_name2,
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
+    info2 = make_service_info(type_2, registration_name2, properties=desc, server=server_name2)
     zc.registry.async_add(info2)
     _clear_cache(zc)
 
@@ -1040,16 +966,7 @@ async def test_qu_response_only_sends_additionals_if_sends_answer():
     registration_name = f"{name}.{type_}"
     desc = {"path": "/healthz/"}
     server_name = "spare-rig.local."
-    info = ServiceInfo(
-        type_,
-        registration_name,
-        80,
-        0,
-        0,
-        desc,
-        server_name,
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
+    info = make_service_info(type_, registration_name, properties=desc, server=server_name)
     zc.registry.async_add(info)
 
     type_2 = "_addtest2._tcp.local."
@@ -1057,16 +974,7 @@ async def test_qu_response_only_sends_additionals_if_sends_answer():
     registration_name2 = f"{name}.{type_2}"
     desc = {"path": "/healthz/"}
     server_name2 = "ash-3.local."
-    info2 = ServiceInfo(
-        type_2,
-        registration_name2,
-        80,
-        0,
-        0,
-        desc,
-        server_name2,
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
+    info2 = make_service_info(type_2, registration_name2, properties=desc, server=server_name2)
     zc.registry.async_add(info2)
 
     ptr_record = info.dns_pointer()
@@ -1206,16 +1114,7 @@ async def test_cache_flush_bit():
     registration_name = f"{name}.{type_}"
     desc = {"path": "/healthz/"}
     server_name = "server-uu1.local."
-    info = ServiceInfo(
-        type_,
-        registration_name,
-        80,
-        0,
-        0,
-        desc,
-        server_name,
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
+    info = make_service_info(type_, registration_name, properties=desc, server=server_name)
     a_record = info.dns_addresses()[0]
     zc.cache.async_add_records([info.dns_pointer(), a_record, info.dns_text(), info.dns_service()])
 
@@ -1321,16 +1220,7 @@ async def test_record_update_manager_add_listener_callsback_existing_records():
     registration_name = f"{name}.{type_}"
     desc = {"path": "/healthz/"}
     server_name = "server-uu1.local."
-    info = ServiceInfo(
-        type_,
-        registration_name,
-        80,
-        0,
-        0,
-        desc,
-        server_name,
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
+    info = make_service_info(type_, registration_name, properties=desc, server=server_name)
     a_record = info.dns_addresses()[0]
     ptr_record = info.dns_pointer()
     zc.cache.async_add_records([ptr_record, a_record, info.dns_text(), info.dns_service()])
@@ -1363,14 +1253,10 @@ async def test_questions_query_handler_populates_the_question_history_from_qm_qu
     _clear_cache(zc)
 
     aiozc.zeroconf.registry.async_add(
-        ServiceInfo(
+        make_service_info(
             "_hap._tcp.local.",
             "other._hap._tcp.local.",
-            80,
-            0,
-            0,
-            {"md": "known"},
-            "spare-rig.local.",
+            properties={"md": "known"},
             addresses=[socket.inet_aton("1.2.3.4")],
         )
     )
@@ -1407,14 +1293,10 @@ async def test_questions_query_handler_does_not_put_qu_questions_in_history():
     zc = aiozc.zeroconf
     now = current_time_millis()
     _clear_cache(zc)
-    info = ServiceInfo(
+    info = make_service_info(
         "_hap._tcp.local.",
         "qu._hap._tcp.local.",
-        80,
-        0,
-        0,
-        {"md": "known"},
-        "spare-rig.local.",
+        properties={"md": "known"},
         addresses=[socket.inet_aton("1.2.3.4")],
     )
     aiozc.zeroconf.registry.async_add(info)
@@ -1553,24 +1435,18 @@ async def test_response_aggregation_timings(run_isolated: None) -> None:
 
     desc = {"path": "/healthz/"}
     info = make_service_info(type_, registration_name, properties=desc)
-    info2 = ServiceInfo(
+    info2 = make_service_info(
         type_2,
         registration_name2,
-        80,
-        0,
-        0,
-        desc,
-        "ash-4.local.",
+        properties=desc,
+        server="ash-4.local.",
         addresses=[socket.inet_aton("10.7.4.3")],
     )
-    info3 = ServiceInfo(
+    info3 = make_service_info(
         type_3,
         registration_name3,
-        80,
-        0,
-        0,
-        desc,
-        "ash-4.local.",
+        properties=desc,
+        server="ash-4.local.",
         addresses=[socket.inet_aton("10.7.4.3")],
     )
     aiozc.zeroconf.registry.async_add(info)
@@ -1680,14 +1556,11 @@ async def test_response_aggregation_timings_multiple(
     registration_name2 = f"{name}.{type_2}"
 
     desc = {"path": "/healthz/"}
-    info2 = ServiceInfo(
+    info2 = make_service_info(
         type_2,
         registration_name2,
-        80,
-        0,
-        0,
-        desc,
-        "ash-4.local.",
+        properties=desc,
+        server="ash-4.local.",
         addresses=[socket.inet_aton("10.7.4.3")],
     )
     aiozc.zeroconf.registry.async_add(info2)
@@ -1775,56 +1648,13 @@ async def test_response_aggregation_random_delay():
     registration_name5 = f"{name}.{type_5}"
 
     desc = {"path": "/healthz/"}
-    info = ServiceInfo(
-        type_,
-        registration_name,
-        80,
-        0,
-        0,
-        desc,
-        "ash-1.local.",
-        addresses=[socket.inet_aton("10.7.4.2")],
+    info = make_service_info(type_, registration_name, properties=desc, server="ash-1.local.")
+    info2 = make_service_info(
+        type_2, registration_name2, properties=desc, addresses=[socket.inet_aton("10.7.4.3")]
     )
-    info2 = ServiceInfo(
-        type_2,
-        registration_name2,
-        80,
-        0,
-        0,
-        desc,
-        "spare-rig.local.",
-        addresses=[socket.inet_aton("10.7.4.3")],
-    )
-    info3 = ServiceInfo(
-        type_3,
-        registration_name3,
-        80,
-        0,
-        0,
-        desc,
-        "ash-3.local.",
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
-    info4 = ServiceInfo(
-        type_4,
-        registration_name4,
-        80,
-        0,
-        0,
-        desc,
-        "ash-4.local.",
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
-    info5 = ServiceInfo(
-        type_5,
-        registration_name5,
-        80,
-        0,
-        0,
-        desc,
-        "ash-5.local.",
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
+    info3 = make_service_info(type_3, registration_name3, properties=desc, server="ash-3.local.")
+    info4 = make_service_info(type_4, registration_name4, properties=desc, server="ash-4.local.")
+    info5 = make_service_info(type_5, registration_name5, properties=desc, server="ash-5.local.")
     mocked_zc = unittest.mock.MagicMock()
     mocked_zc.loop = asyncio.get_running_loop()
     outgoing_queue = MulticastOutgoingQueue(mocked_zc, 0, 500)
@@ -1873,25 +1703,9 @@ async def test_future_answers_are_removed_on_send():
     registration_name2 = f"{name}.{type_2}"
 
     desc = {"path": "/healthz/"}
-    info = ServiceInfo(
-        type_,
-        registration_name,
-        80,
-        0,
-        0,
-        desc,
-        "ash-1.local.",
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
-    info2 = ServiceInfo(
-        type_2,
-        registration_name2,
-        80,
-        0,
-        0,
-        desc,
-        "spare-rig.local.",
-        addresses=[socket.inet_aton("10.7.4.3")],
+    info = make_service_info(type_, registration_name, properties=desc, server="ash-1.local.")
+    info2 = make_service_info(
+        type_2, registration_name2, properties=desc, addresses=[socket.inet_aton("10.7.4.3")]
     )
     mocked_zc = unittest.mock.MagicMock()
     mocked_zc.loop = asyncio.get_running_loop()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,16 +1,15 @@
 from __future__ import annotations
 
 import logging
-import socket
 import time
 from unittest.mock import patch
 
 import pytest
 
 import zeroconf as r
-from zeroconf import ServiceInfo, Zeroconf, const
+from zeroconf import Zeroconf, const
 
-from . import _inject_responses
+from . import _inject_responses, make_service_info
 
 log = logging.getLogger("zeroconf")
 original_logging_level = logging.NOTSET
@@ -111,16 +110,7 @@ def test_large_packet_exception_log_handling():
 
 def verify_name_change(zc, type_, name, number_hosts):
     desc = {"path": "/healthz/"}
-    info_service = ServiceInfo(
-        type_,
-        f"{name}.{type_}",
-        80,
-        0,
-        0,
-        desc,
-        "spare-rig.local.",
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
+    info_service = make_service_info(type_, f"{name}.{type_}", properties=desc)
 
     # verify name conflict
     with pytest.raises(r.NonUniqueNameException):
@@ -132,16 +122,7 @@ def verify_name_change(zc, type_, name, number_hosts):
     # Create a new object since allow_name_change will mutate the
     # original object and then we will have the wrong service
     # in the registry
-    info_service2 = ServiceInfo(
-        type_,
-        f"{name}.{type_}",
-        80,
-        0,
-        0,
-        desc,
-        "spare-rig.local.",
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
+    info_service2 = make_service_info(type_, f"{name}.{type_}", properties=desc)
     zc.register_service(info_service2, allow_name_change=True)
     assert info_service2.name.split(".")[0] == f"{name}-{number_hosts + 1}"
 

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -3,16 +3,15 @@
 from __future__ import annotations
 
 import logging
-import socket
 import time
 
 import pytest
 
 import zeroconf as r
+from tests import make_service_info
 from zeroconf import Zeroconf, const
 from zeroconf._record_update import RecordUpdate
 from zeroconf._services.browser import ServiceBrowser
-from zeroconf._services.info import ServiceInfo
 
 log = logging.getLogger("zeroconf")
 original_logging_level = logging.NOTSET
@@ -61,16 +60,7 @@ def test_legacy_record_update_listener(zc: Zeroconf, quick_timing: None) -> None
     name = "MyTestHome"
     browser = ServiceBrowser(zc, type_, [on_service_state_change])
 
-    info_service = ServiceInfo(
-        type_,
-        f"{name}.{type_}",
-        80,
-        0,
-        0,
-        {"path": "/healthz/"},
-        "spare-rig.local.",
-        addresses=[socket.inet_aton("10.7.4.2")],
-    )
+    info_service = make_service_info(type_, f"{name}.{type_}", properties={"path": "/healthz/"})
 
     zc.register_service(info_service)
 


### PR DESCRIPTION
## Summary
Fourth cleanup pass. Eighty nine positional ServiceInfo constructions (the 80, 0, 0 shape) across nine files collapse to make_service_info calls carrying only their non default overrides; the helper gains explicitly typed parsed_addresses, interface_index, host_ttl and other_ttl parameters instead of a kwargs passthrough, so the calls stay type checked. Two calls stay raw ServiceInfo on purpose: the constructor contract test for the addresses and parsed_addresses mutual exclusion, and the variants whose shape is the behavior under test.

## Test plan
- [x] full suite passes, lint clean