### PR TITLE
chore: add modification notices to headers and require affirmative consent for past contributions

### DIFF
--- a/.github/workflows/license-notice.yml
+++ b/.github/workflows/license-notice.yml
@@ -37,9 +37,11 @@ jobs:
               body: [
                 "Thanks for contributing! A quick note: this project is in the process of moving from LGPL-2.1 to Apache 2.0, see #1835.",
                 "",
-                "By continuing with this pull request you are okay with your contribution, and your previous contributions to this repository, being offered under Apache 2.0.",
+                "By continuing with this pull request you agree that this new contribution is offered under Apache 2.0.",
                 "",
-                "If that does not work for you, no hard feelings; reply with the exact phrase `I do not agree to the Apache 2.0 license` or simply close this pull request, and nothing of yours will be included in the change.",
+                "This notice does not affect your previous contributions. If you would like to consent to relicensing those as well, please post the consent statement on #1835; silence is never treated as consent for past work.",
+                "",
+                "If offering this contribution under Apache 2.0 does not work for you, no hard feelings; reply with the exact phrase `I do not agree to the Apache 2.0 license` or simply close this pull request.",
               ].join("\n"),
             });
 

--- a/src/zeroconf/__init__.py
+++ b/src/zeroconf/__init__.py
@@ -1,6 +1,8 @@
 """A pure python implementation of multicast DNS service discovery.
 
-Licensed under LGPL-2.1-or-later; see COPYING for details.
+Licensed under LGPL-2.1-or-later; see COPYING for details. This file is
+part of a continuously modified work; modification dates are recorded
+in the project's git history.
 """
 
 from __future__ import annotations

--- a/src/zeroconf/_cache.py
+++ b/src/zeroconf/_cache.py
@@ -1,6 +1,8 @@
 """A pure python implementation of multicast DNS service discovery.
 
-Licensed under LGPL-2.1-or-later; see COPYING for details.
+Licensed under LGPL-2.1-or-later; see COPYING for details. This file is
+part of a continuously modified work; modification dates are recorded
+in the project's git history.
 """
 
 from __future__ import annotations

--- a/src/zeroconf/_core.py
+++ b/src/zeroconf/_core.py
@@ -1,6 +1,8 @@
 """A pure python implementation of multicast DNS service discovery.
 
-Licensed under LGPL-2.1-or-later; see COPYING for details.
+Licensed under LGPL-2.1-or-later; see COPYING for details. This file is
+part of a continuously modified work; modification dates are recorded
+in the project's git history.
 """
 
 from __future__ import annotations

--- a/src/zeroconf/_dns.py
+++ b/src/zeroconf/_dns.py
@@ -1,6 +1,8 @@
 """A pure python implementation of multicast DNS service discovery.
 
-Licensed under LGPL-2.1-or-later; see COPYING for details.
+Licensed under LGPL-2.1-or-later; see COPYING for details. This file is
+part of a continuously modified work; modification dates are recorded
+in the project's git history.
 """
 
 from __future__ import annotations

--- a/src/zeroconf/_engine.py
+++ b/src/zeroconf/_engine.py
@@ -1,6 +1,8 @@
 """A pure python implementation of multicast DNS service discovery.
 
-Licensed under LGPL-2.1-or-later; see COPYING for details.
+Licensed under LGPL-2.1-or-later; see COPYING for details. This file is
+part of a continuously modified work; modification dates are recorded
+in the project's git history.
 """
 
 from __future__ import annotations

--- a/src/zeroconf/_exceptions.py
+++ b/src/zeroconf/_exceptions.py
@@ -1,6 +1,8 @@
 """A pure python implementation of multicast DNS service discovery.
 
-Licensed under LGPL-2.1-or-later; see COPYING for details.
+Licensed under LGPL-2.1-or-later; see COPYING for details. This file is
+part of a continuously modified work; modification dates are recorded
+in the project's git history.
 """
 
 from __future__ import annotations

--- a/src/zeroconf/_handlers/__init__.py
+++ b/src/zeroconf/_handlers/__init__.py
@@ -1,6 +1,8 @@
 """A pure python implementation of multicast DNS service discovery.
 
-Licensed under LGPL-2.1-or-later; see COPYING for details.
+Licensed under LGPL-2.1-or-later; see COPYING for details. This file is
+part of a continuously modified work; modification dates are recorded
+in the project's git history.
 """
 
 from __future__ import annotations

--- a/src/zeroconf/_handlers/answers.py
+++ b/src/zeroconf/_handlers/answers.py
@@ -1,6 +1,8 @@
 """A pure python implementation of multicast DNS service discovery.
 
-Licensed under LGPL-2.1-or-later; see COPYING for details.
+Licensed under LGPL-2.1-or-later; see COPYING for details. This file is
+part of a continuously modified work; modification dates are recorded
+in the project's git history.
 """
 
 from __future__ import annotations

--- a/src/zeroconf/_handlers/multicast_outgoing_queue.py
+++ b/src/zeroconf/_handlers/multicast_outgoing_queue.py
@@ -1,6 +1,8 @@
 """A pure python implementation of multicast DNS service discovery.
 
-Licensed under LGPL-2.1-or-later; see COPYING for details.
+Licensed under LGPL-2.1-or-later; see COPYING for details. This file is
+part of a continuously modified work; modification dates are recorded
+in the project's git history.
 """
 
 from __future__ import annotations

--- a/src/zeroconf/_handlers/query_handler.py
+++ b/src/zeroconf/_handlers/query_handler.py
@@ -1,6 +1,8 @@
 """A pure python implementation of multicast DNS service discovery.
 
-Licensed under LGPL-2.1-or-later; see COPYING for details.
+Licensed under LGPL-2.1-or-later; see COPYING for details. This file is
+part of a continuously modified work; modification dates are recorded
+in the project's git history.
 """
 
 from __future__ import annotations

--- a/src/zeroconf/_handlers/record_manager.py
+++ b/src/zeroconf/_handlers/record_manager.py
@@ -1,6 +1,8 @@
 """A pure python implementation of multicast DNS service discovery.
 
-Licensed under LGPL-2.1-or-later; see COPYING for details.
+Licensed under LGPL-2.1-or-later; see COPYING for details. This file is
+part of a continuously modified work; modification dates are recorded
+in the project's git history.
 """
 
 from __future__ import annotations

--- a/src/zeroconf/_history.py
+++ b/src/zeroconf/_history.py
@@ -1,6 +1,8 @@
 """A pure python implementation of multicast DNS service discovery.
 
-Licensed under LGPL-2.1-or-later; see COPYING for details.
+Licensed under LGPL-2.1-or-later; see COPYING for details. This file is
+part of a continuously modified work; modification dates are recorded
+in the project's git history.
 """
 
 from __future__ import annotations

--- a/src/zeroconf/_listener.py
+++ b/src/zeroconf/_listener.py
@@ -1,6 +1,8 @@
 """A pure python implementation of multicast DNS service discovery.
 
-Licensed under LGPL-2.1-or-later; see COPYING for details.
+Licensed under LGPL-2.1-or-later; see COPYING for details. This file is
+part of a continuously modified work; modification dates are recorded
+in the project's git history.
 """
 
 from __future__ import annotations

--- a/src/zeroconf/_logger.py
+++ b/src/zeroconf/_logger.py
@@ -1,6 +1,8 @@
 """A pure python implementation of multicast DNS service discovery.
 
-Licensed under LGPL-2.1-or-later; see COPYING for details.
+Licensed under LGPL-2.1-or-later; see COPYING for details. This file is
+part of a continuously modified work; modification dates are recorded
+in the project's git history.
 """
 
 from __future__ import annotations

--- a/src/zeroconf/_protocol/__init__.py
+++ b/src/zeroconf/_protocol/__init__.py
@@ -1,6 +1,8 @@
 """A pure python implementation of multicast DNS service discovery.
 
-Licensed under LGPL-2.1-or-later; see COPYING for details.
+Licensed under LGPL-2.1-or-later; see COPYING for details. This file is
+part of a continuously modified work; modification dates are recorded
+in the project's git history.
 """
 
 from __future__ import annotations

--- a/src/zeroconf/_protocol/incoming.py
+++ b/src/zeroconf/_protocol/incoming.py
@@ -1,6 +1,8 @@
 """A pure python implementation of multicast DNS service discovery.
 
-Licensed under LGPL-2.1-or-later; see COPYING for details.
+Licensed under LGPL-2.1-or-later; see COPYING for details. This file is
+part of a continuously modified work; modification dates are recorded
+in the project's git history.
 """
 
 from __future__ import annotations

--- a/src/zeroconf/_protocol/outgoing.py
+++ b/src/zeroconf/_protocol/outgoing.py
@@ -1,6 +1,8 @@
 """A pure python implementation of multicast DNS service discovery.
 
-Licensed under LGPL-2.1-or-later; see COPYING for details.
+Licensed under LGPL-2.1-or-later; see COPYING for details. This file is
+part of a continuously modified work; modification dates are recorded
+in the project's git history.
 """
 
 from __future__ import annotations

--- a/src/zeroconf/_record_update.py
+++ b/src/zeroconf/_record_update.py
@@ -1,6 +1,8 @@
 """A pure python implementation of multicast DNS service discovery.
 
-Licensed under LGPL-2.1-or-later; see COPYING for details.
+Licensed under LGPL-2.1-or-later; see COPYING for details. This file is
+part of a continuously modified work; modification dates are recorded
+in the project's git history.
 """
 
 from __future__ import annotations

--- a/src/zeroconf/_services/__init__.py
+++ b/src/zeroconf/_services/__init__.py
@@ -1,6 +1,8 @@
 """A pure python implementation of multicast DNS service discovery.
 
-Licensed under LGPL-2.1-or-later; see COPYING for details.
+Licensed under LGPL-2.1-or-later; see COPYING for details. This file is
+part of a continuously modified work; modification dates are recorded
+in the project's git history.
 """
 
 from __future__ import annotations

--- a/src/zeroconf/_services/browser.py
+++ b/src/zeroconf/_services/browser.py
@@ -1,6 +1,8 @@
 """A pure python implementation of multicast DNS service discovery.
 
-Licensed under LGPL-2.1-or-later; see COPYING for details.
+Licensed under LGPL-2.1-or-later; see COPYING for details. This file is
+part of a continuously modified work; modification dates are recorded
+in the project's git history.
 """
 
 from __future__ import annotations

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -1,6 +1,8 @@
 """A pure python implementation of multicast DNS service discovery.
 
-Licensed under LGPL-2.1-or-later; see COPYING for details.
+Licensed under LGPL-2.1-or-later; see COPYING for details. This file is
+part of a continuously modified work; modification dates are recorded
+in the project's git history.
 """
 
 from __future__ import annotations

--- a/src/zeroconf/_services/registry.py
+++ b/src/zeroconf/_services/registry.py
@@ -1,6 +1,8 @@
 """A pure python implementation of multicast DNS service discovery.
 
-Licensed under LGPL-2.1-or-later; see COPYING for details.
+Licensed under LGPL-2.1-or-later; see COPYING for details. This file is
+part of a continuously modified work; modification dates are recorded
+in the project's git history.
 """
 
 from __future__ import annotations

--- a/src/zeroconf/_services/types.py
+++ b/src/zeroconf/_services/types.py
@@ -1,6 +1,8 @@
 """A pure python implementation of multicast DNS service discovery.
 
-Licensed under LGPL-2.1-or-later; see COPYING for details.
+Licensed under LGPL-2.1-or-later; see COPYING for details. This file is
+part of a continuously modified work; modification dates are recorded
+in the project's git history.
 """
 
 from __future__ import annotations

--- a/src/zeroconf/_transport.py
+++ b/src/zeroconf/_transport.py
@@ -1,6 +1,8 @@
 """A pure python implementation of multicast DNS service discovery.
 
-Licensed under LGPL-2.1-or-later; see COPYING for details.
+Licensed under LGPL-2.1-or-later; see COPYING for details. This file is
+part of a continuously modified work; modification dates are recorded
+in the project's git history.
 """
 
 from __future__ import annotations

--- a/src/zeroconf/_updates.py
+++ b/src/zeroconf/_updates.py
@@ -1,6 +1,8 @@
 """A pure python implementation of multicast DNS service discovery.
 
-Licensed under LGPL-2.1-or-later; see COPYING for details.
+Licensed under LGPL-2.1-or-later; see COPYING for details. This file is
+part of a continuously modified work; modification dates are recorded
+in the project's git history.
 """
 
 from __future__ import annotations

--- a/src/zeroconf/_utils/__init__.py
+++ b/src/zeroconf/_utils/__init__.py
@@ -1,6 +1,8 @@
 """A pure python implementation of multicast DNS service discovery.
 
-Licensed under LGPL-2.1-or-later; see COPYING for details.
+Licensed under LGPL-2.1-or-later; see COPYING for details. This file is
+part of a continuously modified work; modification dates are recorded
+in the project's git history.
 """
 
 from __future__ import annotations

--- a/src/zeroconf/_utils/asyncio.py
+++ b/src/zeroconf/_utils/asyncio.py
@@ -1,6 +1,8 @@
 """A pure python implementation of multicast DNS service discovery.
 
-Licensed under LGPL-2.1-or-later; see COPYING for details.
+Licensed under LGPL-2.1-or-later; see COPYING for details. This file is
+part of a continuously modified work; modification dates are recorded
+in the project's git history.
 """
 
 from __future__ import annotations

--- a/src/zeroconf/_utils/ipaddress.py
+++ b/src/zeroconf/_utils/ipaddress.py
@@ -1,6 +1,8 @@
 """A pure python implementation of multicast DNS service discovery.
 
-Licensed under LGPL-2.1-or-later; see COPYING for details.
+Licensed under LGPL-2.1-or-later; see COPYING for details. This file is
+part of a continuously modified work; modification dates are recorded
+in the project's git history.
 """
 
 from __future__ import annotations

--- a/src/zeroconf/_utils/name.py
+++ b/src/zeroconf/_utils/name.py
@@ -1,6 +1,8 @@
 """A pure python implementation of multicast DNS service discovery.
 
-Licensed under LGPL-2.1-or-later; see COPYING for details.
+Licensed under LGPL-2.1-or-later; see COPYING for details. This file is
+part of a continuously modified work; modification dates are recorded
+in the project's git history.
 """
 
 from __future__ import annotations

--- a/src/zeroconf/_utils/net.py
+++ b/src/zeroconf/_utils/net.py
@@ -1,6 +1,8 @@
 """A pure python implementation of multicast DNS service discovery.
 
-Licensed under LGPL-2.1-or-later; see COPYING for details.
+Licensed under LGPL-2.1-or-later; see COPYING for details. This file is
+part of a continuously modified work; modification dates are recorded
+in the project's git history.
 """
 
 from __future__ import annotations

--- a/src/zeroconf/_utils/time.py
+++ b/src/zeroconf/_utils/time.py
@@ -1,6 +1,8 @@
 """A pure python implementation of multicast DNS service discovery.
 
-Licensed under LGPL-2.1-or-later; see COPYING for details.
+Licensed under LGPL-2.1-or-later; see COPYING for details. This file is
+part of a continuously modified work; modification dates are recorded
+in the project's git history.
 """
 
 from __future__ import annotations

--- a/src/zeroconf/asyncio.py
+++ b/src/zeroconf/asyncio.py
@@ -1,6 +1,8 @@
 """A pure python implementation of multicast DNS service discovery.
 
-Licensed under LGPL-2.1-or-later; see COPYING for details.
+Licensed under LGPL-2.1-or-later; see COPYING for details. This file is
+part of a continuously modified work; modification dates are recorded
+in the project's git history.
 """
 
 from __future__ import annotations

--- a/src/zeroconf/const.py
+++ b/src/zeroconf/const.py
@@ -1,6 +1,8 @@
 """A pure python implementation of multicast DNS service discovery.
 
-Licensed under LGPL-2.1-or-later; see COPYING for details.
+Licensed under LGPL-2.1-or-later; see COPYING for details. This file is
+part of a continuously modified work; modification dates are recorded
+in the project's git history.
 """
 
 from __future__ import annotations

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,8 @@
 """A pure python implementation of multicast DNS service discovery.
 
-Licensed under LGPL-2.1-or-later; see COPYING for details.
+Licensed under LGPL-2.1-or-later; see COPYING for details. This file is
+part of a continuously modified work; modification dates are recorded
+in the project's git history.
 """
 
 from __future__ import annotations

--- a/tests/services/__init__.py
+++ b/tests/services/__init__.py
@@ -1,6 +1,8 @@
 """A pure python implementation of multicast DNS service discovery.
 
-Licensed under LGPL-2.1-or-later; see COPYING for details.
+Licensed under LGPL-2.1-or-later; see COPYING for details. This file is
+part of a continuously modified work; modification dates are recorded
+in the project's git history.
 """
 
 from __future__ import annotations

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,6 +1,8 @@
 """A pure python implementation of multicast DNS service discovery.
 
-Licensed under LGPL-2.1-or-later; see COPYING for details.
+Licensed under LGPL-2.1-or-later; see COPYING for details. This file is
+part of a continuously modified work; modification dates are recorded
+in the project's git history.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
Two hardening items from outside legal review of the relicensing work.

LGPL 2.1 section 2 asks modified files to carry prominent modification notices; the short headers from #1861 now state the work is continuously modified with dates recorded in git history, alongside the existing license pointer.

The license notice workflow no longer treats continuing a pull request as consent covering previous contributions. The new contribution is offered under the incoming license as with any project, and consent for past work happens only through the explicit statement on #1835; the notice now says silence is never treated as consent for past work.

## Test plan
- [x] suite passes; workflow yaml validates