### PR TITLE
chore: record the marcosdiez and pawlizio consents in the ledger

### DIFF
--- a/RELICENSING.md
+++ b/RELICENSING.md
@@ -26,6 +26,8 @@ switch. Nothing already released changes license.
 | @cdce8p       | Marc Mueller        | [comment](https://github.com/python-zeroconf/python-zeroconf/issues/1835#issuecomment-5464917296) | 2026-08-29 |
 | @agners       | Stefan Agner        | [comment](https://github.com/python-zeroconf/python-zeroconf/issues/1835#issuecomment-5465371892) | 2026-08-29 |
 | @devbanu      | Alexandru Ciobanu   | [comment](https://github.com/python-zeroconf/python-zeroconf/issues/1835#issuecomment-5466504402) | 2026-08-30 |
+| @marcosdiez   | Marcos Diez         | [comment](https://github.com/python-zeroconf/python-zeroconf/issues/1835#issuecomment-5467084050) | 2026-08-30 |
+| @pawlizio     | Paul Daumlechner    | [comment](https://github.com/python-zeroconf/python-zeroconf/issues/1835#issuecomment-5467104893) | 2026-08-30 |
 
 <details><summary>Commit email mapping (click to expand)</summary>
 
@@ -41,5 +43,7 @@ switch. Nothing already released changes license.
 - @cdce8p: 30130371+cdce8p@users.noreply.github.com
 - @agners: stefan@agner.ch
 - @devbanu: 93059748+devbanu@users.noreply.github.com
+- @marcosdiez: marcos@unitron.com.br
+- @pawlizio: paul.daumlechner@live.de
 
 </details>


### PR DESCRIPTION
Adds the two consents received 2026-08-30 to RELICENSING.md: @marcosdiez and @pawlizio, both verified verbatim against the consent sentence, with their linked comments, dates, and public commit addresses in the collapsed mapping.