### PR TITLE
refactor: compute service info request pacing from fresh clock reads

### DIFF
--- a/src/zeroconf/_services/info.py
+++ b/src/zeroconf/_services/info.py
@@ -349,36 +349,38 @@ class ServiceInfo(RecordUpdateListener):
 
         first_request = True
         delay = self._get_initial_delay()
-        next_ = now
-        last = now + timeout
+        deadline = now + timeout
+        send_at = now
         try:
             zc.async_add_listener(self, None)
             while not self._is_complete:
-                if last <= now or self._is_denied:
-                    return False
-                if next_ <= now:
-                    this_question_type = question_type or (QU_QUESTION if first_request else QM_QUESTION)
-                    out = self._generate_request_query(zc, now, this_question_type)
-                    first_request = False
-                    if out.questions:
-                        # All questions may have been suppressed
-                        # by the question history, so nothing to send,
-                        # but keep waiting for answers in case another
-                        # client on the network is asking the same
-                        # question or they have not arrived yet.
-                        zc.async_send(out, addr, port)
-                    next_ = now + delay
-                    next_ += self._get_random_delay()
-                    if this_question_type is QM_QUESTION and delay < _DUPLICATE_QUESTION_INTERVAL:
-                        # If we just asked a QM question, we need to
-                        # wait at least the duplicate question interval
-                        # before asking another QM question otherwise
-                        # its likely to be suppressed by the question
-                        # history of the remote responder.
-                        delay = _DUPLICATE_QUESTION_INTERVAL
-
-                await self.async_wait(min(next_, last) - now, zc.loop)
                 now = current_time_millis()
+                if self._is_denied or deadline <= now:
+                    return False
+
+                remaining = min(send_at, deadline) - now
+                if remaining > 0:
+                    await self.async_wait(remaining, zc.loop)
+                    continue
+
+                question_kind = question_type or (QU_QUESTION if first_request else QM_QUESTION)
+                out = self._generate_request_query(zc, now, question_kind)
+                first_request = False
+                if out.questions:
+                    # All questions may have been suppressed
+                    # by the question history, so nothing to send,
+                    # but keep waiting for answers in case another
+                    # client on the network is asking the same
+                    # question or they have not arrived yet.
+                    zc.async_send(out, addr, port)
+                send_at = now + delay + self._get_random_delay()
+                if question_kind is QM_QUESTION and delay < _DUPLICATE_QUESTION_INTERVAL:
+                    # If we just asked a QM question, we need to
+                    # wait at least the duplicate question interval
+                    # before asking another QM question otherwise
+                    # its likely to be suppressed by the question
+                    # history of the remote responder.
+                    delay = _DUPLICATE_QUESTION_INTERVAL
         finally:
             zc.async_remove_listener(self)
 


### PR DESCRIPTION
## Summary

Restructures the `ServiceInfo.async_request` polling loop the same way #1888 restructured the registration probe loop: wait-first `if`/`continue` shape, a fresh clock read at the top of each cycle, and deadline arithmetic in place of the carried `now`/`next_`/`last` trio. This is the last structural item from the tenth audit's inventory (#1835).

## Details

- Behavior preserved: fail at the deadline or on denial; the first query goes out immediately (QU unless a question type is passed, later queries QM); each send schedules the next at delay plus random jitter; the QM duplicate question escalation stands; every wake from a record update re-checks completeness; the listener is always removed.
- Wait durations are computed from the current clock rather than a value cached before the previous send, so queries land on schedule instead of accumulating per-cycle lag.
- The loop now reads the same way as `async_check_service` without being coupled to it. A shared pacing primitive was considered and rejected: the two loops differ in termination (probe count vs deadline/completion), cadence (fixed schedule vs adaptive jitter) and wake condition (engine notify vs the info's own futures), so extraction would be a callback-shaped abstraction bigger than the three lines it saves, with bound-method indirection in a Cythonized module.
- Perf: one extra `current_time_millis()` call per query sent, in a loop whose iterations are separated by 25 to 1000 ms waits; no per-packet or per-record path changed and nothing in `info.pxd` is touched.

## Test plan

- [x] full compiled test suite after `REQUIRE_CYTHON=1` rebuild: 518 passed
- [x] pre-commit clean
- [x] four-agent simplify review: reuse, efficiency and altitude clean; the flatter loop shape it proposed was declined since it is the 2009 statement sequence this change retires
