### PR TITLE
chore: reword the remaining by-details docstring flagged by the eleventh audit

### DIFF
--- a/src/zeroconf/_cache.py
+++ b/src/zeroconf/_cache.py
@@ -206,7 +206,7 @@ class DNSCache:
         return [entry for entry in list(records.values()) if type_ == entry.type and class_ == entry.class_]
 
     def get_by_details(self, name: str, type_: _int, class_: _int) -> DNSRecord | None:
-        """Gets the first matching entry by details. Returns None if no entries match.
+        """Return the first cached record carrying this name, type and class, or None.
 
         Calling this function is not recommended as it will only
         return one record even if there are multiple entries.


### PR DESCRIPTION
## Summary

The eleventh independent audit of the #1835 removal claims found one docstring #1892 missed: `get_by_details` still opened with the 2009 "Gets ... by details. Returns None ..." template (0.68 against the 2009 line). Reworded in fresh words; the caller-facing caveat sentences are untouched.

## Test plan

- [x] full compiled test suite after `REQUIRE_CYTHON=1` rebuild: 518 passed
- [x] pre-commit clean