### PR TITLE
chore: name the txt repr inline limit

### DIFF
--- a/src/zeroconf/_dns.py
+++ b/src/zeroconf/_dns.py
@@ -29,6 +29,11 @@ _float = float
 _int = int
 
 
+# Longest TXT payload rendered inline by repr; larger payloads are
+# summarized as a byte count to keep debug logs readable.
+_TEXT_REPR_INLINE_LIMIT = 16
+
+
 def _type_label(type_: int) -> str:
     return _TYPES.get(type_, f"unknown-type-{type_}")
 
@@ -572,7 +577,7 @@ class DNSText(DNSRecord):
         return self._hash
 
     def __repr__(self) -> str:
-        data = f"{len(self.text)} bytes" if len(self.text) > 16 else str(self.text)
+        data = f"{len(self.text)} bytes" if len(self.text) > _TEXT_REPR_INLINE_LIMIT else str(self.text)
         return self._repr_with(("data", data))
 
     def write(self, out: DNSOutgoing) -> None:


### PR DESCRIPTION
## Summary
Tiny follow up to #1880 that just missed the merge: the 16 byte inline threshold in the DNSText repr becomes a named module constant with its rationale, per the review note that deriving the number from a named diagnostic limit is the maximum caution form.

## Test plan
- [x] repr tests pass