### PR TITLE
chore: replace the last testname fixture stems

### DIFF
--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -245,8 +245,8 @@ def test_suppress_answer():
 
     # Should not be suppressed, name is different
     tmp = copy.copy(answer1)
-    tmp.key = "testname3.local."
-    tmp.name = "testname3.local."
+    tmp.key = "specimen3.local."
+    tmp.name = "specimen3.local."
     response.add_answer(query, tmp)
     assert len(response.answers) == 2
 
@@ -284,7 +284,7 @@ def test_many_questions():
     generated = r.DNSOutgoing(const._FLAGS_QR_QUERY)
     questions = []
     for i in range(100):
-        question = r.DNSQuestion(f"testname{i}.local.", const._TYPE_SRV, const._CLASS_IN)
+        question = r.DNSQuestion(f"specimen{i}.local.", const._TYPE_SRV, const._CLASS_IN)
         generated.add_question(question)
         questions.append(question)
     assert len(generated.questions) == 100
@@ -446,10 +446,10 @@ def test_questions_do_not_end_up_every_packet():
 
     generated = r.DNSOutgoing(const._FLAGS_QR_QUERY)
     for i in range(35):
-        question = r.DNSQuestion(f"testname{i}.local.", const._TYPE_SRV, const._CLASS_IN)
+        question = r.DNSQuestion(f"specimen{i}.local.", const._TYPE_SRV, const._CLASS_IN)
         generated.add_question(question)
         answer = r.DNSService(
-            f"testname{i}.local.",
+            f"specimen{i}.local.",
             const._TYPE_SRV,
             const._CLASS_IN | const._CLASS_UNIQUE,
             const._DNS_HOST_TTL,


### PR DESCRIPTION
## Summary
The third independent audit caught five surviving uses of the 2009 testname fixture stem that the earlier sweep missed because they carry suffixes (testname3 and the f string testname{i}). Replaced with the equal length specimen stem; the packet count assertions in these tests depend on the encoded name length, so the replacement must stay eight characters.

## Test plan
- [x] suite passes