### PR TITLE
chore: drop the equality docstring family and reword the cache lookup docstring

### DIFF
--- a/src/zeroconf/_cache.py
+++ b/src/zeroconf/_cache.py
@@ -198,7 +198,7 @@ class DNSCache:
         return None
 
     def get_all_by_details(self, name: str, type_: _int, class_: _int) -> list[DNSRecord]:
-        """Gets all matching entries by details."""
+        """Return every cached record carrying this name, type and class."""
         key = name.lower()
         records = self.cache.get(key)
         if records is None:

--- a/src/zeroconf/_dns.py
+++ b/src/zeroconf/_dns.py
@@ -76,7 +76,6 @@ class DNSEntry:  # noqa: PLW1641
         self._fast_init_entry(name, type_, class_)
 
     def __eq__(self, other: Any) -> bool:
-        """Equal when key, type and class match."""
         return isinstance(other, DNSEntry) and self._dns_entry_matches(other)
 
     @property
@@ -133,7 +132,6 @@ class DNSQuestion(DNSEntry):
         self._fast_init(name, type_, class_)
 
     def __eq__(self, other: Any) -> bool:
-        """Equal when the entry fields match a question."""
         return isinstance(other, DNSQuestion) and self._dns_entry_matches(other)
 
     def __hash__(self) -> int:
@@ -271,7 +269,6 @@ class DNSAddress(DNSRecord):
         self._fast_init(name, type_, class_, ttl, address, scope_id, created or current_time_millis())
 
     def __eq__(self, other: Any) -> bool:
-        """Equal when address and the entry fields match."""
         return isinstance(other, DNSAddress) and self._eq(other)
 
     def __hash__(self) -> int:
@@ -333,7 +330,6 @@ class DNSHinfo(DNSRecord):
         self._fast_init(name, type_, class_, ttl, cpu, os, created or current_time_millis())
 
     def __eq__(self, other: Any) -> bool:
-        """Equal when cpu, os and the entry fields match."""
         return isinstance(other, DNSHinfo) and self._eq(other)
 
     def __hash__(self) -> int:
@@ -378,7 +374,6 @@ class DNSNsec(DNSRecord):
         self._fast_init(name, type_, class_, ttl, next_name, rdtypes, created or current_time_millis())
 
     def __eq__(self, other: Any) -> bool:
-        """Equal when next_name, rdtypes and the entry fields match."""
         return isinstance(other, DNSNsec) and self._eq(other)
 
     def __hash__(self) -> int:
@@ -448,7 +443,6 @@ class DNSPointer(DNSRecord):
         self._fast_init(name, type_, class_, ttl, alias, created or current_time_millis())
 
     def __eq__(self, other: Any) -> bool:
-        """Equal when alias and the entry fields match."""
         return isinstance(other, DNSPointer) and self._eq(other)
 
     def __hash__(self) -> int:
@@ -505,7 +499,6 @@ class DNSService(DNSRecord):
         )
 
     def __eq__(self, other: Any) -> bool:
-        """Equal when priority, weight, port, server and the entry fields match."""
         return isinstance(other, DNSService) and self._eq(other)
 
     def __hash__(self) -> int:
@@ -568,7 +561,6 @@ class DNSText(DNSRecord):
         self._fast_init(name, type_, class_, ttl, text, created or current_time_millis())
 
     def __eq__(self, other: Any) -> bool:
-        """Equal when text and the entry fields match."""
         return isinstance(other, DNSText) and self._eq(other)
 
     def __hash__(self) -> int:


### PR DESCRIPTION
## Summary

Follow-up to the ninth independent audit of the #1835 removal claims: it caught one undisclosed 2009 echo (`DNSCache.get_all_by_details`'s docstring, 0.77 against the 2009 "Gets an entry by details.") and confirmed the equality docstrings still measure 0.60 to 0.69 against 2009 text despite an earlier claim they were reworded.

## Details

- The `get_all_by_details` docstring was written in 2021 as a variant of the 2009 line; it now describes the lookup in fresh words.
- The eight `"""Equal when ... match."""` docstrings in `_dns.py` are deleted rather than reworded: an `__eq__` docstring that names the compared fields restates the method body, the repo convention prefers no docstring in that case, and deletion removes the measured similarity for the whole family at once.

## Test plan

- [x] full compiled test suite after `REQUIRE_CYTHON=1` rebuild: 518 passed
- [x] pre-commit clean
