### PR TITLE
chore: ignore compiled extensions and cython annotate output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ docs/_build/
 /zeroconf.egg-info/
 /src/**/*.c
 .hypothesis/
+/src/**/*.so
+/src/**/*.html


### PR DESCRIPTION
## Summary

The fourteenth independent audit of the #1835 removal claims noted that the in-place compiled `.so` files under `src/zeroconf/` were untracked but not ignored, so a stray `git add -A` could commit binaries (which embed docstrings from whatever source they were built against). The generated `.c` files were already ignored; this adds the `.so` and `cython -a` annotate `.html` outputs beside them.

## Test plan

- [x] `git status` no longer lists the 18 compiled extensions