### PR TITLE
chore: add the relicensing consent ledger

### DIFF
--- a/RELICENSING.md
+++ b/RELICENSING.md
@@ -1,0 +1,28 @@
+# Relicensing consent ledger
+
+python-zeroconf is gathering contributor consent to relicense from
+LGPL-2.1-or-later to Apache-2.0. The process, its removal history and its
+audit record live in
+[issue #1835](https://github.com/python-zeroconf/python-zeroconf/issues/1835).
+
+This file is the ledger of verified consents. Each row was checked against
+the exact consent sentence and links the comment containing it. A consent
+covers the contributor's commits authored on or before its date; later
+contributions are covered by the license notice posted on every pull
+request, and blame will be re-verified against consent dates before any
+switch. Nothing already released changes license.
+
+| GitHub login  | Git author identities in this repository                                         | Consent                                                                                           | Date (UTC) |
+| ------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | ---------- |
+| @bdraco       | J. Nick Koston — nick@home-assistant.io, nick@koston.org, nick+github@koston.org | maintainer, relicense initiator                                                                   | 2026-08-28 |
+| @stevencrader | Steven Crader — stevencrader@gmail.com                                           | [comment](https://github.com/python-zeroconf/python-zeroconf/issues/1835#issuecomment-5458645316) | 2026-08-28 |
+| @bboe         | Bryce Boe — bbzbryce@gmail.com                                                   | [comment](https://github.com/python-zeroconf/python-zeroconf/issues/1835#issuecomment-5458732025) | 2026-08-28 |
+| @rima1881     | Amir — amd.gharibipour@outlook.com                                               | [comment](https://github.com/python-zeroconf/python-zeroconf/issues/1835#issuecomment-5458753986) | 2026-08-28 |
+| @jpbede       | Jan-Philipp Benecke — github@bnck.me, jan-philipp@bnck.me                        | [comment](https://github.com/python-zeroconf/python-zeroconf/issues/1835#issuecomment-5460526155) | 2026-08-29 |
+| @jstasiak     | Jakub Stasiak — jakub@stasiak.at                                                 | [comment](https://github.com/python-zeroconf/python-zeroconf/issues/1835#issuecomment-5462270134) | 2026-08-29 |
+| @Rotzbua      | Rotzbua — Rotzbua@users.noreply.github.com                                       | [comment](https://github.com/python-zeroconf/python-zeroconf/issues/1835#issuecomment-5462300621) | 2026-08-29 |
+| @ibygrave     | ibygrave — ian+github@bygrave.me.uk                                              | [comment](https://github.com/python-zeroconf/python-zeroconf/issues/1835#issuecomment-5463209000) | 2026-08-29 |
+| @bachp        | Pascal Bach — pasci.bach@gmail.com                                               | [comment](https://github.com/python-zeroconf/python-zeroconf/issues/1835#issuecomment-5464361992) | 2026-08-29 |
+| @cdce8p       | Marc Mueller — 30130371+cdce8p@users.noreply.github.com                          | [comment](https://github.com/python-zeroconf/python-zeroconf/issues/1835#issuecomment-5464917296) | 2026-08-29 |
+| @agners       | Stefan Agner — stefan@agner.ch                                                   | [comment](https://github.com/python-zeroconf/python-zeroconf/issues/1835#issuecomment-5465371892) | 2026-08-29 |
+| @devbanu      | Alexandru Ciobanu — 93059748+devbanu@users.noreply.github.com                    | [comment](https://github.com/python-zeroconf/python-zeroconf/issues/1835#issuecomment-5466504402) | 2026-08-30 |


### PR DESCRIPTION
## Summary

Adds the consent ledger #1835 now references: each verified consent recorded with the contributor's git author identities, the linked consent comment, and its date, so the record is tamper-evident in git history rather than living only in editable issue comments. A consent covers commits authored on or before its date; later contributions are covered by the per-PR license notice.

Contains no code and no quoted expression; author emails are already public commit metadata.

## Test plan

- [x] rows cross-checked against the verified consent comments and `git log --author` email sets