### PR TITLE
chore: refresh changelog prose, metadata and test listener naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -415,7 +415,7 @@
 
 ### Build System
 
-- Adjust actions checkout ref parameter on release
+- Use an explicit checkout ref in the release workflow
   ([#1669](https://github.com/python-zeroconf/python-zeroconf/pull/1669),
   [`bc8ec8d`](https://github.com/python-zeroconf/python-zeroconf/commit/bc8ec8d59d875522f75901644d423d30d803a030))
 
@@ -2013,16 +2013,9 @@ This also revealed that we do not send NSEC records in the initial broadcast. Th
   ([#1145](https://github.com/python-zeroconf/python-zeroconf/pull/1145),
   [`524494e`](https://github.com/python-zeroconf/python-zeroconf/commit/524494edd49bd049726b19ae8ac8f6eea69a3943))
 
-- Include tests and docs in sdist archives
+- Ship the tests, docs and COPYING file in the sdist
   ([#1142](https://github.com/python-zeroconf/python-zeroconf/pull/1142),
   [`da10a3b`](https://github.com/python-zeroconf/python-zeroconf/commit/da10a3b2827cee0719d3bb9152ae897f061c6e2e))
-
-feat: Include tests and docs in sdist archives
-
-Include documentation and test files in source distributions, in order to make them more useful for
-  packagers (Linux distributions, Conda). Testing is an important part of packaging process, and at
-  least Gentoo users have requested offline documentation for Python packages. Furthermore, the
-  COPYING file was missing from sdist, even though it was referenced in README.
 
 - Small cleanups to cache cleanup interval
   ([#1146](https://github.com/python-zeroconf/python-zeroconf/pull/1146),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,10 @@ license = "LGPL-2.1-or-later"
 description = "A pure python implementation of multicast DNS service discovery"
 readme = "README.rst"
 authors = [
-    { name = "Paul Scott-Murphy" },
-    { name = "William McBrine" },
-    { name = "Jakub Stasiak" },
-    { name = "J. Nick Koston" },
+    { name = "The python-zeroconf authors" },  # full history in COPYING and git
+]
+maintainers = [
+    { name = "J. Nick Koston", email = "nick@koston.org" },
 ]
 requires-python = ">=3.10"
 

--- a/src/zeroconf/_dns.py
+++ b/src/zeroconf/_dns.py
@@ -170,7 +170,7 @@ class DNSQuestion(DNSEntry):
 
 
 class DNSRecord(DNSEntry):  # noqa: PLW1641
-    """A DNS entry that also carries a TTL and creation time."""
+    """Record layered on the entry identity with a TTL and creation time."""
 
     __slots__ = ("created", "ttl")
 

--- a/src/zeroconf/_utils/name.py
+++ b/src/zeroconf/_utils/name.py
@@ -60,7 +60,7 @@ def service_type_name(type_: str, *, strict: bool = True) -> str:  # pylint: dis
     and anything else that may be represented using Net-Unicode.
 
     :param type_: Type, SubType or service name to validate
-    :return: fully qualified service name (eg: _http._tcp.local.)
+    :return: the validated name, fully qualified (eg: _http._tcp.local.)
     """
     if len(type_) > 256:
         # https://datatracker.ietf.org/doc/html/rfc6763#section-7.2

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -138,7 +138,7 @@ async def test_async_service_registration(quick_timing: None) -> None:
 
     calls = []
 
-    class MyListener(ServiceListener):
+    class EventStore(ServiceListener):
         def add_service(self, zeroconf: Zeroconf, type: str, name: str) -> None:
             calls.append(("add", type, name))
 
@@ -148,7 +148,7 @@ async def test_async_service_registration(quick_timing: None) -> None:
         def update_service(self, zeroconf: Zeroconf, type: str, name: str) -> None:
             calls.append(("update", type, name))
 
-    listener = MyListener()
+    listener = EventStore()
 
     aiozc.zeroconf.add_service_listener(type_, listener)
 
@@ -193,7 +193,7 @@ async def test_async_service_registration_with_server_missing(quick_timing: None
 
     calls = []
 
-    class MyListener(ServiceListener):
+    class EventStore(ServiceListener):
         def add_service(self, zeroconf: Zeroconf, type: str, name: str) -> None:
             calls.append(("add", type, name))
 
@@ -203,7 +203,7 @@ async def test_async_service_registration_with_server_missing(quick_timing: None
         def update_service(self, zeroconf: Zeroconf, type: str, name: str) -> None:
             calls.append(("update", type, name))
 
-    listener = MyListener()
+    listener = EventStore()
 
     aiozc.zeroconf.add_service_listener(type_, listener)
 
@@ -252,7 +252,7 @@ async def test_async_service_registration_same_server_different_ports(quick_timi
 
     calls = []
 
-    class MyListener(ServiceListener):
+    class EventStore(ServiceListener):
         def add_service(self, zeroconf: Zeroconf, type: str, name: str) -> None:
             calls.append(("add", type, name))
 
@@ -262,7 +262,7 @@ async def test_async_service_registration_same_server_different_ports(quick_timi
         def update_service(self, zeroconf: Zeroconf, type: str, name: str) -> None:
             calls.append(("update", type, name))
 
-    listener = MyListener()
+    listener = EventStore()
 
     aiozc.zeroconf.add_service_listener(type_, listener)
 
@@ -310,7 +310,7 @@ async def test_async_service_registration_same_server_same_ports(quick_timing: N
 
     calls = []
 
-    class MyListener(ServiceListener):
+    class EventStore(ServiceListener):
         def add_service(self, zeroconf: Zeroconf, type: str, name: str) -> None:
             calls.append(("add", type, name))
 
@@ -320,7 +320,7 @@ async def test_async_service_registration_same_server_same_ports(quick_timing: N
         def update_service(self, zeroconf: Zeroconf, type: str, name: str) -> None:
             calls.append(("update", type, name))
 
-    listener = MyListener()
+    listener = EventStore()
 
     aiozc.zeroconf.add_service_listener(type_, listener)
 
@@ -432,7 +432,7 @@ async def test_async_tasks(quick_timing: None) -> None:
 
     calls = []
 
-    class MyListener(ServiceListener):
+    class EventStore(ServiceListener):
         def add_service(self, zeroconf: Zeroconf, type: str, name: str) -> None:
             calls.append(("add", type, name))
 
@@ -442,7 +442,7 @@ async def test_async_tasks(quick_timing: None) -> None:
         def update_service(self, zeroconf: Zeroconf, type: str, name: str) -> None:
             calls.append(("update", type, name))
 
-    listener = MyListener()
+    listener = EventStore()
     aiozc.zeroconf.add_service_listener(type_, listener)
 
     desc = {"path": "/healthz/"}
@@ -609,7 +609,7 @@ async def test_async_service_browser(quick_timing: None) -> None:
 
     calls = []
 
-    class MyListener(ServiceListener):
+    class EventStore(ServiceListener):
         def add_service(self, aiozc: Zeroconf, type: str, name: str) -> None:
             calls.append(("add", type, name))
 
@@ -619,7 +619,7 @@ async def test_async_service_browser(quick_timing: None) -> None:
         def update_service(self, aiozc: Zeroconf, type: str, name: str) -> None:
             calls.append(("update", type, name))
 
-    listener = MyListener()
+    listener = EventStore()
     await aiozc.async_add_service_listener(type_, listener)
 
     desc = {"path": "/healthz/"}

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1208,7 +1208,7 @@ async def test_record_update_manager_add_listener_callsback_existing_records():
     zc: Zeroconf = aiozc.zeroconf
     updated = []
 
-    class MyListener(r.RecordUpdateListener):
+    class EventStore(r.RecordUpdateListener):
         """A RecordUpdateListener that does not implement update_records."""
 
         def async_update_records(self, zc: Zeroconf, now: float, records: list[r.RecordUpdate]) -> None:
@@ -1225,7 +1225,7 @@ async def test_record_update_manager_add_listener_callsback_existing_records():
     ptr_record = info.dns_pointer()
     zc.cache.async_add_records([ptr_record, a_record, info.dns_text(), info.dns_service()])
 
-    listener = MyListener()
+    listener = EventStore()
 
     zc.add_listener(
         listener,
@@ -1750,14 +1750,14 @@ async def test_add_listener_warns_when_not_using_record_update_listener(caplog):
     zc: Zeroconf = aiozc.zeroconf
     updated = []
 
-    class MyListener:
+    class EventStore:
         """A RecordUpdateListener that does not implement update_records."""
 
         def async_update_records(self, zc: Zeroconf, now: float, records: list[r.RecordUpdate]) -> None:
             """Update multiple records in one shot."""
             updated.extend(records)
 
-    zc.add_listener(MyListener(), None)  # type: ignore[arg-type]
+    zc.add_listener(EventStore(), None)  # type: ignore[arg-type]
     await asyncio.sleep(0)  # flush out any call soons
     assert (
         "listeners passed to async_add_listener must inherit from RecordUpdateListener" in caplog.text

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -47,7 +47,7 @@ class ListenerTest(unittest.TestCase):
         name = "UPPERxxxyyyæøå"
         registration_name = f"{name}.{subtype}"
 
-        class MyListener(r.ServiceListener):
+        class EventStore(r.ServiceListener):
             def add_service(self, zeroconf, type, name):
                 zeroconf.get_service_info(type, name)
                 service_added.set()
@@ -78,7 +78,7 @@ class ListenerTest(unittest.TestCase):
             def update_service(self, zeroconf, type, name):
                 sub_service_updated.set()
 
-        listener = MyListener()
+        listener = EventStore()
         zeroconf_browser = Zeroconf(interfaces=["127.0.0.1"])
         zeroconf_browser.add_service_listener(type_, listener)
 


### PR DESCRIPTION
## Summary
Sixteenth pass for #1835, from a fourth independent audit. The changelog carried mgorny's commit body verbatim (semantic release blamed it, so blame driven scoping never saw it); his entry and eshattow's PR title are rewritten as neutral summaries, and old changelog entries are never regenerated so the edit is stable. The pyproject authors metadata gets the same treatment as `__author__` in #1868, with a maintainers field added. The 2009 MyListener test class name is renamed, the DNSRecord docstring no longer opens with the three word 2009 DNSEntry phrase, and the name validator return line is reworded.

## Test plan
- [x] full suite passes; poetry check clean apart from a pre existing dependencies migration warning