### PR TITLE
test: fix flaky test_service_browser_expire_callbacks

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -10,8 +10,9 @@ import platform
 import socket
 import sys
 import time
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from functools import cache
+from threading import Event
 from typing import Any
 from unittest import mock
 
@@ -127,6 +128,16 @@ def _wait_for_start(zc: Zeroconf) -> None:
     asyncio.run_coroutine_threadsafe(zc.async_wait_for_start(), zc.loop).result()
 
 
+def _wait_for(predicate: Callable[[], bool], timeout: float = 2.0) -> bool:
+    """Poll `predicate` from a non-loop thread until true or `timeout` seconds pass."""
+    deadline = time.monotonic() + timeout
+    while not predicate():
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(0.01)
+    return True
+
+
 @cache
 def has_working_ipv6():
     """Return True if the system can bind an IPv6 address."""
@@ -178,6 +189,26 @@ def _backdate_cache(zc: Zeroconf, ms: int = 1100) -> None:
     for store in zc.cache.cache.values():
         for record in store.values():
             record.created -= ms
+
+
+def _restamp_cache(zc: Zeroconf, created: float, ttl: int) -> None:
+    """Re-add every cached record with a new `created` and `ttl` from the loop thread.
+
+    Unlike `_backdate_cache` this goes through `_async_set_created_ttl`, so
+    the expiration heap is updated and the reaper will actually expire the
+    records; the heap is only safe to touch from the event loop thread.
+    """
+    assert zc.loop is not None
+    done = Event()
+
+    def _restamp() -> None:
+        for store in list(zc.cache.cache.values()):
+            for record in list(store.values()):
+                zc.cache._async_set_created_ttl(record, created, ttl)
+        done.set()
+
+    zc.loop.call_soon_threadsafe(_restamp)
+    assert done.wait(2)
 
 
 def time_changed_millis(millis: float | None = None) -> None:

--- a/tests/services/test_browser.py
+++ b/tests/services/test_browser.py
@@ -32,6 +32,8 @@ from zeroconf.asyncio import AsyncServiceBrowser, AsyncZeroconf
 from .. import (
     QuestionHistoryWithoutSuppression,
     _inject_response,
+    _restamp_cache,
+    _wait_for,
     _wait_for_start,
     has_working_ipv6,
     make_service_info,
@@ -1489,31 +1491,11 @@ def test_service_browser_expire_callbacks():
             ]
         ),
     )
-
-    def _restamp_cache(created: float) -> None:
-        # The expiration heap is only safe to touch from the loop thread.
-        done = Event()
-
-        def _restamp() -> None:
-            for cache_record in list(zc.cache.cache.values()):
-                for record in list(cache_record.values()):
-                    zc.cache._async_set_created_ttl(record, created, 1)
-            done.set()
-
-        assert zc.loop is not None
-        zc.loop.call_soon_threadsafe(_restamp)
-        assert done.wait(2)
-
-    def _wait_for_callbacks(count: int) -> None:
-        deadline = time.monotonic() + 2
-        while len(callbacks) < count and time.monotonic() < deadline:
-            time.sleep(0.01)
-
     # Force the ttl to be 1 second
-    _restamp_cache(current_time_millis())
+    _restamp_cache(zc, current_time_millis(), 1)
 
     # Wait for the add callback to fire from the original inject_response.
-    _wait_for_callbacks(1)
+    _wait_for(lambda: len(callbacks) >= 1)
 
     info.port = 400
     info._dns_service_cache = None  # we are mutating the record so clear the cache
@@ -1523,7 +1505,7 @@ def test_service_browser_expire_callbacks():
         mock_incoming_msg([info.dns_service()]),
     )
 
-    _wait_for_callbacks(2)
+    _wait_for(lambda: len(callbacks) >= 2)
 
     assert callbacks == [
         ("add", type_, registration_name),
@@ -1536,9 +1518,9 @@ def test_service_browser_expire_callbacks():
     # Going through `_async_set_created_ttl` updates the expiration
     # heap; mutating `record.created` directly would leave the heap
     # entry pointing at the original `when` so the reaper never wakes.
-    _restamp_cache(current_time_millis() - 2000)
+    _restamp_cache(zc, current_time_millis() - 2000, 1)
 
-    _wait_for_callbacks(3)
+    _wait_for(lambda: len(callbacks) >= 3)
 
     assert callbacks == [
         ("add", type_, registration_name),

--- a/tests/services/test_browser.py
+++ b/tests/services/test_browser.py
@@ -1489,17 +1489,31 @@ def test_service_browser_expire_callbacks():
             ]
         ),
     )
+
+    def _restamp_cache(created: float) -> None:
+        # The expiration heap is only safe to touch from the loop thread.
+        done = Event()
+
+        def _restamp() -> None:
+            for cache_record in list(zc.cache.cache.values()):
+                for record in list(cache_record.values()):
+                    zc.cache._async_set_created_ttl(record, created, 1)
+            done.set()
+
+        assert zc.loop is not None
+        zc.loop.call_soon_threadsafe(_restamp)
+        assert done.wait(2)
+
+    def _wait_for_callbacks(count: int) -> None:
+        deadline = time.monotonic() + 2
+        while len(callbacks) < count and time.monotonic() < deadline:
+            time.sleep(0.01)
+
     # Force the ttl to be 1 second
-    now = current_time_millis()
-    for cache_record in list(zc.cache.cache.values()):
-        for record in cache_record.values():
-            zc.cache._async_set_created_ttl(record, now, 1)
+    _restamp_cache(current_time_millis())
 
     # Wait for the add callback to fire from the original inject_response.
-    for _ in range(30):
-        time.sleep(0.01)
-        if len(callbacks) == 1:
-            break
+    _wait_for_callbacks(1)
 
     info.port = 400
     info._dns_service_cache = None  # we are mutating the record so clear the cache
@@ -1509,10 +1523,7 @@ def test_service_browser_expire_callbacks():
         mock_incoming_msg([info.dns_service()]),
     )
 
-    for _ in range(30):
-        time.sleep(0.01)
-        if len(callbacks) == 2:
-            break
+    _wait_for_callbacks(2)
 
     assert callbacks == [
         ("add", type_, registration_name),
@@ -1525,15 +1536,9 @@ def test_service_browser_expire_callbacks():
     # Going through `_async_set_created_ttl` updates the expiration
     # heap; mutating `record.created` directly would leave the heap
     # entry pointing at the original `when` so the reaper never wakes.
-    past = current_time_millis() - 2000
-    for cache_record in list(zc.cache.cache.values()):
-        for record in list(cache_record.values()):
-            zc.cache._async_set_created_ttl(record, past, 1)
+    _restamp_cache(current_time_millis() - 2000)
 
-    for _ in range(30):
-        time.sleep(0.01)
-        if len(callbacks) == 3:
-            break
+    _wait_for_callbacks(3)
 
     assert callbacks == [
         ("add", type_, registration_name),


### PR DESCRIPTION
## Summary
`test_service_browser_expire_callbacks` intermittently misses the `remove` callback (seen on the PyPy 3.10 / `skip_cython` runner in [this run](https://github.com/python-zeroconf/python-zeroconf/actions/runs/33279610787/job/99172416699)). The test restamped every cached record's TTL from the main thread while the reaper runs `DNSCache.async_expire` on the event loop thread, and then waited a fixed 0.3 s for each callback.

## Details
- `_async_set_created_ttl` rewrites the expiration heap; `async_expire` pops it. Doing the rewrite from the main thread races the reaper, and a re-add that lands mid-pop can leave the record's heap entry behind so the expiry never fires. The restamp now runs on the loop thread via `call_soon_threadsafe` and blocks on an `Event` until it has completed. This lives in `tests/__init__.py` as `_restamp_cache`, next to `_backdate_cache`, with a docstring saying which to reach for: `_backdate_cache` only shifts `created` (for the RFC 6762 §10.2 recency checks), `_restamp_cache` re-adds through `_async_set_created_ttl` so the reaper actually expires the records.
- The three `for _ in range(30): sleep(0.01)` loops are replaced with a predicate-based `_wait_for(predicate, timeout=2.0)` helper in `tests/__init__.py`, so a slow interpreter or a loaded runner no longer trips the assertion. The happy path is unchanged: it returns as soon as the predicate holds. The other hand-rolled poll loops in `test_core.py`, `test_handlers.py` and `utils/test_asyncio.py` could adopt it in a follow-up; left alone here to keep this a flake fix.

## Test plan
- [x] `poetry run pytest tests/services/test_browser.py -k expire_callbacks` 10× in a row, `SKIP_CYTHON=1`
- [x] `tests/services/test_browser.py` and `tests/test_core.py` pass
- [x] `pre-commit run --files tests/services/test_browser.py` clean
