### PR TITLE
chore: enforce the declaration ordering convention in ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,3 +58,10 @@ repos:
     hooks:
       - id: cython-lint
       - id: double-quote-cython-strings
+  - repo: local
+    hooks:
+      - id: check-declaration-order
+        name: check declaration order
+        entry: python3 scripts/check_declaration_order.py
+        language: system
+        files: ^(src/zeroconf/.*\.py|scripts/check_declaration_order\.py)$

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,8 +63,15 @@ path. The authoritative list of cythonized modules lives in
   references** to old codepaths or issue numbers unless there's
   a clear reason a future reader needs that link.
 
-- **Method order**: public API at the top, private helpers
-  (`_underscore_prefixed`) at the bottom. Modules whose names
+- **Method order**: enforced by `scripts/check_declaration_order.py`
+  (a pre-commit hook): dunder methods first with `__init__` leading,
+  then public methods, then private helpers (`_underscore_prefixed`),
+  each group alphabetical. Sibling classes that share a locally defined
+  base are declared alphabetically after that base. The order is
+  rule-generated on purpose — the arrangement of declarations is
+  derived from this stated convention rather than from any earlier
+  codebase — so don't hand-tune it; if a grouping seems more readable,
+  the convention still wins. Modules whose names
   start with `_` (`_cache`, `_dns`, `_handlers/`, etc.) are
   internal; the supported surface is what `zeroconf/__init__.py`
   and `zeroconf/asyncio.py` re-export.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,6 +183,9 @@ select = [
 "examples/**/*" = [
     "T201", # intended
 ]
+"scripts/**/*" = [
+    "T201", # intended
+]
 "setup.py" = ["D100"]
 "conftest.py" = ["D100"]
 "docs/conf.py" = ["D100"]

--- a/scripts/check_declaration_order.py
+++ b/scripts/check_declaration_order.py
@@ -1,0 +1,88 @@
+"""Enforce the repository's declaration ordering convention.
+
+Methods within a class: dunders with ``__init__`` first, then public,
+then private, each group alphabetical. Sibling classes at module level:
+locally defined bases before their subclasses, alphabetical among
+subclasses sharing the same locally defined bases. See CLAUDE.md for the rationale.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src" / "zeroconf"
+
+
+def method_sort_key(name: str) -> tuple[int, bool, str]:
+    is_dunder = name.startswith("__") and name.endswith("__")
+    is_private = not is_dunder and name.startswith("_")
+    group = 0 if is_dunder else (2 if is_private else 1)
+    return (group, name != "__init__", name)
+
+
+def check_methods(rel: Path, cls: ast.ClassDef) -> list[str]:
+    names = [node.name for node in cls.body if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))]
+    # property setters share the getter's name; the sort is stable so
+    # equal-name adjacency is always satisfiable
+    expected = sorted(names, key=method_sort_key)
+    if names != expected:
+        return [
+            f"{rel}:{cls.lineno}: class {cls.name}: method order breaks the "
+            f"convention (dunders with __init__ first, then public, then "
+            f"private, each alphabetical); expected: {', '.join(expected)}"
+        ]
+    return []
+
+
+def check_class_order(rel: Path, tree: ast.Module) -> list[str]:
+    classes = [node for node in tree.body if isinstance(node, ast.ClassDef)]
+    local = {cls.name for cls in classes}
+    position = {cls.name: i for i, cls in enumerate(classes)}
+    problems = []
+    for i, cls in enumerate(classes):
+        bases = sorted(b.id for b in cls.bases if isinstance(b, ast.Name) and b.id in local)
+        for base in bases:
+            if position[base] > i:
+                problems.append(f"{rel}:{cls.lineno}: class {cls.name} is defined before its base {base}")
+        if i:
+            prev = classes[i - 1]
+            prev_bases = sorted(b.id for b in prev.bases if isinstance(b, ast.Name) and b.id in local)
+            if bases and prev_bases == bases and prev.name.lower() > cls.name.lower():
+                problems.append(
+                    f"{rel}:{cls.lineno}: class {cls.name} should come before its "
+                    f"sibling {prev.name} (siblings with the same local bases are "
+                    f"alphabetical)"
+                )
+    return problems
+
+
+def check_file(path: Path) -> list[str]:
+    rel = path.resolve().relative_to(ROOT)
+    tree = ast.parse(path.read_text())
+    problems = check_class_order(rel, tree)
+    stack: list[ast.AST] = [tree]
+    while stack:
+        node = stack.pop()
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, ast.ClassDef):
+                problems.extend(check_methods(rel, child))
+            if isinstance(child, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef, ast.If)):
+                stack.append(child)
+    return problems
+
+
+def main() -> int:
+    paths = [Path(arg) for arg in sys.argv[1:]] or sorted(SRC.rglob("*.py"))
+    problems: list[str] = []
+    for path in paths:
+        problems.extend(check_file(path))
+    for problem in problems:
+        print(problem)
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/zeroconf/_engine.py
+++ b/src/zeroconf/_engine.py
@@ -117,68 +117,6 @@ class AsyncEngine:
         self._cleanup_timer: asyncio.TimerHandle | None = None
         self._setup_task: asyncio.Task[None] | None = None
 
-    def setup(
-        self,
-        loop: asyncio.AbstractEventLoop,
-        loop_thread_ready: threading.Event | None,
-    ) -> None:
-        """Set up the instance."""
-        self.loop = loop
-        self.running_future = loop.create_future()
-        self._setup_task = self.loop.create_task(self._async_setup(loop_thread_ready))
-
-    async def _async_setup(self, loop_thread_ready: threading.Event | None) -> None:
-        """Set up the instance."""
-        self._async_schedule_next_cache_cleanup()
-        await self._async_create_endpoints()
-        assert self.running_future is not None
-        if not self.running_future.done():
-            self.running_future.set_result(True)
-        if loop_thread_ready:
-            loop_thread_ready.set()
-
-    async def _async_create_endpoints(self) -> None:
-        """Create endpoints to send and receive."""
-        reader_sockets = []
-        sender_sockets = []
-        if self._listen_socket:
-            reader_sockets.append(self._listen_socket)
-        for s in self._respond_sockets:
-            if s not in reader_sockets:
-                reader_sockets.append(s)
-            sender_sockets.append(s)
-
-        for s in reader_sockets:
-            reader = await self._async_wrap_socket(s, s in sender_sockets)
-            # _async_wrap_socket registers the transport with no await between
-            # creating and registering it, and the pending-handle cleanup below
-            # adds no await either, so a concurrent shutdown always sees ``s``
-            # in exactly one place.
-            if s is self._listen_socket:
-                # Keep a handle to the shared listen socket so interface
-                # rescans can add/drop multicast memberships on it.
-                self._listen_transport = reader
-                self._listen_socket = None
-            if s in self._respond_sockets:
-                self._respond_sockets.remove(s)
-
-    async def _async_wrap_socket(self, sock: socket.socket, is_sender: bool) -> _WrappedTransport:
-        """Adopt a socket into a transport, register it, and return the reader wrapper."""
-        assert self.loop is not None
-        transport, protocol = await self.loop.create_datagram_endpoint(  # type: ignore[type-var]
-            lambda: AsyncListener(self.zc),  # type: ignore[arg-type, return-value]
-            sock=sock,
-        )
-        datagram_transport = cast(asyncio.DatagramTransport, transport)
-        reader = make_wrapped_transport(datagram_transport)
-        # No ``await`` between wrapping and registering so a concurrent
-        # shutdown always sees the transport in exactly one place.
-        self.protocols.append(cast(AsyncListener, protocol))
-        self.readers.append(reader)
-        if is_sender:
-            self.senders.append(make_wrapped_transport(datagram_transport))
-        return reader
-
     async def async_update_interfaces(
         self,
         interfaces: InterfacesType,
@@ -271,6 +209,32 @@ class AsyncEngine:
                 added = True
         return added
 
+    def close(self) -> None:
+        """Close from sync context.
+
+        While it is not expected during normal operation,
+        this function may raise EventLoopBlocked if the underlying
+        call to `_async_close` cannot be completed.
+        """
+        assert self.loop is not None
+        # Guard against Zeroconf.close() being called from the eventloop
+        if get_running_loop() == self.loop:
+            self._async_shutdown()
+            return
+        if not self.loop.is_running():
+            return
+        run_coro_with_timeout(self._async_close(), self.loop, _CLOSE_TIMEOUT)
+
+    def setup(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        loop_thread_ready: threading.Event | None,
+    ) -> None:
+        """Set up the instance."""
+        self.loop = loop
+        self.running_future = loop.create_future()
+        self._setup_task = self.loop.create_task(self._async_setup(loop_thread_ready))
+
     async def _async_add_interface(
         self,
         interface: str | tuple[tuple[str, int, int], int],
@@ -309,19 +273,32 @@ class AsyncEngine:
             return False
         return True
 
-    def _async_remove_transport(self, transport: asyncio.DatagramTransport) -> None:
-        """Drop a transport's protocol/reader/sender wrappers, cancelling its timers."""
-        kept_protocols = []
-        for protocol in self.protocols:
-            if protocol.transport is not None and protocol.transport.transport is transport:
-                # Cancel any pending TC-reassembly timers so one can't fire a
-                # response against the transport we're about to close.
-                protocol.cancel_pending_timers()
-            else:
-                kept_protocols.append(protocol)
-        self.protocols = kept_protocols
-        self.readers = _without_transport(self.readers, transport)
-        self.senders = _without_transport(self.senders, transport)
+    def _async_cache_cleanup(self) -> None:
+        """Periodic cache cleanup."""
+        now = current_time_millis()
+        self.zc.question_history.async_expire(now)
+        self.zc.record_manager.async_updates(
+            now,
+            [RecordUpdate(record, record) for record in self.zc.cache.async_expire(now)],
+        )
+        self.zc.record_manager.async_updates_complete(False)
+        self._async_schedule_next_cache_cleanup()
+
+    async def _async_close(self) -> None:
+        """Cancel and wait for the cleanup task to finish."""
+        assert self._setup_task is not None
+        # Swallow CancelledError only if the setup task itself was
+        # cancelled (close-before-start); outer-task cancellation must
+        # propagate.
+        try:
+            await self._setup_task
+        except asyncio.CancelledError:
+            if not self._setup_task.cancelled():
+                raise
+        self._async_shutdown()
+        await asyncio.sleep(0)  # flush out any call soons
+        if self._cleanup_timer is not None:
+            self._cleanup_timer.cancel()
 
     def _async_close_sender(self, wrapped: _WrappedTransport, listen_socket: socket.socket | None) -> None:
         """Drop a per-interface sender's wrappers/protocol and close its transport."""
@@ -333,6 +310,31 @@ class AsyncEngine:
         finally:
             # Release the socket even if a non-benign leave (e.g. EPERM) raises.
             transport.close()
+
+    async def _async_create_endpoints(self) -> None:
+        """Create endpoints to send and receive."""
+        reader_sockets = []
+        sender_sockets = []
+        if self._listen_socket:
+            reader_sockets.append(self._listen_socket)
+        for s in self._respond_sockets:
+            if s not in reader_sockets:
+                reader_sockets.append(s)
+            sender_sockets.append(s)
+
+        for s in reader_sockets:
+            reader = await self._async_wrap_socket(s, s in sender_sockets)
+            # _async_wrap_socket registers the transport with no await between
+            # creating and registering it, and the pending-handle cleanup below
+            # adds no await either, so a concurrent shutdown always sees ``s``
+            # in exactly one place.
+            if s is self._listen_socket:
+                # Keep a handle to the shared listen socket so interface
+                # rescans can add/drop multicast memberships on it.
+                self._listen_transport = reader
+                self._listen_socket = None
+            if s in self._respond_sockets:
+                self._respond_sockets.remove(s)
 
     async def _async_rebuild_listen_socket(
         self,
@@ -387,16 +389,19 @@ class AsyncEngine:
         self._async_remove_transport(old_transport)
         old_transport.close()
 
-    def _async_cache_cleanup(self) -> None:
-        """Periodic cache cleanup."""
-        now = current_time_millis()
-        self.zc.question_history.async_expire(now)
-        self.zc.record_manager.async_updates(
-            now,
-            [RecordUpdate(record, record) for record in self.zc.cache.async_expire(now)],
-        )
-        self.zc.record_manager.async_updates_complete(False)
-        self._async_schedule_next_cache_cleanup()
+    def _async_remove_transport(self, transport: asyncio.DatagramTransport) -> None:
+        """Drop a transport's protocol/reader/sender wrappers, cancelling its timers."""
+        kept_protocols = []
+        for protocol in self.protocols:
+            if protocol.transport is not None and protocol.transport.transport is transport:
+                # Cancel any pending TC-reassembly timers so one can't fire a
+                # response against the transport we're about to close.
+                protocol.cancel_pending_timers()
+            else:
+                kept_protocols.append(protocol)
+        self.protocols = kept_protocols
+        self.readers = _without_transport(self.readers, transport)
+        self.senders = _without_transport(self.senders, transport)
 
     def _async_schedule_next_cache_cleanup(self) -> None:
         """Schedule the next cache cleanup."""
@@ -404,21 +409,15 @@ class AsyncEngine:
         assert loop is not None
         self._cleanup_timer = loop.call_at(loop.time() + _CACHE_CLEANUP_INTERVAL, self._async_cache_cleanup)
 
-    async def _async_close(self) -> None:
-        """Cancel and wait for the cleanup task to finish."""
-        assert self._setup_task is not None
-        # Swallow CancelledError only if the setup task itself was
-        # cancelled (close-before-start); outer-task cancellation must
-        # propagate.
-        try:
-            await self._setup_task
-        except asyncio.CancelledError:
-            if not self._setup_task.cancelled():
-                raise
-        self._async_shutdown()
-        await asyncio.sleep(0)  # flush out any call soons
-        if self._cleanup_timer is not None:
-            self._cleanup_timer.cancel()
+    async def _async_setup(self, loop_thread_ready: threading.Event | None) -> None:
+        """Set up the instance."""
+        self._async_schedule_next_cache_cleanup()
+        await self._async_create_endpoints()
+        assert self.running_future is not None
+        if not self.running_future.done():
+            self.running_future.set_result(True)
+        if loop_thread_ready:
+            loop_thread_ready.set()
 
     def _async_shutdown(self) -> None:
         """Shutdown transports and sockets; safe to call repeatedly."""
@@ -439,18 +438,19 @@ class AsyncEngine:
             s.close()
         self._respond_sockets = []
 
-    def close(self) -> None:
-        """Close from sync context.
-
-        While it is not expected during normal operation,
-        this function may raise EventLoopBlocked if the underlying
-        call to `_async_close` cannot be completed.
-        """
+    async def _async_wrap_socket(self, sock: socket.socket, is_sender: bool) -> _WrappedTransport:
+        """Adopt a socket into a transport, register it, and return the reader wrapper."""
         assert self.loop is not None
-        # Guard against Zeroconf.close() being called from the eventloop
-        if get_running_loop() == self.loop:
-            self._async_shutdown()
-            return
-        if not self.loop.is_running():
-            return
-        run_coro_with_timeout(self._async_close(), self.loop, _CLOSE_TIMEOUT)
+        transport, protocol = await self.loop.create_datagram_endpoint(  # type: ignore[type-var]
+            lambda: AsyncListener(self.zc),  # type: ignore[arg-type, return-value]
+            sock=sock,
+        )
+        datagram_transport = cast(asyncio.DatagramTransport, transport)
+        reader = make_wrapped_transport(datagram_transport)
+        # No ``await`` between wrapping and registering so a concurrent
+        # shutdown always sees the transport in exactly one place.
+        self.protocols.append(cast(AsyncListener, protocol))
+        self.readers.append(reader)
+        if is_sender:
+            self.senders.append(make_wrapped_transport(datagram_transport))
+        return reader

--- a/src/zeroconf/_handlers/multicast_outgoing_queue.py
+++ b/src/zeroconf/_handlers/multicast_outgoing_queue.py
@@ -73,12 +73,6 @@ class MulticastOutgoingQueue:
             loop.call_at(loop.time() + millis_to_seconds(random_delay), self.async_ready)
         self.queue.append(AnswerGroup(send_after, send_before, answers))
 
-    def _remove_answers_from_queue(self, answers: _AnswerWithAdditionalsType) -> None:
-        """Remove a set of answers from the outgoing queue."""
-        for pending in self.queue:
-            for record in answers:
-                pending.answers.pop(record, None)
-
     def async_ready(self) -> None:
         """Process anything in the queue that is ready."""
         zc = self.zc
@@ -113,3 +107,9 @@ class MulticastOutgoingQueue:
             # If we have the same answer scheduled to go out, remove them
             self._remove_answers_from_queue(answers)
             zc.async_send(construct_outgoing_multicast_answers(answers))
+
+    def _remove_answers_from_queue(self, answers: _AnswerWithAdditionalsType) -> None:
+        """Remove a set of answers from the outgoing queue."""
+        for pending in self.queue:
+            for record in answers:
+                pending.answers.pop(record, None)

--- a/src/zeroconf/_handlers/query_handler.py
+++ b/src/zeroconf/_handlers/query_handler.py
@@ -103,22 +103,6 @@ class _QueryResponse:
         self._mcast_aggregate: set[DNSRecord] = set()
         self._mcast_aggregate_last_second: set[DNSRecord] = set()
 
-    def add_qu_question_response(self, answers: _AnswerWithAdditionalsType) -> None:
-        """Generate a response to a multicast QU query."""
-        for record, additionals in answers.items():
-            self._additionals[record] = additionals
-            if self._is_probe:
-                self._ucast.add(record)
-            if not self._has_mcast_within_one_quarter_ttl(record):
-                self._mcast_now.add(record)
-            elif not self._is_probe:
-                self._ucast.add(record)
-
-    def add_ucast_question_response(self, answers: _AnswerWithAdditionalsType) -> None:
-        """Generate a response to a unicast query."""
-        self._additionals.update(answers)
-        self._ucast.update(answers)
-
     def add_mcast_question_response(self, answers: _AnswerWithAdditionalsType) -> None:
         """Generate a response to a multicast query."""
         self._additionals.update(answers)
@@ -139,6 +123,22 @@ class _QueryResponse:
 
             self._mcast_aggregate.add(answer)
 
+    def add_qu_question_response(self, answers: _AnswerWithAdditionalsType) -> None:
+        """Generate a response to a multicast QU query."""
+        for record, additionals in answers.items():
+            self._additionals[record] = additionals
+            if self._is_probe:
+                self._ucast.add(record)
+            if not self._has_mcast_within_one_quarter_ttl(record):
+                self._mcast_now.add(record)
+            elif not self._is_probe:
+                self._ucast.add(record)
+
+    def add_ucast_question_response(self, answers: _AnswerWithAdditionalsType) -> None:
+        """Generate a response to a unicast query."""
+        self._additionals.update(answers)
+        self._ucast.update(answers)
+
     def answers(
         self,
     ) -> QuestionAnswers:
@@ -148,6 +148,16 @@ class _QueryResponse:
         mcast_aggregate = {r: self._additionals[r] for r in self._mcast_aggregate}
         mcast_aggregate_last_second = {r: self._additionals[r] for r in self._mcast_aggregate_last_second}
         return QuestionAnswers(ucast, mcast_now, mcast_aggregate, mcast_aggregate_last_second)
+
+    def _has_mcast_record_in_last_second(self, record: DNSRecord) -> bool:
+        """Check if an answer was seen in the last second.
+        Protect the network against excessive packet flooding
+        https://datatracker.ietf.org/doc/html/rfc6762#section-14
+        """
+        if TYPE_CHECKING:
+            record = cast(_UniqueRecordsType, record)
+        maybe_entry = self._cache.async_get_unique(record)
+        return bool(maybe_entry is not None and self._now - maybe_entry.created < _ONE_SECOND)
 
     def _has_mcast_within_one_quarter_ttl(self, record: DNSRecord) -> bool:
         """Check to see if a record has been mcasted recently.
@@ -164,16 +174,6 @@ class _QueryResponse:
             record = cast(_UniqueRecordsType, record)
         maybe_entry = self._cache.async_get_unique(record)
         return bool(maybe_entry is not None and maybe_entry.is_recent(self._now))
-
-    def _has_mcast_record_in_last_second(self, record: DNSRecord) -> bool:
-        """Check if an answer was seen in the last second.
-        Protect the network against excessive packet flooding
-        https://datatracker.ietf.org/doc/html/rfc6762#section-14
-        """
-        if TYPE_CHECKING:
-            record = cast(_UniqueRecordsType, record)
-        maybe_entry = self._cache.async_get_unique(record)
-        return bool(maybe_entry is not None and self._now - maybe_entry.created < _ONE_SECOND)
 
 
 class QueryHandler:
@@ -196,109 +196,6 @@ class QueryHandler:
         self.question_history = zc.question_history
         self.out_queue = zc.out_queue
         self.out_delay_queue = zc.out_delay_queue
-
-    def _add_service_type_enumeration_query_answers(
-        self,
-        types: list[_str],
-        answer_set: _AnswerWithAdditionalsType,
-        known_answers: DNSRRSet,
-    ) -> None:
-        """Provide an answer to a service type enumeration query.
-
-        https://datatracker.ietf.org/doc/html/rfc6763#section-9
-        """
-        for stype in types:
-            dns_pointer = DNSPointer(
-                _SERVICE_TYPE_ENUMERATION_NAME,
-                _TYPE_PTR,
-                _CLASS_IN,
-                _DNS_OTHER_TTL,
-                stype,
-                0.0,
-            )
-            if not known_answers.suppresses(dns_pointer):
-                answer_set[dns_pointer] = set()
-
-    def _add_pointer_answers(
-        self,
-        services: list[_ServiceInfo],
-        answer_set: _AnswerWithAdditionalsType,
-        known_answers: DNSRRSet,
-    ) -> None:
-        """Answer PTR/ANY question."""
-        for service in services:
-            # Add recommended additional answers according to
-            # https://tools.ietf.org/html/rfc6763#section-12.1.
-            dns_pointer = service._dns_pointer(None)
-            if known_answers.suppresses(dns_pointer):
-                continue
-            answer_set[dns_pointer] = {
-                service._dns_service(None),
-                service._dns_text(None),
-                *service._get_address_and_nsec_records(None),
-            }
-
-    def _add_address_answers(
-        self,
-        services: list[_ServiceInfo],
-        answer_set: _AnswerWithAdditionalsType,
-        known_answers: DNSRRSet,
-        type_: _int,
-    ) -> None:
-        """Answer A/AAAA/ANY question."""
-        for service in services:
-            answers: list[DNSAddress] = []
-            additionals: set[DNSRecord] = set()
-            type_seen = False
-            for dns_address in service._dns_addresses(None, _IPVersion_ALL):
-                if dns_address.type != type_:
-                    additionals.add(dns_address)
-                else:
-                    type_seen = True
-                    if not known_answers.suppresses(dns_address):
-                        answers.append(dns_address)
-            if answers:
-                nsec = service._dns_address_nsec(None)
-                if nsec is not None:
-                    additionals.add(nsec)
-                for answer in answers:
-                    answer_set[answer] = additionals
-            elif not type_seen and type_ in _ADDRESS_RECORD_TYPES:
-                nsec = service._dns_address_nsec(None)
-                if nsec is not None:
-                    answer_set[nsec] = set()
-
-    def _answer_question(
-        self,
-        question: DNSQuestion,
-        strategy_type: _int,
-        types: list[_str],
-        services: list[_ServiceInfo],
-        known_answers: DNSRRSet,
-    ) -> _AnswerWithAdditionalsType:
-        """Answer a question."""
-        answer_set: _AnswerWithAdditionalsType = {}
-
-        if strategy_type == _ANSWER_STRATEGY_SERVICE_TYPE_ENUMERATION:
-            self._add_service_type_enumeration_query_answers(types, answer_set, known_answers)
-        elif strategy_type == _ANSWER_STRATEGY_POINTER:
-            self._add_pointer_answers(services, answer_set, known_answers)
-        elif strategy_type == _ANSWER_STRATEGY_ADDRESS:
-            self._add_address_answers(services, answer_set, known_answers, question.type)
-        elif strategy_type == _ANSWER_STRATEGY_SERVICE:
-            # Add recommended additional answers according to
-            # https://tools.ietf.org/html/rfc6763#section-12.2.
-            service = services[0]
-            dns_service = service._dns_service(None)
-            if not known_answers.suppresses(dns_service):
-                answer_set[dns_service] = service._get_address_and_nsec_records(None)
-        elif strategy_type == _ANSWER_STRATEGY_TEXT:  # pragma: no branch
-            service = services[0]
-            dns_text = service._dns_text(None)
-            if not known_answers.suppresses(dns_text):
-                answer_set[dns_text] = set()
-
-        return answer_set
 
     def async_response(  # pylint: disable=unused-argument
         self, msgs: list[_DNSIncoming], ucast_source: bool
@@ -355,6 +252,148 @@ class QueryHandler:
             query_res.add_mcast_question_response(answer_set)
 
         return query_res.answers()
+
+    def handle_assembled_query(
+        self,
+        packets: list[_DNSIncoming],
+        addr: _str,
+        port: _int,
+        transport: _WrappedTransport,
+        v6_flow_scope: tuple[()] | tuple[int, int],
+    ) -> None:
+        """Respond to a (re)assembled query.
+
+        If the protocol received packets with the TC bit set, it will
+        wait a bit for the rest of the packets and only call
+        handle_assembled_query once it has a complete set of packets
+        or the timer expires. If the TC bit is not set, a single
+        packet will be in packets.
+        """
+        first_packet = packets[0]
+        ucast_source = port != _MDNS_PORT
+        question_answers = self.async_response(packets, ucast_source)
+        if question_answers is None:
+            return
+        if question_answers.ucast:
+            questions = first_packet._questions
+            id_ = first_packet.id
+            out = construct_outgoing_unicast_answers(question_answers.ucast, ucast_source, questions, id_)
+            # When sending unicast, only send back the reply
+            # via the same socket that it was received from
+            # as we know its reachable from that socket
+            self.zc.async_send(out, addr, port, v6_flow_scope, transport)
+        if question_answers.mcast_now:
+            self.zc.async_send(construct_outgoing_multicast_answers(question_answers.mcast_now))
+        if question_answers.mcast_aggregate:
+            self.out_queue.async_add(first_packet.now, question_answers.mcast_aggregate)
+        if question_answers.mcast_aggregate_last_second:
+            # https://datatracker.ietf.org/doc/html/rfc6762#section-14
+            # If we broadcast it in the last second, we have to delay
+            # at least a second before we send it again
+            self.out_delay_queue.async_add(first_packet.now, question_answers.mcast_aggregate_last_second)
+
+    def _add_address_answers(
+        self,
+        services: list[_ServiceInfo],
+        answer_set: _AnswerWithAdditionalsType,
+        known_answers: DNSRRSet,
+        type_: _int,
+    ) -> None:
+        """Answer A/AAAA/ANY question."""
+        for service in services:
+            answers: list[DNSAddress] = []
+            additionals: set[DNSRecord] = set()
+            type_seen = False
+            for dns_address in service._dns_addresses(None, _IPVersion_ALL):
+                if dns_address.type != type_:
+                    additionals.add(dns_address)
+                else:
+                    type_seen = True
+                    if not known_answers.suppresses(dns_address):
+                        answers.append(dns_address)
+            if answers:
+                nsec = service._dns_address_nsec(None)
+                if nsec is not None:
+                    additionals.add(nsec)
+                for answer in answers:
+                    answer_set[answer] = additionals
+            elif not type_seen and type_ in _ADDRESS_RECORD_TYPES:
+                nsec = service._dns_address_nsec(None)
+                if nsec is not None:
+                    answer_set[nsec] = set()
+
+    def _add_pointer_answers(
+        self,
+        services: list[_ServiceInfo],
+        answer_set: _AnswerWithAdditionalsType,
+        known_answers: DNSRRSet,
+    ) -> None:
+        """Answer PTR/ANY question."""
+        for service in services:
+            # Add recommended additional answers according to
+            # https://tools.ietf.org/html/rfc6763#section-12.1.
+            dns_pointer = service._dns_pointer(None)
+            if known_answers.suppresses(dns_pointer):
+                continue
+            answer_set[dns_pointer] = {
+                service._dns_service(None),
+                service._dns_text(None),
+                *service._get_address_and_nsec_records(None),
+            }
+
+    def _add_service_type_enumeration_query_answers(
+        self,
+        types: list[_str],
+        answer_set: _AnswerWithAdditionalsType,
+        known_answers: DNSRRSet,
+    ) -> None:
+        """Provide an answer to a service type enumeration query.
+
+        https://datatracker.ietf.org/doc/html/rfc6763#section-9
+        """
+        for stype in types:
+            dns_pointer = DNSPointer(
+                _SERVICE_TYPE_ENUMERATION_NAME,
+                _TYPE_PTR,
+                _CLASS_IN,
+                _DNS_OTHER_TTL,
+                stype,
+                0.0,
+            )
+            if not known_answers.suppresses(dns_pointer):
+                answer_set[dns_pointer] = set()
+
+    def _answer_question(
+        self,
+        question: DNSQuestion,
+        strategy_type: _int,
+        types: list[_str],
+        services: list[_ServiceInfo],
+        known_answers: DNSRRSet,
+    ) -> _AnswerWithAdditionalsType:
+        """Answer a question."""
+        answer_set: _AnswerWithAdditionalsType = {}
+
+        if strategy_type == _ANSWER_STRATEGY_SERVICE_TYPE_ENUMERATION:
+            self._add_service_type_enumeration_query_answers(types, answer_set, known_answers)
+        elif strategy_type == _ANSWER_STRATEGY_POINTER:
+            self._add_pointer_answers(services, answer_set, known_answers)
+        elif strategy_type == _ANSWER_STRATEGY_ADDRESS:
+            self._add_address_answers(services, answer_set, known_answers, question.type)
+        elif strategy_type == _ANSWER_STRATEGY_SERVICE:
+            # Add recommended additional answers according to
+            # https://tools.ietf.org/html/rfc6763#section-12.2.
+            service = services[0]
+            dns_service = service._dns_service(None)
+            if not known_answers.suppresses(dns_service):
+                answer_set[dns_service] = service._get_address_and_nsec_records(None)
+        elif strategy_type == _ANSWER_STRATEGY_TEXT:  # pragma: no branch
+            service = services[0]
+            dns_text = service._dns_text(None)
+            if not known_answers.suppresses(dns_text):
+                answer_set[dns_text] = set()
+
+        return answer_set
 
     def _get_answer_strategies(
         self,
@@ -416,42 +455,3 @@ class QueryHandler:
                     )
 
         return strategies
-
-    def handle_assembled_query(
-        self,
-        packets: list[_DNSIncoming],
-        addr: _str,
-        port: _int,
-        transport: _WrappedTransport,
-        v6_flow_scope: tuple[()] | tuple[int, int],
-    ) -> None:
-        """Respond to a (re)assembled query.
-
-        If the protocol received packets with the TC bit set, it will
-        wait a bit for the rest of the packets and only call
-        handle_assembled_query once it has a complete set of packets
-        or the timer expires. If the TC bit is not set, a single
-        packet will be in packets.
-        """
-        first_packet = packets[0]
-        ucast_source = port != _MDNS_PORT
-        question_answers = self.async_response(packets, ucast_source)
-        if question_answers is None:
-            return
-        if question_answers.ucast:
-            questions = first_packet._questions
-            id_ = first_packet.id
-            out = construct_outgoing_unicast_answers(question_answers.ucast, ucast_source, questions, id_)
-            # When sending unicast, only send back the reply
-            # via the same socket that it was received from
-            # as we know its reachable from that socket
-            self.zc.async_send(out, addr, port, v6_flow_scope, transport)
-        if question_answers.mcast_now:
-            self.zc.async_send(construct_outgoing_multicast_answers(question_answers.mcast_now))
-        if question_answers.mcast_aggregate:
-            self.out_queue.async_add(first_packet.now, question_answers.mcast_aggregate)
-        if question_answers.mcast_aggregate_last_second:
-            # https://datatracker.ietf.org/doc/html/rfc6762#section-14
-            # If we broadcast it in the last second, we have to delay
-            # at least a second before we send it again
-            self.out_delay_queue.async_add(first_packet.now, question_answers.mcast_aggregate_last_second)

--- a/src/zeroconf/_handlers/record_manager.py
+++ b/src/zeroconf/_handlers/record_manager.py
@@ -37,6 +37,36 @@ class RecordManager:
         self.cache = zeroconf.cache
         self.listeners: set[RecordUpdateListener] = set()
 
+    def async_add_listener(
+        self,
+        listener: RecordUpdateListener,
+        question: DNSQuestion | list[DNSQuestion] | None,
+    ) -> None:
+        """Subscribe a listener, optionally scoped to questions, and seed it
+        with matching cached records; event loop only.
+        """
+        if not isinstance(listener, RecordUpdateListener):
+            log.error(  # type: ignore[unreachable]
+                "listeners passed to async_add_listener must inherit from RecordUpdateListener;"
+                " In the future this will fail"
+            )
+
+        self.listeners.add(listener)
+
+        if question is None:
+            return
+
+        questions = [question] if isinstance(question, DNSQuestion) else question
+        self._async_update_matching_records(listener, questions)
+
+    def async_remove_listener(self, listener: RecordUpdateListener) -> None:
+        """Detach a record listener; event loop only, not threadsafe."""
+        try:
+            self.listeners.remove(listener)
+            self.zc.async_notify_all()
+        except ValueError as e:
+            log.exception("Failed to remove listener: %r", e)
+
     def async_updates(self, now: _float, records: list[_RecordUpdate]) -> None:
         """Notify listeners of updated records, before the cache commits them."""
         for listener in self.listeners.copy():
@@ -137,28 +167,6 @@ class RecordManager:
         if updates:
             self.async_updates_complete(new)
 
-    def async_add_listener(
-        self,
-        listener: RecordUpdateListener,
-        question: DNSQuestion | list[DNSQuestion] | None,
-    ) -> None:
-        """Subscribe a listener, optionally scoped to questions, and seed it
-        with matching cached records; event loop only.
-        """
-        if not isinstance(listener, RecordUpdateListener):
-            log.error(  # type: ignore[unreachable]
-                "listeners passed to async_add_listener must inherit from RecordUpdateListener;"
-                " In the future this will fail"
-            )
-
-        self.listeners.add(listener)
-
-        if question is None:
-            return
-
-        questions = [question] if isinstance(question, DNSQuestion) else question
-        self._async_update_matching_records(listener, questions)
-
     def _async_update_matching_records(
         self, listener: RecordUpdateListener, questions: list[_DNSQuestion]
     ) -> None:
@@ -178,11 +186,3 @@ class RecordManager:
         listener.async_update_records(self.zc, now, records)
         listener.async_update_records_complete()
         self.zc.async_notify_all()
-
-    def async_remove_listener(self, listener: RecordUpdateListener) -> None:
-        """Detach a record listener; event loop only, not threadsafe."""
-        try:
-            self.listeners.remove(listener)
-            self.zc.async_notify_all()
-        except ValueError as e:
-            log.exception("Failed to remove listener: %r", e)

--- a/src/zeroconf/_history.py
+++ b/src/zeroconf/_history.py
@@ -42,6 +42,20 @@ class QuestionHistory:
             self._evict_to_make_room(now)
         self._history[question] = (now, known_answers)
 
+    def async_expire(self, now: _float) -> None:
+        """Expire the history of old questions."""
+        removes: list[DNSQuestion] = []
+        for question, now_known_answers in self._history.items():
+            than, _ = now_known_answers
+            if now - than > _DUPLICATE_QUESTION_INTERVAL:
+                removes.append(question)
+        for question in removes:
+            del self._history[question]
+
+    def clear(self) -> None:
+        """Clear the history."""
+        self._history.clear()
+
     def suppresses(self, question: DNSQuestion, now: _float, known_answers: set[DNSRecord]) -> bool:
         """Check to see if a question should be suppressed.
 
@@ -61,20 +75,6 @@ class QuestionHistory:
         # The last question has more known answers than
         # we knew so we have to ask
         return not previous_known_answers - known_answers
-
-    def async_expire(self, now: _float) -> None:
-        """Expire the history of old questions."""
-        removes: list[DNSQuestion] = []
-        for question, now_known_answers in self._history.items():
-            than, _ = now_known_answers
-            if now - than > _DUPLICATE_QUESTION_INTERVAL:
-                removes.append(question)
-        for question in removes:
-            del self._history[question]
-
-    def clear(self) -> None:
-        """Clear the history."""
-        self._history.clear()
 
     def _evict_to_make_room(self, now: _float) -> None:
         """Drop expired or oldest entries when the history is at cap.

--- a/src/zeroconf/_listener.py
+++ b/src/zeroconf/_listener.py
@@ -80,6 +80,25 @@ class AsyncListener:
         self._recent_packets: dict[bytes, float] = {}
         super().__init__()
 
+    def cancel_pending_timers(self) -> None:
+        """Cancel all pending TC-reassembly timers and drop deferred state.
+
+        Called when this listener's transport is removed so a timer cannot
+        fire a response against an already-closed transport. Every timer's
+        addr also has a deferred entry, so dropping each deferred addr
+        cancels its timer too.
+        """
+        for addr in list(self._deferred):
+            self._drop_deferred(addr)
+
+    def connection_lost(self, exc: Exception | None) -> None:
+        """Handle connection lost."""
+
+    def connection_made(self, transport: asyncio.BaseTransport) -> None:
+        wrapped_transport = make_wrapped_transport(cast(asyncio.DatagramTransport, transport))
+        self.transport = wrapped_transport
+        self.sock_description = f"{wrapped_transport.fileno} ({wrapped_transport.sock_name})"
+
     def datagram_received(self, data: _bytes, addrs: tuple[str, int] | tuple[str, int, int, int]) -> None:
         data_len = len(data)
         debug = DEBUG_ENABLED()
@@ -97,6 +116,109 @@ class AsyncListener:
             return
         now = current_time_millis()
         self._process_datagram_at_time(debug, data_len, now, data, addrs)
+
+    def error_received(self, exc: Exception) -> None:
+        """Likely socket closed or IPv6."""
+        # We preformat the message string with the socket as we want
+        # log_exception_once to log a warning message once PER EACH
+        # different socket in case there are problems with multiple
+        # sockets
+        msg_str = f"Error with socket {self.sock_description}): %s"
+        QuietLogger.log_exception_once(exc, msg_str, exc)
+
+    def handle_query_or_defer(
+        self,
+        msg: DNSIncoming,
+        addr: _str,
+        port: _int,
+        transport: _WrappedTransport,
+        v6_flow_scope: tuple[()] | tuple[int, int],
+    ) -> None:
+        """Answer immediately, or hold a truncated query for reassembly."""
+        if not msg.truncated:
+            self._respond_query(msg, addr, port, transport, v6_flow_scope)
+            return
+
+        if addr not in self._deferred and len(self._deferred) >= _MAX_DEFERRED_ADDRS:
+            # Bound total deferred addrs so a spoofed-source flood
+            # cannot keep adding distinct entries; evict the oldest
+            # (insertion-order) entry and discard its in-flight queue.
+            self._evict_oldest_deferred()
+
+        deferred = self._deferred.setdefault(addr, [])
+        if len(deferred) >= _MAX_DEFERRED_PER_ADDR:
+            # Bound per-addr queue length; further fragments from the
+            # same source are dropped until the timer flushes.
+            return
+        # If we get the same packet we ignore it
+        for incoming in reversed(deferred):
+            if incoming.data == msg.data:
+                return
+        deferred.append(msg)
+        loop = self.zc.loop
+        assert loop is not None
+        now = loop.time()
+        delay = millis_to_seconds(random.randint(*_TC_DELAY_RANDOM_INTERVAL))  # noqa: S311
+        fire_at = self._compute_deferred_fire_at(addr, now, delay)
+        if fire_at < 0.0:
+            # Sentinel: a new reset would push the flush past the
+            # per-addr reassembly deadline, so leave the existing
+            # TimerHandle in place rather than re-arming it.
+            return
+        self._cancel_any_timers_for_addr(addr)
+        self._timers[addr] = loop.call_at(
+            fire_at,
+            self._respond_query,
+            None,
+            addr,
+            port,
+            transport,
+            v6_flow_scope,
+        )
+
+    def _cancel_any_timers_for_addr(self, addr: _str) -> None:
+        """Cancel any future truncated packet timers for the address."""
+        if addr in self._timers:
+            self._timers.pop(addr).cancel()
+
+    def _compute_deferred_fire_at(self, addr: _str, now: _float, delay: _float) -> _float:
+        """Return the bounded call_at time for a TC-deferred flush, or -1.0 to keep the existing timer."""
+        # RFC 6762 §18.5 frames the random delay as a fixed reassembly budget
+        # starting at first arrival, not a sliding heartbeat.
+        deadline = self._deferred_deadlines.get(addr)
+        if deadline is None:
+            deadline = now + millis_to_seconds(_TC_DELAY_RANDOM_INTERVAL[1])
+            self._deferred_deadlines[addr] = deadline
+        fire_at = now + delay
+        if fire_at >= deadline:
+            if addr in self._timers:
+                # Existing timer already fires at or before the deadline;
+                # signal the caller to leave it alone rather than reset it.
+                return -1.0
+            # First packet for this addr already proposes a fire-time at
+            # or past the deadline — clamp to the deadline so the flush
+            # still happens within the reassembly budget.
+            return deadline
+        # Within budget: schedule at the proposed fire-time.
+        return fire_at
+
+    def _drop_deferred(self, addr: _str) -> None:
+        """Cancel an address's timer and discard its reassembly state."""
+        self._cancel_any_timers_for_addr(addr)
+        self._deferred_deadlines.pop(addr, None)
+        self._deferred.pop(addr, None)
+
+    def _evict_oldest_deferred(self) -> None:
+        """Discard the oldest deferred addr's reassembly state.
+
+        Used when ``_MAX_DEFERRED_ADDRS`` would be exceeded; the
+        evicted addr's queue and timer are dropped without firing, so
+        the bound holds even when an attacker rotates source IPs.
+        Eviction is FIFO (oldest by first-seen, via dict insertion
+        order) rather than LRU so an active flooder cannot pin its
+        slots by re-sending into the same addr.
+        """
+        self._drop_deferred(next(iter(self._deferred)))
 
     def _process_datagram_at_time(
         self,
@@ -213,111 +335,6 @@ class AsyncListener:
             assert self.transport is not None
         self.handle_query_or_defer(msg, addr, port, self.transport, v6_flow_scope)
 
-    def handle_query_or_defer(
-        self,
-        msg: DNSIncoming,
-        addr: _str,
-        port: _int,
-        transport: _WrappedTransport,
-        v6_flow_scope: tuple[()] | tuple[int, int],
-    ) -> None:
-        """Answer immediately, or hold a truncated query for reassembly."""
-        if not msg.truncated:
-            self._respond_query(msg, addr, port, transport, v6_flow_scope)
-            return
-
-        if addr not in self._deferred and len(self._deferred) >= _MAX_DEFERRED_ADDRS:
-            # Bound total deferred addrs so a spoofed-source flood
-            # cannot keep adding distinct entries; evict the oldest
-            # (insertion-order) entry and discard its in-flight queue.
-            self._evict_oldest_deferred()
-
-        deferred = self._deferred.setdefault(addr, [])
-        if len(deferred) >= _MAX_DEFERRED_PER_ADDR:
-            # Bound per-addr queue length; further fragments from the
-            # same source are dropped until the timer flushes.
-            return
-        # If we get the same packet we ignore it
-        for incoming in reversed(deferred):
-            if incoming.data == msg.data:
-                return
-        deferred.append(msg)
-        loop = self.zc.loop
-        assert loop is not None
-        now = loop.time()
-        delay = millis_to_seconds(random.randint(*_TC_DELAY_RANDOM_INTERVAL))  # noqa: S311
-        fire_at = self._compute_deferred_fire_at(addr, now, delay)
-        if fire_at < 0.0:
-            # Sentinel: a new reset would push the flush past the
-            # per-addr reassembly deadline, so leave the existing
-            # TimerHandle in place rather than re-arming it.
-            return
-        self._cancel_any_timers_for_addr(addr)
-        self._timers[addr] = loop.call_at(
-            fire_at,
-            self._respond_query,
-            None,
-            addr,
-            port,
-            transport,
-            v6_flow_scope,
-        )
-
-    def _compute_deferred_fire_at(self, addr: _str, now: _float, delay: _float) -> _float:
-        """Return the bounded call_at time for a TC-deferred flush, or -1.0 to keep the existing timer."""
-        # RFC 6762 §18.5 frames the random delay as a fixed reassembly budget
-        # starting at first arrival, not a sliding heartbeat.
-        deadline = self._deferred_deadlines.get(addr)
-        if deadline is None:
-            deadline = now + millis_to_seconds(_TC_DELAY_RANDOM_INTERVAL[1])
-            self._deferred_deadlines[addr] = deadline
-        fire_at = now + delay
-        if fire_at >= deadline:
-            if addr in self._timers:
-                # Existing timer already fires at or before the deadline;
-                # signal the caller to leave it alone rather than reset it.
-                return -1.0
-            # First packet for this addr already proposes a fire-time at
-            # or past the deadline — clamp to the deadline so the flush
-            # still happens within the reassembly budget.
-            return deadline
-        # Within budget: schedule at the proposed fire-time.
-        return fire_at
-
-    def _cancel_any_timers_for_addr(self, addr: _str) -> None:
-        """Cancel any future truncated packet timers for the address."""
-        if addr in self._timers:
-            self._timers.pop(addr).cancel()
-
-    def _drop_deferred(self, addr: _str) -> None:
-        """Cancel an address's timer and discard its reassembly state."""
-        self._cancel_any_timers_for_addr(addr)
-        self._deferred_deadlines.pop(addr, None)
-        self._deferred.pop(addr, None)
-
-    def cancel_pending_timers(self) -> None:
-        """Cancel all pending TC-reassembly timers and drop deferred state.
-
-        Called when this listener's transport is removed so a timer cannot
-        fire a response against an already-closed transport. Every timer's
-        addr also has a deferred entry, so dropping each deferred addr
-        cancels its timer too.
-        """
-        for addr in list(self._deferred):
-            self._drop_deferred(addr)
-
-    def _evict_oldest_deferred(self) -> None:
-        """Discard the oldest deferred addr's reassembly state.
-
-        Used when ``_MAX_DEFERRED_ADDRS`` would be exceeded; the
-        evicted addr's queue and timer are dropped without firing, so
-        the bound holds even when an attacker rotates source IPs.
-        Eviction is FIFO (oldest by first-seen, via dict insertion
-        order) rather than LRU so an active flooder cannot pin its
-        slots by re-sending into the same addr.
-        """
-        self._drop_deferred(next(iter(self._deferred)))
-
     def _respond_query(
         self,
         msg: DNSIncoming | None,
@@ -334,20 +351,3 @@ class AsyncListener:
             packets.append(msg)
 
         self._query_handler.handle_assembled_query(packets, addr, port, transport, v6_flow_scope)
-
-    def error_received(self, exc: Exception) -> None:
-        """Likely socket closed or IPv6."""
-        # We preformat the message string with the socket as we want
-        # log_exception_once to log a warning message once PER EACH
-        # different socket in case there are problems with multiple
-        # sockets
-        msg_str = f"Error with socket {self.sock_description}): %s"
-        QuietLogger.log_exception_once(exc, msg_str, exc)
-
-    def connection_made(self, transport: asyncio.BaseTransport) -> None:
-        wrapped_transport = make_wrapped_transport(cast(asyncio.DatagramTransport, transport))
-        self.transport = wrapped_transport
-        self.sock_description = f"{wrapped_transport.fileno} ({wrapped_transport.sock_name})"
-
-    def connection_lost(self, exc: Exception | None) -> None:
-        """Handle connection lost."""

--- a/src/zeroconf/_logger.py
+++ b/src/zeroconf/_logger.py
@@ -74,22 +74,22 @@ def _mark_seen(seen: dict[str, None], key: str) -> bool:
 
 class QuietLogger:
     @classmethod
+    def log_exception_debug(cls, *logger_data: Any) -> None:
+        first_time = _mark_seen(_seen_logs, str(sys.exc_info()[1]))
+        log.debug(*(logger_data or ["Exception occurred"]), exc_info=first_time)
+
+    @classmethod
+    def log_exception_once(cls, exc: Exception, *args: Any) -> None:
+        logger = log.warning if _mark_seen(_seen_logs, args[0]) else log.debug
+        logger(*args, exc_info=exc)
+
+    @classmethod
     def log_exception_warning(cls, *logger_data: Any) -> None:
         first_time = _mark_seen(_seen_logs, str(sys.exc_info()[1]))
         logger = log.warning if first_time else log.debug
         logger(*(logger_data or ["Exception occurred"]), exc_info=True)
 
     @classmethod
-    def log_exception_debug(cls, *logger_data: Any) -> None:
-        first_time = _mark_seen(_seen_logs, str(sys.exc_info()[1]))
-        log.debug(*(logger_data or ["Exception occurred"]), exc_info=first_time)
-
-    @classmethod
     def log_warning_once(cls, *args: Any) -> None:
         logger = log.warning if _mark_seen(_seen_logs, args[0]) else log.debug
         logger(*args)
-
-    @classmethod
-    def log_exception_once(cls, exc: Exception, *args: Any) -> None:
-        logger = log.warning if _mark_seen(_seen_logs, args[0]) else log.debug
-        logger(*args, exc_info=exc)

--- a/src/zeroconf/_record_update.py
+++ b/src/zeroconf/_record_update.py
@@ -19,11 +19,6 @@ class RecordUpdate:
         """RecordUpdate represents a change in a DNS record."""
         self._fast_init(new, old)
 
-    def _fast_init(self, new: _DNSRecord, old: _DNSRecord | None) -> None:
-        """Fast init for RecordUpdate."""
-        self.new = new
-        self.old = old
-
     def __getitem__(self, index: int) -> DNSRecord | None:
         """Get the new or old record."""
         if index == 0:
@@ -31,3 +26,8 @@ class RecordUpdate:
         if index == 1:
             return self.old
         raise IndexError(index)
+
+    def _fast_init(self, new: _DNSRecord, old: _DNSRecord | None) -> None:
+        """Fast init for RecordUpdate."""
+        self.new = new
+        self.old = old

--- a/src/zeroconf/_services/browser.py
+++ b/src/zeroconf/_services/browser.py
@@ -126,31 +126,6 @@ class _ScheduledPTRQuery:  # noqa: PLW1641
         # we failed to rescue the record.
         self.when_millis = when_millis
 
-    def __repr__(self) -> str:
-        """Return a string representation of the scheduled query."""
-        return (
-            f"<{self.__class__.__name__} "
-            f"alias={self.alias} "
-            f"name={self.name} "
-            f"ttl={self.ttl} "
-            f"cancelled={self.cancelled} "
-            f"expire_time_millis={self.expire_time_millis} "
-            f"when_millis={self.when_millis}"
-            ">"
-        )
-
-    def __lt__(self, other: _ScheduledPTRQuery) -> bool:
-        """Compare two scheduled queries."""
-        if type(other) is _ScheduledPTRQuery:
-            return self.when_millis < other.when_millis
-        return NotImplemented
-
-    def __le__(self, other: _ScheduledPTRQuery) -> bool:
-        """Compare two scheduled queries."""
-        if type(other) is _ScheduledPTRQuery:
-            return self.when_millis < other.when_millis or self.__eq__(other)
-        return NotImplemented
-
     def __eq__(self, other: Any) -> bool:
         """Compare two scheduled queries."""
         if type(other) is _ScheduledPTRQuery:
@@ -168,6 +143,31 @@ class _ScheduledPTRQuery:  # noqa: PLW1641
         if type(other) is _ScheduledPTRQuery:
             return self.when_millis > other.when_millis
         return NotImplemented
+
+    def __le__(self, other: _ScheduledPTRQuery) -> bool:
+        """Compare two scheduled queries."""
+        if type(other) is _ScheduledPTRQuery:
+            return self.when_millis < other.when_millis or self.__eq__(other)
+        return NotImplemented
+
+    def __lt__(self, other: _ScheduledPTRQuery) -> bool:
+        """Compare two scheduled queries."""
+        if type(other) is _ScheduledPTRQuery:
+            return self.when_millis < other.when_millis
+        return NotImplemented
+
+    def __repr__(self) -> str:
+        """Return a string representation of the scheduled query."""
+        return (
+            f"<{self.__class__.__name__} "
+            f"alias={self.alias} "
+            f"name={self.name} "
+            f"ttl={self.ttl} "
+            f"cancelled={self.cancelled} "
+            f"expire_time_millis={self.expire_time_millis} "
+            f"when_millis={self.when_millis}"
+            ">"
+        )
 
 
 class _DNSPointerOutgoingBucket:
@@ -354,44 +354,19 @@ class QueryScheduler:
         self._clock_resolution_millis = time.get_clock_info("monotonic").resolution * 1000
         self._question_type = question_type
 
-    def start(self, loop: asyncio.AbstractEventLoop) -> None:
-        """Start the scheduler.
-
-        https://datatracker.ietf.org/doc/html/rfc6762#section-5.2
-        To avoid accidental synchronization when, for some reason, multiple
-        clients begin querying at exactly the same moment (e.g., because of
-        some common external trigger event), a Multicast DNS querier SHOULD
-        also delay the first query of the series by a randomly chosen amount
-        in the range 20-120 ms.
-        """
-        start_delay = millis_to_seconds(random.randint(*self._first_random_delay_interval))  # noqa: S311
-        self._loop = loop
-        self._next_run = loop.call_later(start_delay, self._process_startup_queries)
-
-    def stop(self) -> None:
-        """Stop the scheduler."""
-        if self._next_run is not None:
-            self._next_run.cancel()
-            self._next_run = None
-        self._next_scheduled_for_alias.clear()
-        self._query_heap.clear()
-
-    def _schedule_ptr_refresh(
-        self,
-        pointer: DNSPointer,
-        expire_time_millis: float_,
-        refresh_time_millis: float_,
+    def async_send_ready_queries(
+        self, first_request: bool, now_millis: float_, ready_types: set[str_]
     ) -> None:
-        """Schedule a query for a pointer."""
-        scheduled_ptr_query = _ScheduledPTRQuery(
-            pointer.alias, pointer.name, pointer.ttl, expire_time_millis, refresh_time_millis
-        )
-        self._schedule_ptr_query(scheduled_ptr_query)
-
-    def _schedule_ptr_query(self, scheduled_query: _ScheduledPTRQuery) -> None:
-        """Schedule a query for a pointer."""
-        self._next_scheduled_for_alias[scheduled_query.alias] = scheduled_query
-        heappush(self._query_heap, scheduled_query)
+        """Send any ready queries."""
+        # If they did not specify and this is the first request, ask QU questions
+        # https://datatracker.ietf.org/doc/html/rfc6762#section-5.4 since we are
+        # just starting up and we know our cache is likely empty. This ensures
+        # the next outgoing will be sent with the known answers list.
+        question_type = QU_QUESTION if self._question_type is None and first_request else self._question_type
+        outs = generate_service_query(self._zc, now_millis, ready_types, self._multicast, question_type)
+        if outs:
+            for out in outs:
+                self._zc.async_send(out, self._addr, self._port)
 
     def cancel_ptr_refresh(self, pointer: DNSPointer) -> None:
         """Cancel a query for a pointer."""
@@ -441,31 +416,27 @@ class QueryScheduler:
         )
         self._schedule_ptr_query(scheduled_ptr_query)
 
-    def _process_startup_queries(self) -> None:
-        if TYPE_CHECKING:
-            assert self._loop is not None
-        # This is a safety to ensure we stop sending queries if Zeroconf instance
-        # is stopped without the browser being cancelled
-        if self._zc.done:
-            return
+    def start(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Start the scheduler.
 
-        now_millis = current_time_millis()
+        https://datatracker.ietf.org/doc/html/rfc6762#section-5.2
+        To avoid accidental synchronization when, for some reason, multiple
+        clients begin querying at exactly the same moment (e.g., because of
+        some common external trigger event), a Multicast DNS querier SHOULD
+        also delay the first query of the series by a randomly chosen amount
+        in the range 20-120 ms.
+        """
+        start_delay = millis_to_seconds(random.randint(*self._first_random_delay_interval))  # noqa: S311
+        self._loop = loop
+        self._next_run = loop.call_later(start_delay, self._process_startup_queries)
 
-        # At first we will send STARTUP_QUERIES queries to get the cache populated
-        self.async_send_ready_queries(self._startup_queries_sent == 0, now_millis, self._types)
-        self._startup_queries_sent += 1
-
-        # Once we finish sending the initial queries we will
-        # switch to a strategy of sending queries only when we
-        # need to refresh records that are about to expire
-        if self._startup_queries_sent >= STARTUP_QUERIES:
-            self._next_run = self._loop.call_at(
-                millis_to_seconds(now_millis + self._min_time_between_queries_millis),
-                self._process_ready_types,
-            )
-            return
-
-        self._next_run = self._loop.call_later(self._startup_queries_sent**2, self._process_startup_queries)
+    def stop(self) -> None:
+        """Stop the scheduler."""
+        if self._next_run is not None:
+            self._next_run.cancel()
+            self._next_run = None
+        self._next_scheduled_for_alias.clear()
+        self._query_heap.clear()
 
     def _process_ready_types(self) -> None:
         """Generate a list of ready types that is due and schedule the next time."""
@@ -520,19 +491,48 @@ class QueryScheduler:
 
         self._next_run = self._loop.call_at(millis_to_seconds(next_when_millis), self._process_ready_types)
 
-    def async_send_ready_queries(
-        self, first_request: bool, now_millis: float_, ready_types: set[str_]
+    def _process_startup_queries(self) -> None:
+        if TYPE_CHECKING:
+            assert self._loop is not None
+        # This is a safety to ensure we stop sending queries if Zeroconf instance
+        # is stopped without the browser being cancelled
+        if self._zc.done:
+            return
+
+        now_millis = current_time_millis()
+
+        # At first we will send STARTUP_QUERIES queries to get the cache populated
+        self.async_send_ready_queries(self._startup_queries_sent == 0, now_millis, self._types)
+        self._startup_queries_sent += 1
+
+        # Once we finish sending the initial queries we will
+        # switch to a strategy of sending queries only when we
+        # need to refresh records that are about to expire
+        if self._startup_queries_sent >= STARTUP_QUERIES:
+            self._next_run = self._loop.call_at(
+                millis_to_seconds(now_millis + self._min_time_between_queries_millis),
+                self._process_ready_types,
+            )
+            return
+
+        self._next_run = self._loop.call_later(self._startup_queries_sent**2, self._process_startup_queries)
+
+    def _schedule_ptr_query(self, scheduled_query: _ScheduledPTRQuery) -> None:
+        """Schedule a query for a pointer."""
+        self._next_scheduled_for_alias[scheduled_query.alias] = scheduled_query
+        heappush(self._query_heap, scheduled_query)
+
+    def _schedule_ptr_refresh(
+        self,
+        pointer: DNSPointer,
+        expire_time_millis: float_,
+        refresh_time_millis: float_,
     ) -> None:
-        """Send any ready queries."""
-        # If they did not specify and this is the first request, ask QU questions
-        # https://datatracker.ietf.org/doc/html/rfc6762#section-5.4 since we are
-        # just starting up and we know our cache is likely empty. This ensures
-        # the next outgoing will be sent with the known answers list.
-        question_type = QU_QUESTION if self._question_type is None and first_request else self._question_type
-        outs = generate_service_query(self._zc, now_millis, ready_types, self._multicast, question_type)
-        if outs:
-            for out in outs:
-                self._zc.async_send(out, self._addr, self._port)
+        """Schedule a query for a pointer."""
+        scheduled_ptr_query = _ScheduledPTRQuery(
+            pointer.alias, pointer.name, pointer.ttl, expire_time_millis, refresh_time_millis
+        )
+        self._schedule_ptr_query(scheduled_ptr_query)
 
 
 class _ServiceBrowserBase(RecordUpdateListener):

--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -1090,10 +1090,6 @@ class ServiceInfo(RecordUpdateListener):
         return False
 
 
-class AsyncServiceInfo(ServiceInfo):
-    """An async version of ServiceInfo."""
-
-
 class AddressResolver(ServiceInfo):
     """Resolve a host name to an IP address."""
 
@@ -1106,6 +1102,20 @@ class AddressResolver(ServiceInfo):
     def _is_complete(self) -> bool:
         """The ServiceInfo has all expected properties."""
         return bool(self._ipv4_addresses) or bool(self._ipv6_addresses)
+
+
+class AddressResolverIPv4(ServiceInfo):
+    """Resolve a host name to an IPv4 address."""
+
+    def __init__(self, server: str) -> None:
+        """Initialize the AddressResolver."""
+        super().__init__(server, server, server=server)
+        self._query_record_types = _TYPE_A_RECORDS
+
+    @property
+    def _is_complete(self) -> bool:
+        """The ServiceInfo has all expected properties."""
+        return bool(self._ipv4_addresses)
 
 
 class AddressResolverIPv6(ServiceInfo):
@@ -1122,15 +1132,5 @@ class AddressResolverIPv6(ServiceInfo):
         return bool(self._ipv6_addresses)
 
 
-class AddressResolverIPv4(ServiceInfo):
-    """Resolve a host name to an IPv4 address."""
-
-    def __init__(self, server: str) -> None:
-        """Initialize the AddressResolver."""
-        super().__init__(server, server, server=server)
-        self._query_record_types = _TYPE_A_RECORDS
-
-    @property
-    def _is_complete(self) -> bool:
-        """The ServiceInfo has all expected properties."""
-        return bool(self._ipv4_addresses)
+class AsyncServiceInfo(ServiceInfo):
+    """An async version of ServiceInfo."""

--- a/src/zeroconf/_services/registry.py
+++ b/src/zeroconf/_services/registry.py
@@ -37,6 +37,26 @@ class ServiceRegistry:
         """Add a new service to the registry."""
         self._add(info)
 
+    def async_get_info_name(self, name: str) -> ServiceInfo | None:
+        """Return all ServiceInfo for the name."""
+        return self._services.get(name)
+
+    def async_get_infos_server(self, server: str) -> list[ServiceInfo]:
+        """Return all ServiceInfo matching server."""
+        return self._async_get_by_index(self.servers, server)
+
+    def async_get_infos_type(self, type_: str) -> list[ServiceInfo]:
+        """Return all ServiceInfo matching type."""
+        return self._async_get_by_index(self.types, type_)
+
+    def async_get_service_infos(self) -> list[ServiceInfo]:
+        """Return all ServiceInfo."""
+        return list(self._services.values())
+
+    def async_get_types(self) -> list[str]:
+        """Return all types."""
+        return list(self.types)
+
     def async_remove(self, info: list[ServiceInfo] | ServiceInfo) -> None:
         """Remove a new service from the registry."""
         self._remove(info if isinstance(info, list) else [info])
@@ -45,33 +65,6 @@ class ServiceRegistry:
         """Update new service in the registry."""
         self._remove([info])
         self._add(info)
-
-    def async_get_service_infos(self) -> list[ServiceInfo]:
-        """Return all ServiceInfo."""
-        return list(self._services.values())
-
-    def async_get_info_name(self, name: str) -> ServiceInfo | None:
-        """Return all ServiceInfo for the name."""
-        return self._services.get(name)
-
-    def async_get_types(self) -> list[str]:
-        """Return all types."""
-        return list(self.types)
-
-    def async_get_infos_type(self, type_: str) -> list[ServiceInfo]:
-        """Return all ServiceInfo matching type."""
-        return self._async_get_by_index(self.types, type_)
-
-    def async_get_infos_server(self, server: str) -> list[ServiceInfo]:
-        """Return all ServiceInfo matching server."""
-        return self._async_get_by_index(self.servers, server)
-
-    def _async_get_by_index(self, records: _ServiceIndex, key: _str) -> list[_ServiceInfo]:
-        """Return all ServiceInfo matching the index."""
-        record_infos = records.get(key)
-        if record_infos is None:
-            return []
-        return list(record_infos.values())
 
     def _add(self, info: ServiceInfo) -> None:
         """Add a new service under the lock."""
@@ -85,6 +78,13 @@ class ServiceRegistry:
         self.types.setdefault(info.type.lower(), {})[info.key] = info
         self.servers.setdefault(info.server_key, {})[info.key] = info
         self.has_entries = True
+
+    def _async_get_by_index(self, records: _ServiceIndex, key: _str) -> list[_ServiceInfo]:
+        """Return all ServiceInfo matching the index."""
+        record_infos = records.get(key)
+        if record_infos is None:
+            return []
+        return list(record_infos.values())
 
     def _remove(self, infos: list[_ServiceInfo]) -> None:
         """Remove a services under the lock."""

--- a/src/zeroconf/_services/types.py
+++ b/src/zeroconf/_services/types.py
@@ -29,12 +29,6 @@ class ZeroconfServiceTypes(ServiceListener):
         """Service added."""
         self.found_services.add(name)
 
-    def update_service(self, zc: Zeroconf, type_: str, name: str) -> None:
-        """Service updated."""
-
-    def remove_service(self, zc: Zeroconf, type_: str, name: str) -> None:
-        """Service removed."""
-
     @classmethod
     def find(
         cls,
@@ -67,3 +61,9 @@ class ZeroconfServiceTypes(ServiceListener):
             local_zc.close()
 
         return tuple(sorted(listener.found_services))
+
+    def remove_service(self, zc: Zeroconf, type_: str, name: str) -> None:
+        """Service removed."""
+
+    def update_service(self, zc: Zeroconf, type_: str, name: str) -> None:
+        """Service updated."""

--- a/src/zeroconf/_updates.py
+++ b/src/zeroconf/_updates.py
@@ -26,16 +26,6 @@ class RecordUpdateListener:
     as a base class. In the future it will be required.
     """
 
-    def update_record(  # pylint: disable=no-self-use
-        self, zc: Zeroconf, now: float, record: DNSRecord
-    ) -> None:
-        """Update a single record.
-
-        This method is deprecated and will be removed in a future version.
-        update_records should be implemented instead.
-        """
-        raise RuntimeError("update_record is deprecated and will be removed in a future version.")
-
     def async_update_records(self, zc: Zeroconf, now: float_, records: list[RecordUpdate]) -> None:
         """Update multiple records in one shot.
 
@@ -64,3 +54,13 @@ class RecordUpdateListener:
 
         This method will be run in the event loop.
         """
+
+    def update_record(  # pylint: disable=no-self-use
+        self, zc: Zeroconf, now: float, record: DNSRecord
+    ) -> None:
+        """Update a single record.
+
+        This method is deprecated and will be removed in a future version.
+        update_records should be implemented instead.
+        """
+        raise RuntimeError("update_record is deprecated and will be removed in a future version.")

--- a/src/zeroconf/_utils/ipaddress.py
+++ b/src/zeroconf/_utils/ipaddress.py
@@ -31,13 +31,13 @@ class ZeroconfIPv4Address(IPv4Address):
         self._hash = IPv4Address.__hash__(self)
         self.zc_integer = int(self)
 
-    def __str__(self) -> str:
-        """Return the string representation of the IPv4 address."""
-        return self._str
-
     def __hash__(self) -> int:
         """Return the precomputed hash of the IPv4 address."""
         return self._hash
+
+    def __str__(self) -> str:
+        """Return the string representation of the IPv4 address."""
+        return self._str
 
     @property
     def is_link_local(self) -> bool:
@@ -45,14 +45,14 @@ class ZeroconfIPv4Address(IPv4Address):
         return self._is_link_local
 
     @property
-    def is_unspecified(self) -> bool:
-        """True for an unspecified address."""
-        return self._is_unspecified
-
-    @property
     def is_loopback(self) -> bool:
         """True for a loopback address."""
         return self._is_loopback
+
+    @property
+    def is_unspecified(self) -> bool:
+        """True for an unspecified address."""
+        return self._is_unspecified
 
 
 class ZeroconfIPv6Address(IPv6Address):
@@ -68,13 +68,13 @@ class ZeroconfIPv6Address(IPv6Address):
         self._hash = IPv6Address.__hash__(self)
         self.zc_integer = int(self)
 
-    def __str__(self) -> str:
-        """Return the string representation of the IPv6 address."""
-        return self._str
-
     def __hash__(self) -> int:
         """Return the precomputed hash of the IPv6 address."""
         return self._hash
+
+    def __str__(self) -> str:
+        """Return the string representation of the IPv6 address."""
+        return self._str
 
     @property
     def is_link_local(self) -> bool:
@@ -82,14 +82,14 @@ class ZeroconfIPv6Address(IPv6Address):
         return self._is_link_local
 
     @property
-    def is_unspecified(self) -> bool:
-        """True for an unspecified address."""
-        return self._is_unspecified
-
-    @property
     def is_loopback(self) -> bool:
         """True for a loopback address."""
         return self._is_loopback
+
+    @property
+    def is_unspecified(self) -> bool:
+        """True for an unspecified address."""
+        return self._is_unspecified
 
 
 @lru_cache(maxsize=512)

--- a/src/zeroconf/asyncio.py
+++ b/src/zeroconf/asyncio.py
@@ -48,10 +48,6 @@ class AsyncServiceBrowser(_ServiceBrowserBase):
         super().__init__(zeroconf, type_, handlers, listener, addr, port, delay, question_type)
         self._async_start()
 
-    async def async_cancel(self) -> None:
-        """Cancel the browser."""
-        self._async_cancel()
-
     async def __aenter__(self) -> AsyncServiceBrowser:
         return self
 
@@ -63,6 +59,10 @@ class AsyncServiceBrowser(_ServiceBrowserBase):
     ) -> bool | None:
         await self.async_cancel()
         return None
+
+    async def async_cancel(self) -> None:
+        """Cancel the browser."""
+        self._async_cancel()
 
 
 class AsyncZeroconfServiceTypes(ZeroconfServiceTypes):
@@ -138,57 +138,25 @@ class AsyncZeroconf:
         )
         self.async_browsers: dict[ServiceListener, AsyncServiceBrowser] = {}
 
-    async def async_register_service(
+    async def __aenter__(self) -> AsyncZeroconf:
+        return self
+
+    async def __aexit__(
         self,
-        info: ServiceInfo,
-        ttl: int | None = None,
-        allow_name_change: bool = False,
-        cooperating_responders: bool = False,
-        strict: bool = True,
-    ) -> Awaitable:
-        """Announce a service on the network.
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> bool | None:
+        await self.async_close()
+        return None
 
-        Returns an awaitable that completes once the announcements have
-        been sent.
+    async def async_add_service_listener(self, type_: str, listener: ServiceListener) -> None:
+        """Browse a service type, delivering events to the listener.
+
+        Replaces any browser previously registered for the same listener.
         """
-        return await self.zeroconf.async_register_service(
-            info, ttl, allow_name_change, cooperating_responders, strict
-        )
-
-    async def async_unregister_all_services(self) -> None:
-        """Send goodbye packets for every registered service and drop them all.
-
-        Runs only at shutdown, so unlike the single service calls it
-        returns nothing to await separately.
-        """
-        await self.zeroconf.async_unregister_all_services()
-
-    async def async_unregister_service(self, info: ServiceInfo) -> Awaitable:
-        """Withdraw a service, returning an awaitable that completes once the goodbyes are sent."""
-        return await self.zeroconf.async_unregister_service(info)
-
-    async def async_update_service(self, info: ServiceInfo) -> Awaitable:
-        """Publish updated records for an already registered service.
-
-        Returns an awaitable that completes once the rebroadcasts finish.
-        """
-        return await self.zeroconf.async_update_service(info)
-
-    async def async_update_interfaces(
-        self,
-        interfaces: InterfacesType | None = None,
-        ip_version: IPVersion | None = None,
-        apple_p2p: bool | None = None,
-    ) -> None:
-        """Rescan network interfaces and reconcile the sockets in use.
-
-        Adds sockets for interfaces that appeared, drops sockets for
-        interfaces that disappeared, and re-announces existing
-        registrations on the resulting senders. ``interfaces``,
-        ``ip_version`` and ``apple_p2p`` each default to the construction-time
-        value. Raises RuntimeError if apple_p2p is set on a non-Apple platform.
-        """
-        await self.zeroconf.async_update_interfaces(interfaces, ip_version, apple_p2p)
+        await self.async_remove_service_listener(listener)
+        self.async_browsers[listener] = AsyncServiceBrowser(self.zeroconf, type_, listener)
 
     async def async_close(self) -> None:
         """Unregister everything and shut the wrapped Zeroconf down."""
@@ -215,19 +183,22 @@ class AsyncZeroconf:
         """
         return await self.zeroconf.async_get_service_info(type_, name, timeout, question_type)
 
-    async def async_add_service_listener(self, type_: str, listener: ServiceListener) -> None:
-        """Browse a service type, delivering events to the listener.
+    async def async_register_service(
+        self,
+        info: ServiceInfo,
+        ttl: int | None = None,
+        allow_name_change: bool = False,
+        cooperating_responders: bool = False,
+        strict: bool = True,
+    ) -> Awaitable:
+        """Announce a service on the network.
 
-        Replaces any browser previously registered for the same listener.
+        Returns an awaitable that completes once the announcements have
+        been sent.
         """
-        await self.async_remove_service_listener(listener)
-        self.async_browsers[listener] = AsyncServiceBrowser(self.zeroconf, type_, listener)
-
-    async def async_remove_service_listener(self, listener: ServiceListener) -> None:
-        """Stop and drop the browser registered for the listener, if any."""
-        if listener in self.async_browsers:
-            await self.async_browsers[listener].async_cancel()
-            del self.async_browsers[listener]
+        return await self.zeroconf.async_register_service(
+            info, ttl, allow_name_change, cooperating_responders, strict
+        )
 
     async def async_remove_all_service_listeners(self) -> None:
         """Stop and drop every browser started through add_service_listener."""
@@ -235,14 +206,43 @@ class AsyncZeroconf:
             *(self.async_remove_service_listener(listener) for listener in list(self.async_browsers))
         )
 
-    async def __aenter__(self) -> AsyncZeroconf:
-        return self
+    async def async_remove_service_listener(self, listener: ServiceListener) -> None:
+        """Stop and drop the browser registered for the listener, if any."""
+        if listener in self.async_browsers:
+            await self.async_browsers[listener].async_cancel()
+            del self.async_browsers[listener]
 
-    async def __aexit__(
+    async def async_unregister_all_services(self) -> None:
+        """Send goodbye packets for every registered service and drop them all.
+
+        Runs only at shutdown, so unlike the single service calls it
+        returns nothing to await separately.
+        """
+        await self.zeroconf.async_unregister_all_services()
+
+    async def async_unregister_service(self, info: ServiceInfo) -> Awaitable:
+        """Withdraw a service, returning an awaitable that completes once the goodbyes are sent."""
+        return await self.zeroconf.async_unregister_service(info)
+
+    async def async_update_interfaces(
         self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
-    ) -> bool | None:
-        await self.async_close()
-        return None
+        interfaces: InterfacesType | None = None,
+        ip_version: IPVersion | None = None,
+        apple_p2p: bool | None = None,
+    ) -> None:
+        """Rescan network interfaces and reconcile the sockets in use.
+
+        Adds sockets for interfaces that appeared, drops sockets for
+        interfaces that disappeared, and re-announces existing
+        registrations on the resulting senders. ``interfaces``,
+        ``ip_version`` and ``apple_p2p`` each default to the construction-time
+        value. Raises RuntimeError if apple_p2p is set on a non-Apple platform.
+        """
+        await self.zeroconf.async_update_interfaces(interfaces, ip_version, apple_p2p)
+
+    async def async_update_service(self, info: ServiceInfo) -> Awaitable:
+        """Publish updated records for an already registered service.
+
+        Returns an awaitable that completes once the rebroadcasts finish.
+        """
+        return await self.zeroconf.async_update_service(info)


### PR DESCRIPTION
## Summary
Follow up to #1886. The fifth audit showed the ordering convention can regress silently (#1880 broke it in three classes), so it is now enforced and fully documented:

- scripts/check_declaration_order.py verifies method order in every class (dunders with __init__ first, then public, then private, each alphabetical) and sibling class order (locally defined bases first, subclasses sharing the same local bases alphabetical), printing the full expected sequence on failure
- runs as a pre-commit hook receiving the changed files from pre-commit (full tree scan when run standalone), triggering on the script's own changes too, via python3
- CLAUDE.md now documents the full convention it enforces, including that the arrangement is deliberately rule generated
- enforcement required conforming the eighteen classes earlier rounds never touched plus the info.py resolver siblings; a review confirmed the reorder is invisible to the compiled Cython layout since the untouched pxd files own the struct and vtable order and matching is by name

## Test plan
- [x] checker green tree wide, fails correctly on perturbation, argv mode verified
- [x] full suite passes against a REQUIRE_CYTHON rebuild; CodSpeed is the authoritative perf confirmation