### PR TITLE
chore: collapse the ledger email mapping behind a details block

### DIFF
--- a/RELICENSING.md
+++ b/RELICENSING.md
@@ -6,23 +6,40 @@ audit record live in
 [issue #1835](https://github.com/python-zeroconf/python-zeroconf/issues/1835).
 
 This file is the ledger of verified consents. Each row was checked against
-the exact consent sentence and links the comment containing it. A consent
+the exact consent sentence and links the comment containing it. The commit email mapping is collapsed below as a courtesy: it keeps the addresses out of casual view, nothing more, since they are the public ones already recorded in this repository's commit history and recoverable by anyone with a clone. A consent
 covers the contributor's commits authored on or before its date; later
 contributions are covered by the license notice posted on every pull
 request, and blame will be re-verified against consent dates before any
 switch. Nothing already released changes license.
 
-| GitHub login  | Git author identities in this repository                                         | Consent                                                                                           | Date (UTC) |
-| ------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | ---------- |
-| @bdraco       | J. Nick Koston — nick@home-assistant.io, nick@koston.org, nick+github@koston.org | maintainer, relicense initiator                                                                   | 2026-08-28 |
-| @stevencrader | Steven Crader — stevencrader@gmail.com                                           | [comment](https://github.com/python-zeroconf/python-zeroconf/issues/1835#issuecomment-5458645316) | 2026-08-28 |
-| @bboe         | Bryce Boe — bbzbryce@gmail.com                                                   | [comment](https://github.com/python-zeroconf/python-zeroconf/issues/1835#issuecomment-5458732025) | 2026-08-28 |
-| @rima1881     | Amir — amd.gharibipour@outlook.com                                               | [comment](https://github.com/python-zeroconf/python-zeroconf/issues/1835#issuecomment-5458753986) | 2026-08-28 |
-| @jpbede       | Jan-Philipp Benecke — github@bnck.me, jan-philipp@bnck.me                        | [comment](https://github.com/python-zeroconf/python-zeroconf/issues/1835#issuecomment-5460526155) | 2026-08-29 |
-| @jstasiak     | Jakub Stasiak — jakub@stasiak.at                                                 | [comment](https://github.com/python-zeroconf/python-zeroconf/issues/1835#issuecomment-5462270134) | 2026-08-29 |
-| @Rotzbua      | Rotzbua — Rotzbua@users.noreply.github.com                                       | [comment](https://github.com/python-zeroconf/python-zeroconf/issues/1835#issuecomment-5462300621) | 2026-08-29 |
-| @ibygrave     | ibygrave — ian+github@bygrave.me.uk                                              | [comment](https://github.com/python-zeroconf/python-zeroconf/issues/1835#issuecomment-5463209000) | 2026-08-29 |
-| @bachp        | Pascal Bach — pasci.bach@gmail.com                                               | [comment](https://github.com/python-zeroconf/python-zeroconf/issues/1835#issuecomment-5464361992) | 2026-08-29 |
-| @cdce8p       | Marc Mueller — 30130371+cdce8p@users.noreply.github.com                          | [comment](https://github.com/python-zeroconf/python-zeroconf/issues/1835#issuecomment-5464917296) | 2026-08-29 |
-| @agners       | Stefan Agner — stefan@agner.ch                                                   | [comment](https://github.com/python-zeroconf/python-zeroconf/issues/1835#issuecomment-5465371892) | 2026-08-29 |
-| @devbanu      | Alexandru Ciobanu — 93059748+devbanu@users.noreply.github.com                    | [comment](https://github.com/python-zeroconf/python-zeroconf/issues/1835#issuecomment-5466504402) | 2026-08-30 |
+| GitHub login  | Git author name     | Consent                                                                                           | Date (UTC) |
+| ------------- | ------------------- | ------------------------------------------------------------------------------------------------- | ---------- |
+| @bdraco       | J. Nick Koston      | maintainer, relicense initiator                                                                   | 2026-08-28 |
+| @stevencrader | Steven Crader       | [comment](https://github.com/python-zeroconf/python-zeroconf/issues/1835#issuecomment-5458645316) | 2026-08-28 |
+| @bboe         | Bryce Boe           | [comment](https://github.com/python-zeroconf/python-zeroconf/issues/1835#issuecomment-5458732025) | 2026-08-28 |
+| @rima1881     | Amir                | [comment](https://github.com/python-zeroconf/python-zeroconf/issues/1835#issuecomment-5458753986) | 2026-08-28 |
+| @jpbede       | Jan-Philipp Benecke | [comment](https://github.com/python-zeroconf/python-zeroconf/issues/1835#issuecomment-5460526155) | 2026-08-29 |
+| @jstasiak     | Jakub Stasiak       | [comment](https://github.com/python-zeroconf/python-zeroconf/issues/1835#issuecomment-5462270134) | 2026-08-29 |
+| @Rotzbua      | Rotzbua             | [comment](https://github.com/python-zeroconf/python-zeroconf/issues/1835#issuecomment-5462300621) | 2026-08-29 |
+| @ibygrave     | ibygrave            | [comment](https://github.com/python-zeroconf/python-zeroconf/issues/1835#issuecomment-5463209000) | 2026-08-29 |
+| @bachp        | Pascal Bach         | [comment](https://github.com/python-zeroconf/python-zeroconf/issues/1835#issuecomment-5464361992) | 2026-08-29 |
+| @cdce8p       | Marc Mueller        | [comment](https://github.com/python-zeroconf/python-zeroconf/issues/1835#issuecomment-5464917296) | 2026-08-29 |
+| @agners       | Stefan Agner        | [comment](https://github.com/python-zeroconf/python-zeroconf/issues/1835#issuecomment-5465371892) | 2026-08-29 |
+| @devbanu      | Alexandru Ciobanu   | [comment](https://github.com/python-zeroconf/python-zeroconf/issues/1835#issuecomment-5466504402) | 2026-08-30 |
+
+<details><summary>Commit email mapping (click to expand)</summary>
+
+- @bdraco: nick@home-assistant.io, nick@koston.org, nick+github@koston.org
+- @stevencrader: stevencrader@gmail.com
+- @bboe: bbzbryce@gmail.com
+- @rima1881: amd.gharibipour@outlook.com
+- @jpbede: github@bnck.me, jan-philipp@bnck.me
+- @jstasiak: jakub@stasiak.at
+- @Rotzbua: Rotzbua@users.noreply.github.com
+- @ibygrave: ian+github@bygrave.me.uk
+- @bachp: pasci.bach@gmail.com
+- @cdce8p: 30130371+cdce8p@users.noreply.github.com
+- @agners: stefan@agner.ch
+- @devbanu: 93059748+devbanu@users.noreply.github.com
+
+</details>


### PR DESCRIPTION
Follow-up to #1899: the consent table now shows login, git author name, consent link and date; the commit email mapping moves into a collapsed details block as a courtesy. The note is explicit that this only keeps addresses out of casual view: they are the public ones already recorded in commit history and recoverable by anyone with a clone.