### PR TITLE
revert: remove the 2009 record display formats

### DIFF
--- a/src/zeroconf/_dns.py
+++ b/src/zeroconf/_dns.py
@@ -7,12 +7,12 @@ from __future__ import annotations
 
 import enum
 import socket
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 from ._exceptions import AbstractMethodException
 from ._utils.net import _is_v6_address
 from ._utils.time import current_time_millis
-from .const import _CLASS_MASK, _CLASS_UNIQUE, _CLASSES, _TYPE_ANY, _TYPES
+from .const import _CLASS_MASK, _CLASS_UNIQUE, _TYPE_ANY
 
 _LEN_BYTE = 1
 _LEN_SHORT = 2

--- a/src/zeroconf/_dns.py
+++ b/src/zeroconf/_dns.py
@@ -58,24 +58,6 @@ class DNSEntry:  # noqa: PLW1641
         """Equal when key, type and class match."""
         return isinstance(other, DNSEntry) and self._dns_entry_matches(other)
 
-    def entry_to_string(self, hdr: str, other: bytes | str | None) -> str:
-        return "{}[{},{}{},{}]{}".format(
-            hdr,
-            self.get_type(self.type),
-            self.get_class_(self.class_),
-            "-unique" if self.unique else "",
-            self.name,
-            f"={cast(Any, other)}" if other is not None else "",
-        )
-
-    @staticmethod
-    def get_class_(class_: int) -> str:
-        return _CLASSES.get(class_, f"?({class_})")
-
-    @staticmethod
-    def get_type(t: int) -> str:
-        return _TYPES.get(t, f"?({t})")
-
     def _dns_entry_matches(self, other: DNSEntry) -> bool:
         return self.key == other.key and self.type == other.type and self.class_ == other.class_
 
@@ -190,10 +172,6 @@ class DNSRecord(DNSEntry):  # noqa: PLW1641
                 return True
         return False
 
-    def to_string(self, other: bytes | str) -> str:
-        arg = f"{self.ttl}/{int(self.get_remaining_ttl(current_time_millis()))},{cast(Any, other)}"
-        return DNSEntry.entry_to_string(self, "record", arg)
-
     def write(self, out: DNSOutgoing) -> None:
         raise AbstractMethodException(f"{type(self).__name__} is missing write")
 
@@ -302,9 +280,6 @@ class DNSHinfo(DNSRecord):
     def __hash__(self) -> int:
         """Hash to compare like DNSHinfo."""
         return self._hash
-
-    def __repr__(self) -> str:
-        return self.to_string(self.cpu + " " + self.os)
 
     def write(self, out: DNSOutgoing) -> None:
         """Write the rdata to an outgoing packet."""
@@ -477,9 +452,6 @@ class DNSService(DNSRecord):
     def __hash__(self) -> int:
         """Hash to compare like DNSService."""
         return self._hash
-
-    def __repr__(self) -> str:
-        return self.to_string(f"{self.server}:{self.port}")
 
     def write(self, out: DNSOutgoing) -> None:
         out.write_short(self.priority)

--- a/src/zeroconf/_protocol/outgoing.py
+++ b/src/zeroconf/_protocol/outgoing.py
@@ -415,8 +415,6 @@ class DNSOutgoing:
         self.size += 4
 
     def _write_link_to_name(self, index: int_) -> None:
-        # If part of the name already exists in the packet,
-        # create a pointer to it
         self._write_byte((index >> 8) | 0xC0)
         self._write_byte(index & 0xFF)
 


### PR DESCRIPTION
## Summary
Fifteenth removal pass for #1835, from a third independent audit. The record display family in `_dns.py` is a structural port of the 2009 toString family: the hdr[type,class-unique,name]=other layout, the ?(x) fallback, the ttl/remaining prefix, the cpu space os and server colon port arguments. #1872 removed only the DNSText member; this deletes the rest of the family whole (entry_to_string, get_class_, get_type, to_string, the DNSHinfo and DNSService reprs) plus a 2021 comment in the name compressor that paraphrases the 2009 pointer comment. The tree is intentionally red until the follow up lands fresh formats.

## Test plan
- [x] deletion only; repr smoke tests red by design until the follow up